### PR TITLE
Save refreshed token in existing session, not a new one

### DIFF
--- a/app/routes/__auth/login.ts
+++ b/app/routes/__auth/login.ts
@@ -9,7 +9,7 @@
 import type { LoaderFunction } from '@remix-run/node'
 import { redirect } from '@remix-run/node'
 import { generators } from 'openid-client'
-import { getOpenIDClient, oidcStorage } from './auth.server'
+import { getOpenIDClient, oidcStorage, storage } from './auth.server'
 import { parseTokenSet, updateSession } from './user.server'
 
 export const loader: LoaderFunction = async ({ request: { headers, url } }) => {
@@ -84,7 +84,9 @@ export const loader: LoaderFunction = async ({ request: { headers, url } }) => {
     const parsedTokenSet = parseTokenSet(tokenSet)
 
     const [cookie] = await Promise.all([
-      updateSession(parsedTokenSet),
+      (async () => {
+        return await updateSession(parsedTokenSet, await storage.getSession())
+      })(),
       oidcSessionDestroyPromise,
     ])
 


### PR DESCRIPTION
When the updateSession function was calling storage.getSession, it wasn't passing in the cookie. As a result, it was always generating a _new_ orphan session, not bound to the user's cookie.

The consequence of this bug was that if the tokens ever needed refresh, the refresh token would be submitted on _every_ request thereafter.

updateSession must take an existing session as a parameter.