### PR TITLE
Spelling: website -> web site

### DIFF
--- a/app/routes/docs/index.md
+++ b/app/routes/docs/index.md
@@ -20,7 +20,7 @@ To begin receiving GCN notices via Kafka, users have two options for setting up 
 
 ## Contributing
 
-The GCN website is an open source project built in [Remix](https://remix.run), a full stack web framework. Have an idea to make GCN better and want to contribute, or have a bug to report? Head over to our [contributing](/docs/contributing) documentation for our quick start instructions.
+The GCN web site is an open source project built in [Remix](https://remix.run), a full stack web framework. Have an idea to make GCN better and want to contribute, or have a bug to report? Head over to our [contributing](/docs/contributing) documentation for our quick start instructions.
 
 ## Roadmap
 


### PR DESCRIPTION
For consistency with other pages.