### PR TITLE
Adds a form to set and update Name and Affiliation, to be used when authoring circulars

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -25,9 +25,6 @@ email_notification_subscription
   uuid *String
   topic **String
 
-user
-  sub *String
-
 circular_endorsements
   requestorSub *String
   endorserSub **String

--- a/app.arc
+++ b/app.arc
@@ -25,6 +25,9 @@ email_notification_subscription
   uuid *String
   topic **String
 
+user
+  sub *String
+
 circular_endorsements
   requestorSub *String
   endorserSub **String

--- a/app/routes/__auth/login.ts
+++ b/app/routes/__auth/login.ts
@@ -46,7 +46,7 @@ export const loader: LoaderFunction = async ({ request: { headers, url } }) => {
     parsedUrl.searchParams.delete('identity_provider')
 
     const authorizationUrl = client.authorizationUrl({
-      scope: 'openid',
+      scope: 'openid profile aws.cognito.signin.user.admin',
       code_challenge_method: 'S256',
       redirect_uri: parsedUrl.toString(),
       identity_provider,

--- a/app/routes/__auth/user.server.ts
+++ b/app/routes/__auth/user.server.ts
@@ -18,6 +18,7 @@ export interface User {
   groups: string[]
   cognitoUserName: string
   name: string | undefined
+  affiliation: string | undefined
 }
 
 export function parseTokenSet(tokenSet: TokenSet): {
@@ -54,6 +55,7 @@ export function parseTokenSet(tokenSet: TokenSet): {
     (group) => group.startsWith('gcn.nasa.gov/')
   )
   const name = claims.name
+  const affiliation = (claims['custom:affiliation'] ?? '') as string
   const accessToken = tokenSet.access_token
   const refreshToken = tokenSet.refresh_token
   const expiresAt = tokenSet.expires_at
@@ -63,7 +65,7 @@ export function parseTokenSet(tokenSet: TokenSet): {
   if (typeof cognitoUserName !== 'string')
     throw new Error('cognito:username claim must be a string')
 
-  const user = { sub, email, groups, idp, cognitoUserName, name }
+  const user = { sub, email, groups, idp, cognitoUserName, name, affiliation }
   return { user, accessToken, refreshToken, expiresAt, existingIdp }
 }
 
@@ -78,9 +80,15 @@ export async function getUser({ headers }: Request) {
     return await refreshUser(refreshToken, session)
   } else {
     const user = Object.fromEntries(
-      ['sub', 'email', 'groups', 'idp', 'cognitoUserName', 'name'].map(
-        (key) => [key, session.get(key)]
-      )
+      [
+        'sub',
+        'email',
+        'groups',
+        'idp',
+        'cognitoUserName',
+        'name',
+        'affiliation',
+      ].map((key) => [key, session.get(key)])
     )
     if (user.sub) return user as User
   }

--- a/app/routes/__auth/user.server.ts
+++ b/app/routes/__auth/user.server.ts
@@ -54,7 +54,7 @@ export function parseTokenSet(tokenSet: TokenSet): {
   const groups = ((claims['cognito:groups'] ?? []) as string[]).filter(
     (group) => group.startsWith('gcn.nasa.gov/')
   )
-  const name = claims.name
+  const name = claims.name ?? ''
   const affiliation = (claims['custom:affiliation'] ?? '') as string
   const accessToken = tokenSet.access_token
   const refreshToken = tokenSet.refresh_token

--- a/app/routes/user/index.tsx
+++ b/app/routes/user/index.tsx
@@ -27,21 +27,16 @@ export async function loader({ request }: DataFunctionArgs) {
 
 export async function action({ request }: DataFunctionArgs) {
   const data = await request.formData()
-  const displayName = getFormDataString(data, 'name')
+  const name = getFormDataString(data, 'name')
   const affiliation = getFormDataString(data, 'affiliation')
-
-  if (!displayName) throw new Response('displayName not set', { status: 400 })
-  if (!affiliation) throw new Response('affiliation not set', { status: 400 })
-
   const server = await UserDataServer.create(request)
-  await server.updateUserData(displayName, affiliation)
+  await server.updateUserData(name, affiliation)
 
   return redirect('/user')
 }
 
 export default function User() {
-  const { email, idp, displayName, affiliation } =
-    useLoaderData<typeof loader>()
+  const { email, idp, name, affiliation } = useLoaderData<typeof loader>()
   return (
     <>
       <h1>Welcome, {email}!</h1>
@@ -62,13 +57,7 @@ export default function User() {
           How would you like your name to appear in GCN Circulars? For example:
           A. E. Einstein, A. Einstein, Albert Einstein
         </small>
-        <TextInput
-          id="displayName"
-          name="displayName"
-          type="text"
-          defaultValue={displayName}
-          required
-        />
+        <TextInput id="name" name="name" type="text" defaultValue={name} />
         <Label htmlFor="affiliation">Affiliation</Label>
         <small className="text-base">
           For example: Pennsylvania State University, Ioffe Institute, DESY,
@@ -79,7 +68,6 @@ export default function User() {
           name="affiliation"
           type="text"
           defaultValue={affiliation}
-          required
         />
         <Button className="usa-button margin-top-2" type="submit">
           Update

--- a/app/routes/user/index.tsx
+++ b/app/routes/user/index.tsx
@@ -17,13 +17,11 @@ import { UserDataServer } from './user_data.server'
 export async function loader({ request }: DataFunctionArgs) {
   const user = await getUser(request)
   if (!user) throw new Response(null, { status: 403 })
-  const server = await UserDataServer.create(request)
-  const addlUserData = await server.getUserData()
   return {
     email: user.email,
     idp: user.idp,
-    displayName: addlUserData?.displayName ?? user.name,
-    affiliation: addlUserData?.affiliation,
+    displayName: user.name,
+    affiliation: user.affiliation,
   }
 }
 

--- a/app/routes/user/index.tsx
+++ b/app/routes/user/index.tsx
@@ -27,7 +27,7 @@ export async function loader({ request }: DataFunctionArgs) {
 
 export async function action({ request }: DataFunctionArgs) {
   const data = await request.formData()
-  const displayName = getFormDataString(data, 'displayName')
+  const displayName = getFormDataString(data, 'name')
   const affiliation = getFormDataString(data, 'affiliation')
 
   if (!displayName) throw new Response('displayName not set', { status: 400 })

--- a/app/routes/user/index.tsx
+++ b/app/routes/user/index.tsx
@@ -20,7 +20,7 @@ export async function loader({ request }: DataFunctionArgs) {
   return {
     email: user.email,
     idp: user.idp,
-    displayName: user.name,
+    name: user.name,
     affiliation: user.affiliation,
   }
 }

--- a/app/routes/user/index.tsx
+++ b/app/routes/user/index.tsx
@@ -22,7 +22,7 @@ export async function loader({ request }: DataFunctionArgs) {
   return {
     email: user.email,
     idp: user.idp,
-    displayName: addlUserData?.displayName,
+    displayName: addlUserData?.displayName ?? user.name,
     affiliation: addlUserData?.affiliation,
   }
 }
@@ -50,6 +50,15 @@ export default function User() {
       <p>You signed in with {idp || 'username and password'}.</p>
       <h2>Profile Info</h2>
       <Form method="post">
+        <p>
+          These fields will be displayed as the Submitter for any GCN Circulars
+          you submit. They will follow the format of "&lt;Display Name&gt; at
+          &lt;Affiliation&gt; &lt;Email&gt;".
+        </p>
+        <p>
+          For example, "A. E. Einstein at Pennsylvania State University
+          example@example.com"
+        </p>
         <Label htmlFor="displayName">Display Name</Label>
         <small className="text-base">
           How would you like your name to appear in GCN Circulars? For example:

--- a/app/routes/user/index.tsx
+++ b/app/routes/user/index.tsx
@@ -57,7 +57,7 @@ export default function User() {
           For example, "A. E. Einstein at Pennsylvania State University
           example@example.com"
         </p>
-        <Label htmlFor="displayName">Display Name</Label>
+        <Label htmlFor="Name">Name</Label>
         <small className="text-base">
           How would you like your name to appear in GCN Circulars? For example:
           A. E. Einstein, A. Einstein, Albert Einstein

--- a/app/routes/user/index.tsx
+++ b/app/routes/user/index.tsx
@@ -7,21 +7,77 @@
  */
 
 import type { DataFunctionArgs } from '@remix-run/node'
-import { useLoaderData } from '@remix-run/react'
+import { redirect } from '@remix-run/node'
+import { Form, useLoaderData } from '@remix-run/react'
+import { Button, Label, TextInput } from '@trussworks/react-uswds'
+import { getFormDataString } from '~/lib/utils'
 import { getUser } from '../__auth/user.server'
+import { UserDataServer } from './user_data.server'
 
 export async function loader({ request }: DataFunctionArgs) {
   const user = await getUser(request)
   if (!user) throw new Response(null, { status: 403 })
-  return { email: user.email, idp: user.idp }
+  const server = await UserDataServer.create(request)
+  const addlUserData = await server.getUserData()
+  return {
+    email: user.email,
+    idp: user.idp,
+    displayName: addlUserData?.displayName,
+    affiliation: addlUserData?.affiliation,
+  }
+}
+
+export async function action({ request }: DataFunctionArgs) {
+  const data = await request.formData()
+  const displayName = getFormDataString(data, 'displayName')
+  const affiliation = getFormDataString(data, 'affiliation')
+
+  if (!displayName) throw new Response('displayName not set', { status: 400 })
+  if (!affiliation) throw new Response('affiliation not set', { status: 400 })
+
+  const server = await UserDataServer.create(request)
+  await server.updateUserData(displayName, affiliation)
+
+  return redirect('/user')
 }
 
 export default function User() {
-  const { email, idp } = useLoaderData<typeof loader>()
+  const { email, idp, displayName, affiliation } =
+    useLoaderData<typeof loader>()
   return (
     <>
       <h1>Welcome, {email}!</h1>
       <p>You signed in with {idp || 'username and password'}.</p>
+      <h2>Profile Info</h2>
+      <Form method="post">
+        <Label htmlFor="displayName">Display Name</Label>
+        <small className="text-base">
+          How would you like your name to appear in GCN Circulars? For example:
+          A. E. Einstein, A. Einstein, Albert Einstein
+        </small>
+        <TextInput
+          id="displayName"
+          name="displayName"
+          type="text"
+          defaultValue={displayName}
+          required
+        />
+        <Label htmlFor="affiliation">Affiliation</Label>
+        <small className="text-base">
+          For example: Pennsylvania State University, Ioffe Institute, DESY,
+          Fermi-GBM Team, or AAVSO
+        </small>
+        <TextInput
+          id="affiliation"
+          name="affiliation"
+          type="text"
+          defaultValue={affiliation}
+          required
+        />
+        <Button className="usa-button margin-top-2" type="submit">
+          Update
+        </Button>
+      </Form>
     </>
   )
 }

--- a/app/routes/user/user_data.server.ts
+++ b/app/routes/user/user_data.server.ts
@@ -14,21 +14,19 @@ import { storage } from '../__auth/auth.server'
 import { getUser, refreshUser } from '../__auth/user.server'
 
 export class UserDataServer {
-  #sub: string
   #cookie: string
 
-  private constructor(sub: string, cookie: string) {
-    this.#sub = sub
+  private constructor(cookie: string) {
     this.#cookie = cookie
   }
 
   static async create(request: Request) {
     const user = await getUser(request)
     if (!user) throw new Response('not signed in', { status: 403 })
-    return new this(user.sub, request.headers.get('Cookie') ?? '')
+    return new this(request.headers.get('Cookie') ?? '')
   }
 
-  async updateUserData(name: string, affiliation: string) {
+  async updateUserData(name?: string, affiliation?: string) {
     const session = await storage.getSession(this.#cookie)
     const client = new CognitoIdentityProviderClient({})
     const command = new UpdateUserAttributesCommand({

--- a/app/routes/user/user_data.server.ts
+++ b/app/routes/user/user_data.server.ts
@@ -35,7 +35,7 @@ export class UserDataServer {
       UserAttributes: [
         {
           Name: 'name',
-          Value: displayName,
+          Value: name,
         },
         {
           Name: 'custom:affiliation',

--- a/app/routes/user/user_data.server.ts
+++ b/app/routes/user/user_data.server.ts
@@ -1,0 +1,44 @@
+/*!
+ * Copyright © 2022 United States Government as represented by the Administrator
+ * of the National Aeronautics and Space Administration. No copyright is claimed
+ * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ *
+ * SPDX-License-Identifier: NASA-1.3
+ */
+
+import { tables } from '@architect/functions'
+import { getUser } from '../__auth/user.server'
+
+export class UserDataServer {
+  #sub: string
+
+  private constructor(sub: string) {
+    this.#sub = sub
+  }
+
+  static async create(request: Request) {
+    const user = await getUser(request)
+    if (!user) throw new Response('not signed in', { status: 403 })
+    return new this(user.sub)
+  }
+
+  async updateUserData(displayName: string, affiliation: string) {
+    const db = await tables()
+
+    await db.user.update({
+      Key: { sub: this.#sub },
+      UpdateExpression:
+        'set displayName = :displayName, affiliation = :affiliation',
+      ExpressionAttributeValues: {
+        ':displayName': displayName,
+        ':affiliation': affiliation,
+      },
+    })
+  }
+
+  async getUserData() {
+    const db = await tables()
+    const results = await db.user.get({ sub: this.#sub })
+    return results
+  }
+}

--- a/app/routes/user/user_data.server.ts
+++ b/app/routes/user/user_data.server.ts
@@ -28,7 +28,7 @@ export class UserDataServer {
     return new this(user.sub, request.headers.get('Cookie') ?? '')
   }
 
-  async updateUserData(displayName: string, affiliation: string) {
+  async updateUserData(name: string, affiliation: string) {
     const session = await storage.getSession(this.#cookie)
     const client = new CognitoIdentityProviderClient({})
     const command = new UpdateUserAttributesCommand({


### PR DESCRIPTION

An option for saving username and association which we might need for circulars.  

Relates to https://github.com/nasa-gcn/gcn.nasa.gov/issues/291

![image](https://user-images.githubusercontent.com/11023698/202016736-517f2ffe-b7e0-41d9-8494-6fd964fdec7e.png)
