### PR TITLE
Clean up circulars backend

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -31,7 +31,8 @@ circular_endorsements
   endorserSub **String
 
 circulars
-  circularId *Number
+  dummy *Number  # dummy partition key so that all records are stored in one partition
+  circularId **Number
 
 auto_increment_metadata
   tableName *String

--- a/app/lib/pagination.ts
+++ b/app/lib/pagination.ts
@@ -1,0 +1,103 @@
+/**
+ * Implement the pagination algorithm desscribed at
+ * https://designsystem.digital.gov/components/pagination/.
+ * Impmenetation is adapted from https://github.com/trussworks/react-uswds/blob/main/src/components/Pagination/Pagination.tsx */
+export function usePagination({
+  totalPages,
+  currentPage,
+  maxSlots = 7,
+}: {
+  totalPages: number
+  currentPage: number
+  maxSlots?: number
+}) {
+  const isOnFirstPage = currentPage === 1
+  const isOnLastPage = currentPage === totalPages
+
+  const showOverflow = totalPages > maxSlots // If more pages than slots, use overflow indicator(s)
+
+  const middleSlot = Math.round(maxSlots / 2) // 4 if maxSlots is 7
+  const showPrevOverflow = showOverflow && currentPage > middleSlot
+  const showNextOverflow =
+    showOverflow && totalPages - currentPage >= middleSlot
+
+  // Assemble array of page numbers to be shown
+  const currentPageRange: Array<number | 'overflow'> = showOverflow
+    ? [currentPage]
+    : Array.from({ length: totalPages }).map((_, i) => i + 1)
+
+  if (showOverflow) {
+    // Determine range of pages to show based on current page & number of slots
+    // Follows logic described at: https://designsystem.digital.gov/components/pagination/
+    const prevSlots = isOnFirstPage ? 0 : showPrevOverflow ? 2 : 1 // first page + prev overflow
+    const nextSlots = isOnLastPage ? 0 : showNextOverflow ? 2 : 1 // next overflow + last page
+    const pageRangeSize = maxSlots - 1 - (prevSlots + nextSlots) // remaining slots to show (minus one for the current page)
+
+    // Determine how many slots we have before/after the current page
+    let currentPageBeforeSize = 0
+    let currentPageAfterSize = 0
+    if (showPrevOverflow && showNextOverflow) {
+      // We are in the middle of the set, there will be overflow (...) at both the beginning & end
+      // Ex: [1] [...] [9] [10] [11] [...] [24]
+      currentPageBeforeSize = Math.round((pageRangeSize - 1) / 2)
+      currentPageAfterSize = pageRangeSize - currentPageBeforeSize
+    } else if (showPrevOverflow) {
+      // We are in the end of the set, there will be overflow (...) at the beginning
+      // Ex: [1] [...] [20] [21] [22] [23] [24]
+      currentPageAfterSize = totalPages - currentPage - 1 // current & last
+      currentPageAfterSize = currentPageAfterSize < 0 ? 0 : currentPageAfterSize
+      currentPageBeforeSize = pageRangeSize - currentPageAfterSize
+    } else if (showNextOverflow) {
+      // We are in the beginning of the set, there will be overflow (...) at the end
+      // Ex: [1] [2] [3] [4] [5] [...] [24]
+      currentPageBeforeSize = currentPage - 2 // first & current
+      currentPageBeforeSize =
+        currentPageBeforeSize < 0 ? 0 : currentPageBeforeSize
+      currentPageAfterSize = pageRangeSize - currentPageBeforeSize
+    }
+
+    // Populate the remaining slots
+    let counter = 1
+    while (currentPageBeforeSize > 0) {
+      // Add previous pages before the current page
+      currentPageRange.unshift(currentPage - counter)
+      counter++
+      currentPageBeforeSize--
+    }
+
+    counter = 1
+    while (currentPageAfterSize > 0) {
+      // Add subsequent pages after the current page
+      currentPageRange.push(currentPage + counter)
+      counter++
+      currentPageAfterSize--
+    }
+
+    // Add prev/next overflow indicators, and first/last pages as needed
+    if (showPrevOverflow) currentPageRange.unshift('overflow')
+    if (currentPage !== 1) currentPageRange.unshift(1)
+    if (showNextOverflow) currentPageRange.push('overflow')
+    if (currentPage !== totalPages) currentPageRange.push(totalPages)
+  }
+
+  const prevPage = !isOnFirstPage && currentPage - 1
+  const nextPage = !isOnLastPage && currentPage + 1
+
+  return [
+    ...(prevPage ? [{ type: 'prev', number: prevPage }] : []),
+    ...currentPageRange.map((pageNum) =>
+      pageNum === 'overflow'
+        ? { type: 'overflow' }
+        : {
+            type: 'number',
+            number: pageNum,
+            isCurrent: pageNum === currentPage,
+          }
+    ),
+    ...(nextPage ? [{ type: 'next', number: nextPage }] : []),
+  ] as {
+    type: 'next' | 'prev' | 'overflow' | 'number'
+    number?: number
+    isCurrent?: boolean
+  }[]
+}

--- a/app/routes/circulars/$circularId.tsx
+++ b/app/routes/circulars/$circularId.tsx
@@ -9,26 +9,24 @@
 import type { DataFunctionArgs } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 import TimeAgo from '~/components/TimeAgo'
-import { CircularsServer } from './circulars.server'
+import { get } from './circulars.server'
 
-export async function loader({ request, params }: DataFunctionArgs) {
-  const id = params.circularId
-  if (!id) throw new Response('Id is required', { status: 404 })
-  const server = await CircularsServer.create(request)
-  const circular = await server.get(parseInt(id))
-  return { circular }
+export async function loader({ params: { circularId } }: DataFunctionArgs) {
+  if (!circularId)
+    throw new Response('circularId must be defined', { status: 400 })
+  return get(parseInt(circularId))
 }
 
 export default function $circularId() {
-  const { circular } = useLoaderData<typeof loader>()
+  const { subject, submitter, createdOn, body } = useLoaderData<typeof loader>()
   return (
     <>
-      <h2>{circular.subject}</h2>
-      <h4>{circular.submitter}</h4>
+      <h2>{subject}</h2>
+      <h4>{submitter}</h4>
       <small className="text-base-light">
-        <TimeAgo time={circular.createdOn}></TimeAgo>
+        <TimeAgo time={createdOn}></TimeAgo>
       </small>
-      <div className="text-pre-wrap ">{circular.body}</div>
+      <div className="text-pre-wrap ">{body}</div>
     </>
   )
 }

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -9,206 +9,132 @@
 import { tables } from '@architect/functions'
 import type { DynamoDB } from '@aws-sdk/client-dynamodb'
 import type { DynamoDBDocument } from '@aws-sdk/lib-dynamodb'
-import { dynamoDBAutoIncrement } from '@nasa-gcn/dynamodb-autoincrement'
+import { DynamoDBAutoIncrement } from '@nasa-gcn/dynamodb-autoincrement'
 import { formatAuthor } from '../user/index'
 import { getUser } from '../__auth/user.server'
 
-export type CircularModel = {
+async function getDynamoDBAutoIncrement() {
+  const db = await tables()
+  const doc = db._doc as unknown as DynamoDBDocument
+
+  const tableName = db.name('circulars')
+  const counterTableName = db.name('auto_increment_metadata')
+  const dangerously =
+    (await (db._db as unknown as DynamoDB).config.endpoint?.())?.hostname ==
+    'localhost'
+
+  return new DynamoDBAutoIncrement({
+    doc,
+    counterTableName,
+    counterTableKey: { tableName: 'circulars' },
+    counterTableAttributeName: 'circularId',
+    tableName: tableName,
+    tableAttributeName: 'circularId',
+    initialValue: 1,
+    dangerously,
+  })
+}
+
+export interface CircularMetadata {
   circularId: number
+  subject: string
+}
+
+export interface Circular extends CircularMetadata {
   sub?: string
   createdOn: number
-  subject: string
   body: string
   submitter: string
 }
 
-export class CircularsServer {
-  #sub?: string
-  #email?: string
-  #groups?: string[]
-  #name?: string
-  #affiliation?: string
+/** List circulars in order of descending ID. */
+export async function list({
+  page,
+  limit,
+}: {
+  /** Page in results to retrieve. Note that indexing is 1-based. */
+  page: number
+  /** Number of results per page. */
+  limit: number
+}): Promise<{ items: CircularMetadata[]; totalPages: number }> {
+  const db = await tables()
+  const autoincrement = await getDynamoDBAutoIncrement()
+  const last = (await autoincrement.getLast()) ?? 1
 
-  private constructor(
-    sub?: string,
-    email?: string,
-    groups?: string[],
-    name?: string,
-    affiliation?: string
-  ) {
-    this.#affiliation = affiliation
-    this.#email = email
-    this.#groups = groups
-    this.#name = name
-    this.#sub = sub
-  }
+  // Calculate pagination assuming that last === the number of records.
+  const totalPages = Math.ceil(last / limit)
+  const firstIdOnPage = Math.max(last - page * limit + 1, 1)
 
-  static async create(request: Request) {
-    const user = await getUser(request)
-    return new this(
-      user?.sub,
-      user?.email,
-      user?.groups,
-      user?.name,
-      user?.affiliation
-    )
-  }
+  const { Items } = await db.circulars.query({
+    Limit: limit,
+    ScanIndexForward: false,
+    ExclusiveStartKey: { dummy: 0, circularId: firstIdOnPage },
+    ProjectionExpression: 'circularId, subject',
+    KeyConditionExpression: 'dummy = :dummy',
+    ExpressionAttributeValues: { ':dummy': 0 },
+  })
 
-  /**
-   * Gets all available circulars
-   * @param searchString - a string that will be checked against subjects,
-   * bodies, and authors of saved circulars. A blank value returns all.
-   * @returns an array of CircularModel objects
-   */
-  async getCirculars(searchString?: string) {
-    let result = await this.#scanCircularsTable(searchString)
-    let items: CircularModel[] = result.Items
-    while (result.LastEvaluatedKey) {
-      result = await this.#scanCircularsTable(
-        searchString,
-        result.LastEvaluatedKey
-      )
-      items = [...items, ...result.Items]
-    }
-    return items.sort((a, b) => b.circularId - a.circularId)
-  }
+  return { items: Items, totalPages }
+}
 
-  async #scanCircularsTable(searchString?: string, lastEvaluatedKey?: any) {
-    const db = await tables()
-    const result = await db.circulars.scan({
-      ExclusiveStartKey: lastEvaluatedKey,
-      ExpressionAttributeValues: searchString
-        ? {
-            ':searchTerm': searchString,
-          }
-        : undefined,
-      FilterExpression: searchString
-        ? 'contains(subject, :searchTerm) OR contains(body, :searchTerm) OR contains(submitter, :searchTerm)'
-        : undefined,
+/** Get a circular by ID. */
+export async function get(circularId: number): Promise<Circular> {
+  const db = await tables()
+  const result = await db.circulars.get({
+    dummy: 0,
+    circularId,
+  })
+  if (!result)
+    throw new Response('The requested circular does not exist', {
+      status: 404,
     })
-    return result
-  }
+  return result
+}
 
-  /**
-   * Get a specified Circular by Id.
-   *
-   * Throws an HTTP error if:
-   *  - the provided Id does not match any existing circulars
-   *
-   * @param id - the number Id (ex. 12345) of a specific Circular
-   * @returns a CircularModel object
-   */
-  async get(circularId: number): Promise<CircularModel> {
-    const db = await tables()
-    const result = await db.circulars.get({
-      circularId: circularId,
-    })
-    if (!result)
-      throw new Response('The requested circular does not exist', {
-        status: 404,
-      })
-    return result
-  }
-
-  /**
-   * Adds a new entry into the GCN Circulars table
-   *
-   * Throws an HTTP error if:
-   *  - The current user is not signed in, verified by the class's #sub and #groups properties
-   *  - The current user is not in the submitters group
-   *  - Body or Subject are blank
-   * @param body - main content of the Circular
-   * @param subject - the title/subject line of the Circular
-   */
-  async createNewCircular(body: string, subject: string) {
-    if (!this.#sub || !this.#groups || !this.#email)
-      throw new Response('User is not signed in', { status: 403 })
-    if (!this.#groups.includes('gcn.nasa.gov/circular-submitter'))
-      throw new Response('User is not in the submitters group', {
-        status: 403,
-      })
-    if (!body || !subject)
-      throw new Response('Subject and Body cannot be blank', { status: 400 })
-
-    const db = await tables()
-    const doc = db._doc as unknown as DynamoDBDocument
-
-    const tableName = db.name('circulars')
-    const indexTableName = db.name('auto_increment_metadata')
-
-    const submitter = formatAuthor({
-      name: this.#name,
-      affiliation: this.#affiliation,
-      email: this.#email,
+/** Delete a circular by ID.
+ * Throws an HTTP error if:
+ *  - The current user is not signed in
+ *  - The current user is not in the moderator group
+ */
+export async function remove(circularId: number, request: Request) {
+  const user = await getUser(request)
+  if (!user?.groups.includes('gcn.nasa.gov/circular-moderator'))
+    throw new Response('User is not a moderator', {
+      status: 403,
     })
 
-    const useDangerous =
-      (await (db._db as unknown as DynamoDB).config.endpoint?.())?.hostname ==
-      'localhost'
+  const db = await tables()
+  await db.circulars.delete({ dummy: 0, circularId: circularId })
+}
 
-    await dynamoDBAutoIncrement({
-      doc,
-      counterTableName: indexTableName,
-      counterTableKey: { tableName: 'circulars' },
-      counterTableAttributeName: 'circularsIDCounter',
-      tableName: tableName,
-      tableAttributeName: 'circularId',
-      initialValue: 1,
-      dangerously: useDangerous,
-    })({
-      createdOn: Date.now(),
-      subject,
-      body,
-      sub: this.#sub,
-      submitter,
+/**
+ * Adds a new entry into the GCN Circulars table
+ *
+ * Throws an HTTP error if:
+ *  - The current user is not signed in, verified by the class's #sub and #groups properties
+ *  - The current user is not in the submitters group
+ *  - Body or Subject are blank
+ * @param body - main content of the Circular
+ * @param subject - the title/subject line of the Circular
+ */
+export async function put(subject: string, body: string, request: Request) {
+  const [user, autoincrement] = await Promise.all([
+    getUser(request),
+    getDynamoDBAutoIncrement(),
+  ])
+  if (!user?.groups.includes('gcn.nasa.gov/circular-submitter'))
+    throw new Response('User is not in the submitters group', {
+      status: 403,
     })
-  }
+  if (!body || !subject)
+    throw new Response('Subject and Body cannot be blank', { status: 400 })
 
-  /**
-   * Gets all of the GCN Circualrs submitted by the current user.
-   *
-   * Throws and HTTP error if:
-   *  - The current user is not signed in, verified by the class's #sub and #groups properties
-   *
-   * @returns an array of CircularModel objects
-   */
-  async getUserSubmittedCirculars() {
-    if (!this.#sub) throw new Response('User is not signed in', { status: 403 })
-
-    const db = await tables()
-    const result = await db.circulars.scan({
-      ExpressionAttributeNames: {
-        '#sub': 'sub',
-      },
-      ExpressionAttributeValues: {
-        ':sub': this.#sub,
-      },
-      FilterExpression: '#sub = :sub',
-      ProjectionExpression:
-        'subject, body, createdOn, circularId, #sub, submitter',
-    })
-
-    return result.Items as CircularModel[]
-  }
-
-  /**
-   * Deletes the circular corresponding to the given circularId
-   *
-   * Throws an HTTP error if:
-   *  - The current user is not signed in, verified by the class's #sub and #groups properties
-   *  - The current user is not in the moderator group
-   * @param circularId - the ID of the circular to be deleted
-   */
-  async deleteCircular(circularId: number) {
-    if (!this.#sub || !this.#groups)
-      throw new Response('User is not signed in', { status: 403 })
-
-    if (!this.#groups.includes('gcn.nasa.gov/circular-moderator'))
-      throw new Response('User is not a moderator', {
-        status: 403,
-      })
-
-    const db = await tables()
-    await db.circulars.delete({ circularId: circularId })
-  }
+  await autoincrement.put({
+    dummy: 0,
+    createdOn: Date.now(),
+    subject,
+    body,
+    sub: user.sub,
+    submitter: formatAuthor(user),
+  })
 }

--- a/app/routes/circulars/submit.tsx
+++ b/app/routes/circulars/submit.tsx
@@ -5,7 +5,7 @@ import { Label, TextInput, Textarea, Button } from '@trussworks/react-uswds'
 import { useState } from 'react'
 import { getFormDataString } from '~/lib/utils'
 import { getUser } from '../__auth/user.server'
-import { CircularsServer } from './circulars.server'
+import { put } from './circulars.server'
 
 interface FormProps {
   id?: string
@@ -19,7 +19,7 @@ export async function loader({ request }: DataFunctionArgs) {
   const user = await getUser(request)
   if (!user || !user.groups.includes('gcn.nasa.gov/circular-submitter'))
     throw new Response('', { status: 403 })
-  return { user }
+  return null
 }
 
 export async function action({ request }: DataFunctionArgs) {
@@ -28,9 +28,7 @@ export async function action({ request }: DataFunctionArgs) {
   const subject = getFormDataString(data, 'subject')
   if (!body || !subject)
     throw new Response('Body and subject are required', { status: 400 })
-  const server = await CircularsServer.create(request)
-  await server.createNewCircular(body, subject)
-
+  await put(subject, body, request)
   return redirect('/circulars')
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@aws-sdk/client-cognito-identity-provider": "^3.223.0",
         "@aws-sdk/client-sesv2": "^3.223.0",
         "@balavishnuvj/remix-seo": "^1.0.2",
-        "@nasa-gcn/dynamodb-autoincrement": "^0.0.1",
+        "@nasa-gcn/dynamodb-autoincrement": "^0.0.4",
         "@octokit/rest": "^19.0.5",
         "@remix-run/architect": "^1.9.0",
         "@remix-run/node": "^1.9.0",
@@ -38,6 +38,7 @@
       "devDependencies": {
         "@architect/architect": "^10.8.2",
         "@aws-sdk/lib-dynamodb": "^3.188.0",
+        "@aws-sdk/util-dynamodb": "^3.188.0",
         "@remix-run/dev": "^1.9.0",
         "@remix-run/eslint-config": "^1.9.0",
         "@types/architect__functions": "^3.13.6",
@@ -10736,9 +10737,9 @@
       "dev": true
     },
     "node_modules/@nasa-gcn/dynamodb-autoincrement": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@nasa-gcn/dynamodb-autoincrement/-/dynamodb-autoincrement-0.0.1.tgz",
-      "integrity": "sha512-lofly6FAxL1nmmG+nfa+ME3Tffagp3+0tULpecB7clXl0NuCpK348mOWgnI0QAx+nDmB7Nm0w+DYUgIy5OfZ8A==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@nasa-gcn/dynamodb-autoincrement/-/dynamodb-autoincrement-0.0.4.tgz",
+      "integrity": "sha512-vX1w2dVFKZbZF+u2JoRSvDdIu9D6P6SeRNyC+pXzOdzVMjOJmc+iEWmARwrNLIYLdCiWGWYbrM5JpzNWnhVKSQ==",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.188.0"
       },
@@ -36859,9 +36860,9 @@
       }
     },
     "@nasa-gcn/dynamodb-autoincrement": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@nasa-gcn/dynamodb-autoincrement/-/dynamodb-autoincrement-0.0.1.tgz",
-      "integrity": "sha512-lofly6FAxL1nmmG+nfa+ME3Tffagp3+0tULpecB7clXl0NuCpK348mOWgnI0QAx+nDmB7Nm0w+DYUgIy5OfZ8A==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@nasa-gcn/dynamodb-autoincrement/-/dynamodb-autoincrement-0.0.4.tgz",
+      "integrity": "sha512-vX1w2dVFKZbZF+u2JoRSvDdIu9D6P6SeRNyC+pXzOdzVMjOJmc+iEWmARwrNLIYLdCiWGWYbrM5JpzNWnhVKSQ==",
       "requires": {
         "@aws-sdk/client-dynamodb": "^3.188.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/client-cognito-identity-provider": "^3.223.0",
     "@aws-sdk/client-sesv2": "^3.223.0",
     "@balavishnuvj/remix-seo": "^1.0.2",
-    "@nasa-gcn/dynamodb-autoincrement": "^0.0.1",
+    "@nasa-gcn/dynamodb-autoincrement": "^0.0.4",
     "@octokit/rest": "^19.0.5",
     "@remix-run/architect": "^1.9.0",
     "@remix-run/node": "^1.9.0",
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@architect/architect": "^10.8.2",
     "@aws-sdk/lib-dynamodb": "^3.188.0",
+    "@aws-sdk/util-dynamodb": "^3.188.0",
     "@remix-run/dev": "^1.9.0",
     "@remix-run/eslint-config": "^1.9.0",
     "@types/architect__functions": "^3.13.6",


### PR DESCRIPTION
- Eliminate unnecessary class
- Move all circulars into a single DynamoDB partition so that they can be queried in ID order without incurring large read capacity costs
- Full-text search is temporarily non-functional; we will implement it using Elastic Search
- Pull out pagination logic into a React hook so that the pagination links are proper Remix links with client-side routing