### PR TITLE
Fix disclosure icon for webinar announcement banner

### DIFF
--- a/app/components/AnnounceBanner.tsx
+++ b/app/components/AnnounceBanner.tsx
@@ -31,23 +31,16 @@ export default function AnnounceBanner() {
                 an overview of the new GCN.
               </h2>
             </div>
-            {showFullBanner ? (
-              <Button
-                type="button"
-                className="usa-banner__button"
-                onClick={toggleShowBanner}
-              >
-                <span className="usa-banner__button-text">Show Less</span>
-              </Button>
-            ) : (
-              <Button
-                type="button"
-                className="usa-banner__button"
-                onClick={toggleShowBanner}
-              >
-                <span className="usa-banner__button-text">Show More</span>
-              </Button>
-            )}
+            <Button
+              type="button"
+              className="usa-banner__button"
+              aria-expanded={showFullBanner}
+              onClick={toggleShowBanner}
+            >
+              <span className="usa-banner__button-text">
+                Show {showFullBanner ? 'less' : 'more'}
+              </span>
+            </Button>
           </div>
         </header>
         {showFullBanner ? (


### PR DESCRIPTION
The arrow icon in the "Show more"/"Show less" button for the announcement banner was not updating when the button was toggled.