### PR TITLE
Prevent logging in with duplicated emails

### DIFF
--- a/app/routes/__auth/post_logout.tsx
+++ b/app/routes/__auth/post_logout.tsx
@@ -1,0 +1,67 @@
+/*!
+ * Copyright © 2022 United States Government as represented by the Administrator
+ * of the National Aeronautics and Space Administration. No copyright is claimed
+ * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ *
+ * SPDX-License-Identifier: NASA-1.3
+ */
+
+import type { LoaderArgs } from '@remix-run/node'
+import { redirect } from '@remix-run/node'
+import { Form, Link, useLoaderData } from '@remix-run/react'
+import {
+  Button,
+  Modal,
+  ModalFooter,
+  ModalHeading,
+} from '@trussworks/react-uswds'
+import { storage } from './auth.server'
+
+export async function loader({ request: { headers } }: LoaderArgs) {
+  const session = await storage.getSession(headers.get('Cookie'))
+  const existingIdp = session.get('existingIdp')
+  if (session.id) await storage.destroySession(session)
+
+  if (existingIdp) return { existingIdp }
+  else return redirect('/')
+}
+
+export default function PostLogout() {
+  const { existingIdp } = useLoaderData()
+  const friendlyExistingIdp =
+    existingIdp == 'COGNITO' ? 'email and password' : existingIdp
+  return (
+    <Modal
+      id="modal-existing-idp"
+      aria-labelledby="modal-existing-idp"
+      aria-describedby="modal-existing-idp-description"
+      isInitiallyOpen={true}
+      forceAction={true}
+      renderToPortal={false}
+    >
+      <ModalHeading id="modal-existing-idp-heading">
+        That email address is already registered
+      </ModalHeading>
+      <div className="usa-prose" id="modal-existing-idp-description">
+        <p>
+          You already have an existing account with the same email address. Last
+          time that you signed in, you used <b>{friendlyExistingIdp}</b>. Would
+          you like to try signing in that way again?
+        </p>
+      </div>
+      <ModalFooter>
+        <Form action="/login">
+          <input type="hidden" name="identity_provider" value={existingIdp} />
+          <Link to="/">
+            <Button type="button" outline>
+              Cancel
+            </Button>
+          </Link>
+          <Button type="submit" className="btn-default">
+            Sign in using {friendlyExistingIdp}
+          </Button>
+        </Form>
+      </ModalFooter>
+    </Modal>
+  )
+}

--- a/app/routes/__auth/user.server.ts
+++ b/app/routes/__auth/user.server.ts
@@ -22,6 +22,7 @@ export function parseTokenSet(tokenSet: TokenSet): {
   user: User
   refreshToken: string | undefined
   expiresAt: number | undefined
+  existingIdp: string | undefined
 } {
   const claims = tokenSet.claims()
   // NOTE: The OpenID Connect spec cautions that `sub` and `iss` together are
@@ -51,13 +52,14 @@ export function parseTokenSet(tokenSet: TokenSet): {
   )
   const refreshToken = tokenSet.refresh_token
   const expiresAt = tokenSet.expires_at
+  const existingIdp = claims.existingIdp as string | undefined
 
   if (!email) throw new Error('email claim must be present')
   if (typeof cognitoUserName !== 'string')
     throw new Error('cognito:username claim must be a string')
 
   const user = { sub, email, groups, idp, cognitoUserName }
-  return { user, refreshToken, expiresAt }
+  return { user, refreshToken, expiresAt, existingIdp }
 }
 
 export async function getUser({ headers }: Request) {


### PR DESCRIPTION
I added a Cognito PostConfirmSignup Lambda function trigger that populates the `existingIdp` user attribute when the user signs up with an account whose email address matches another existing account.

When the authentication flow returns the browser to our app, if the `existingIdp` claim is present, then our app will not save the user session, will immediately log the user out, and will prompt the user to sign in using the existing IdP.

Fixes #22.
Fixes #418.

![Screen Shot 2022-12-08 at 21 19 53](https://user-images.githubusercontent.com/728407/206609725-ac29159a-6e71-46cf-a374-7757718eac79.png)
