### PR TITLE
Generalize feature flags mechanism

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -112,8 +112,37 @@ export async function loader({ request }: DataFunctionArgs) {
 
   const user = await getUser(request)
   const email = user?.email
+  const features = getFeatures()
 
-  return { url, email }
+  return { url, email, features }
+}
+
+function getFeatures() {
+  return process.env.GCN_FEATURES?.split(',') ?? []
+}
+
+/**
+ * Return true if the given feature flag is enabled.
+ *
+ * Feature flags are configured by the environment variable GCN_FEATURES, which
+ * is a comma-separated list of enabled features.
+ */
+export function feature(feature: string) {
+  return getFeatures().includes(feature)
+}
+
+/**
+ * Return true if the given feature flag is enabled.
+ *
+ * This is a React hook version of {@link feature}.
+ *
+ * Feature flags are configured by the environment variable GCN_FEATURES, which
+ * is a comma-separated list of enabled features.
+ */
+export function useFeature(feature: string) {
+  const [{ data }] = useMatches()
+  const { features } = data as Awaited<ReturnType<typeof loader>>
+  return features.includes(feature)
 }
 
 export function useUrl() {

--- a/app/routes/circulars/index.tsx
+++ b/app/routes/circulars/index.tsx
@@ -14,9 +14,10 @@ import { list, put } from './circulars.server'
 import classNames from 'classnames'
 import { usePagination } from '~/lib/pagination'
 import { getFormDataString } from '~/lib/utils'
+import { feature } from '~/root'
 
 export async function loader({ request: { url } }: DataFunctionArgs) {
-  if (!process.env['GCN_CIRCULARS_ENABLE']) throw redirect('/circulars/classic')
+  if (!feature('circulars')) throw redirect('/circulars/classic')
 
   const { searchParams } = new URL(url)
   const page = parseInt(searchParams.get('page') ?? '1')

--- a/app/routes/circulars/new.tsx
+++ b/app/routes/circulars/new.tsx
@@ -22,10 +22,10 @@ import Spinner from '~/components/Spinner'
 import { formatAuthor } from '../user/index'
 import { getUser } from '../__auth/user.server'
 import { subjectIsValid } from './circulars.lib'
+import { feature } from '~/root'
 
 export async function loader({ request }: DataFunctionArgs) {
-  if (!process.env['GCN_CIRCULARS_ENABLE'])
-    throw new Response(null, { status: 404 })
+  if (!feature('circulars')) throw new Response(null, { status: 404 })
   const user = await getUser(request)
   if (!user || !user.groups.includes('gcn.nasa.gov/circular-submitter'))
     throw new Response(null, { status: 403 })


### PR DESCRIPTION
Add a feature() function and a useFeature() react hook to generalize feature flags and avoid repeating logic to inject their values into loader data.