### PR TITLE
Increase timeout for lambda

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -57,6 +57,7 @@ architecture arm64
 memory 256
 concurrency 100
 provisionedConcurrency 5
+timeout 10  # Allow extra time because Cognito's .well-known/openid-configuration endpoint can take several seconds.
 
 @plugins
 tracing  # Enable AWS X-Ray distributed tracing


### PR DESCRIPTION
Allow extra time because Cognito's .well-known/openid-configuration endpoint can take several seconds.