### PR TITLE
Counterpart notices are not Swift-specific by design

### DIFF
--- a/app/routes/notices.tsx
+++ b/app/routes/notices.tsx
@@ -220,12 +220,12 @@ export default function Notices() {
           Monitoring of known sources by the BAT instrument on Swift.
         </NoticeCard>
         <NoticeCard
-          name="Swift Counterpart"
+          name="Counterpart"
           href="https://gcn.gsfc.nasa.gov/counterpart_tbl.html"
-          tags={['x-ray', 'gw']}
+          tags={['gw']}
           selectedTags={tagNames}
         >
-          Swift counterpart candidates of LVK events.
+          Counterpart candidates of LVK events.
         </NoticeCard>
         <NoticeCard
           name="INTEGRAL GRBs"


### PR DESCRIPTION
Fixes #229.