### PR TITLE
Make AWS SDK packages dev-only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,8 @@
       "license": "NASA-1.3",
       "dependencies": {
         "@architect/functions": "^5.3.3",
-        "@aws-sdk/client-cognito-identity-provider": "^3.223.0",
-        "@aws-sdk/client-sesv2": "^3.223.0",
         "@balavishnuvj/remix-seo": "^1.0.2",
-        "@nasa-gcn/dynamodb-autoincrement": "^0.0.4",
+        "@nasa-gcn/dynamodb-autoincrement": "^0.0.5",
         "@octokit/rest": "^19.0.7",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.34.0",
         "@opentelemetry/sdk-trace-base": "^1.9.0",
@@ -41,6 +39,8 @@
       },
       "devDependencies": {
         "@architect/architect": "^10.9.1",
+        "@aws-sdk/client-cognito-identity-provider": "^3.223.0",
+        "@aws-sdk/client-sesv2": "^3.223.0",
         "@aws-sdk/lib-dynamodb": "^3.188.0",
         "@aws-sdk/util-dynamodb": "^3.188.0",
         "@remix-run/dev": "^1.11.1",
@@ -2158,6 +2158,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
       "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -2165,7 +2166,8 @@
     "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-crypto/sha1-browser": {
       "version": "2.0.0",
@@ -2191,6 +2193,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
       "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^2.0.0",
         "@aws-crypto/sha256-js": "^2.0.0",
@@ -2205,12 +2208,14 @@
     "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
       "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -2220,12 +2225,14 @@
     "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
       "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -2233,12 +2240,14 @@
     "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-crypto/util": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
       "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -2248,12 +2257,14 @@
     "node_modules/@aws-crypto/util/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-sdk/abort-controller": {
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
       "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -3064,6 +3075,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.231.0.tgz",
       "integrity": "sha512-6UmDTPxYAerQdbH8bnIwZSHBzZeutDZ4ASatoT0L/mVD3OmqAVXRBnP2Fyd30JUGdtEPzw54EU8mX8HPGIwBzA==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -3110,6 +3122,8 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.231.0.tgz",
       "integrity": "sha512-WvNM3NmsFFB7S7I5B2PECe945bEzdwU3MElLznmcbccaRf31S61C4EAkghm6hXz0EoZlgdRfBqHaRB1PgmAUuA==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -3159,6 +3173,8 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
       "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/abort-controller": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -3970,6 +3986,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.231.0.tgz",
       "integrity": "sha512-hNJoV0QYAfrBT50siNt+Ax3Lc+YY5UnpZ8kKuugnlU8SKMS+nrZ2tuNWv95awMAlsORaPo2Vm35ySTdM1+v87A==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -6359,6 +6376,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.231.0.tgz",
       "integrity": "sha512-/q7BptaMiT6/wxW9vE/gcQuApMXio5vdTuqt77A6+mjqhNzYFfCn7RRS4BU8KEOpZObnYBKP3mYe3NDccEbMzQ==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -6402,6 +6420,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.231.0.tgz",
       "integrity": "sha512-yqEZW9/Q6VvMDMcQoE52oa/oa6F8z8cqyax7m29VpuVrncYcfELpkZKWPoaJVfierR5ysKfKiAU0acPgMpvllQ==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -6445,6 +6464,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.231.0.tgz",
       "integrity": "sha512-5WYqlcbM49ofOFBsu28QBt3t26M5D9XynhSaswSrCzawwdNkIMYQrKOCplF5mqOy+GywVIRrFeCVVrAKPMZJxQ==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -6492,6 +6512,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.231.0.tgz",
       "integrity": "sha512-qpjV4Fw/NQ4a0p5/qwzqaShflYRlY/SPcgA7N5GTJjIjZjg3NV+5BKJSF3VeZcNKfbXq68kkn207OSCpyheYxQ==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/signature-v4": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -6507,6 +6528,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
       "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -6520,6 +6542,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
       "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/node-config-provider": "3.226.0",
         "@aws-sdk/property-provider": "3.226.0",
@@ -6535,6 +6558,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.231.0.tgz",
       "integrity": "sha512-4JJgrJg2O91Vki4m5nSQNZGX/5yAYgzG1IOjeZ+8vCDxfR+jA2O9+/Xhi2/8aDpb1da77OJ+cK1+ezzSMchIfQ==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.226.0",
         "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -6553,6 +6577,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.231.0.tgz",
       "integrity": "sha512-DOojjyYdLNeBQv9+PaDXmvvww9SmcZsaL1YCl27e5larcJSMfT41vn4WRnVRu2zBI2BIi464Z8ziRRKwd2YFVg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.226.0",
         "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -6573,6 +6598,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
       "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.226.0",
         "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -6587,6 +6613,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.231.0.tgz",
       "integrity": "sha512-aImUD+PAqZ7A2C1ef7gskMN3KuxFT4Am1Vrl6M0oLGyrhKG2QtRT/UaXJE+Yt6d/C2qc2OsQ9j2oim7D6Qha/A==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.231.0",
         "@aws-sdk/property-provider": "3.226.0",
@@ -6603,6 +6630,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
       "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -6616,6 +6644,8 @@
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.208.0.tgz",
       "integrity": "sha512-MkrCvaZhTb1qZCjcDH73t5n43h0Kr0GS+30lpXZ9PAnHJZPqv+vhWFPK0ZsFe1XktbS0WOoDR4ED+lWm0Dw7Rg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.3.1"
@@ -6752,6 +6782,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
       "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.226.0",
         "@aws-sdk/querystring-builder": "3.226.0",
@@ -6785,6 +6816,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
       "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.226.0",
         "@aws-sdk/util-buffer-from": "3.208.0",
@@ -6820,6 +6852,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
       "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -6829,6 +6862,7 @@
       "version": "3.201.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
       "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -6840,6 +6874,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.231.0.tgz",
       "integrity": "sha512-q1gvuxBQGR+xflaTbEP9Q+jCqnuqtznVrKt26skVUvzjmJJLB1dxHxwUPHv6SKO3R+bby7ATlVGQwQkZxViSGA==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/util-dynamodb": "3.231.0",
         "tslib": "^2.3.1"
@@ -6966,6 +7001,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
       "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -6979,6 +7015,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
       "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/middleware-serde": "3.226.0",
         "@aws-sdk/protocol-http": "3.226.0",
@@ -6997,6 +7034,8 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.231.0.tgz",
       "integrity": "sha512-8HRZRrZWuAlm/I8uwFG8+iK8TCJWHSizRTEZfNazx7V5anOk55UeCVg3ifuXnFPmGeb4VDBRTn4h2dUx4LRKLQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/config-resolver": "3.231.0",
         "@aws-sdk/endpoint-cache": "3.208.0",
@@ -7099,6 +7138,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
       "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -7134,6 +7174,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
       "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -7146,6 +7187,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
       "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -7159,6 +7201,7 @@
       "version": "3.229.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.229.0.tgz",
       "integrity": "sha512-/y0BWio9b2RRH2QvRTohbuqE0vhH4IZKlc6k+JRbGV9aSwyOzACU/L/qkGftC/W0puvgNvZYjGxmB6cGHAEZaw==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.226.0",
         "@aws-sdk/service-error-classification": "3.229.0",
@@ -7248,6 +7291,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
       "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/middleware-signing": "3.226.0",
         "@aws-sdk/property-provider": "3.226.0",
@@ -7264,6 +7308,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
       "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -7276,6 +7321,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
       "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.226.0",
         "@aws-sdk/protocol-http": "3.226.0",
@@ -7314,6 +7360,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
       "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -7325,6 +7372,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
       "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -7338,6 +7386,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
       "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.226.0",
         "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -7352,6 +7401,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
       "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/abort-controller": "3.226.0",
         "@aws-sdk/protocol-http": "3.226.0",
@@ -7367,6 +7417,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
       "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -7379,6 +7430,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
       "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -7391,6 +7443,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
       "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.226.0",
         "@aws-sdk/util-uri-escape": "3.201.0",
@@ -7404,6 +7457,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
       "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -7416,6 +7470,7 @@
       "version": "3.229.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
       "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+      "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -7424,6 +7479,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
       "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -7436,6 +7492,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
       "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.201.0",
         "@aws-sdk/types": "3.226.0",
@@ -7563,6 +7620,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.226.0.tgz",
       "integrity": "sha512-BWr1FhWSUhkSBp0TLzliD5AQBjA2Jmo9FlOOt+cBwd9BKkSGlGj+HgATYJ83Sjjg2+J6qvEZBxB78LKVHhorBw==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -7576,6 +7634,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.231.0.tgz",
       "integrity": "sha512-sxx6X/moSdukyrnoBtLxmgQQLWqixMc/qAM5yNg5lfNoGamWslH6CnT1HlxTFv71q8/1xwnvZ4LC2kbD6vDc6Q==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/client-sso-oidc": "3.231.0",
         "@aws-sdk/property-provider": "3.226.0",
@@ -7591,6 +7650,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
       "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -7602,6 +7662,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
       "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/querystring-parser": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -7624,6 +7685,7 @@
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
       "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
@@ -7685,6 +7747,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
       "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -7693,6 +7756,7 @@
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
       "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -7704,6 +7768,7 @@
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
       "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.201.0",
         "tslib": "^2.3.1"
@@ -7716,6 +7781,7 @@
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
       "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -7727,6 +7793,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.226.0.tgz",
       "integrity": "sha512-chLx+6AeMSjuPsCVbI1B4Pg3jftjjcsuTsJucjo0DKBb1VSWqPCitmOILQVvKiA2Km8TSs3VcbUuOCyDExkzAg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -7741,6 +7808,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.231.0.tgz",
       "integrity": "sha512-jH+9z96x8Oxv+bqBdD7x8CRvbKzM9id+VHzI9+h1oTY9J+6MkUubPshliBTQeus5pD03NBOS/2F3GX2rJ9Avuw==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/config-resolver": "3.231.0",
         "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -7757,6 +7825,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.231.0.tgz",
       "integrity": "sha512-7+Mj3wBqUdgV0U+9Va+89qafclXhEsjULTbfNdfic4C3PVtcRb1B5on5EPg3g2r3OlDoJBYFjoyW4CAro7TCiA==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -7768,6 +7837,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
       "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -7780,6 +7850,7 @@
       "version": "3.201.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
       "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -7791,6 +7862,7 @@
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
       "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -7802,6 +7874,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
       "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -7813,6 +7886,7 @@
       "version": "3.229.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
       "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/service-error-classification": "3.229.0",
         "tslib": "^2.3.1"
@@ -8029,6 +8103,7 @@
       "version": "3.201.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
       "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -8040,6 +8115,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
       "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.226.0",
         "bowser": "^2.11.0",
@@ -8050,6 +8126,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
       "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/node-config-provider": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -8071,6 +8148,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
       "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -8079,6 +8157,7 @@
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
       "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
@@ -10746,17 +10825,11 @@
       "dev": true
     },
     "node_modules/@nasa-gcn/dynamodb-autoincrement": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@nasa-gcn/dynamodb-autoincrement/-/dynamodb-autoincrement-0.0.4.tgz",
-      "integrity": "sha512-vX1w2dVFKZbZF+u2JoRSvDdIu9D6P6SeRNyC+pXzOdzVMjOJmc+iEWmARwrNLIYLdCiWGWYbrM5JpzNWnhVKSQ==",
-      "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.188.0"
-      },
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@nasa-gcn/dynamodb-autoincrement/-/dynamodb-autoincrement-0.0.5.tgz",
+      "integrity": "sha512-hu6Rj3/l45Zw6kus592ZbOK6JKtYVesXeoyhlA0X96nDGxVhIPdeC2tQZ/nLSbQIr/z8gCzFXTivjgbQ8pzRsg==",
       "engines": {
         "node": ">=16"
-      },
-      "peerDependencies": {
-        "@aws-sdk/lib-dynamodb": "^3.188.0"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -13369,7 +13442,8 @@
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "dev": true
     },
     "node_modules/boxen": {
       "version": "5.1.2",
@@ -16931,6 +17005,7 @@
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
       "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "dev": true,
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -22767,6 +22842,7 @@
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dev": true,
       "dependencies": {
         "obliterator": "^1.6.1"
       }
@@ -23542,7 +23618,8 @@
     "node_modules/obliterator": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
-      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "dev": true
     },
     "node_modules/oidc-provider": {
       "version": "8.1.0",
@@ -27296,7 +27373,8 @@
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
     },
     "node_modules/style-to-object": {
       "version": "0.3.0",
@@ -28465,6 +28543,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -30837,6 +30916,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
       "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -30844,7 +30924,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -30874,6 +30955,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
       "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "dev": true,
       "requires": {
         "@aws-crypto/ie11-detection": "^2.0.0",
         "@aws-crypto/sha256-js": "^2.0.0",
@@ -30888,7 +30970,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -30896,6 +30979,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
       "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "dev": true,
       "requires": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -30905,7 +30989,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -30913,6 +30998,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
       "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -30920,7 +31006,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -30928,6 +31015,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
       "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -30937,7 +31025,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -30945,6 +31034,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
       "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -31611,6 +31701,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.231.0.tgz",
       "integrity": "sha512-6UmDTPxYAerQdbH8bnIwZSHBzZeutDZ4ASatoT0L/mVD3OmqAVXRBnP2Fyd30JUGdtEPzw54EU8mX8HPGIwBzA==",
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -31654,6 +31745,8 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.231.0.tgz",
       "integrity": "sha512-WvNM3NmsFFB7S7I5B2PECe945bEzdwU3MElLznmcbccaRf31S61C4EAkghm6hXz0EoZlgdRfBqHaRB1PgmAUuA==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -31700,6 +31793,8 @@
           "version": "3.226.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
           "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
+          "dev": true,
+          "peer": true,
           "requires": {
             "@aws-sdk/abort-controller": "3.226.0",
             "@aws-sdk/types": "3.226.0",
@@ -32369,6 +32464,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.231.0.tgz",
       "integrity": "sha512-hNJoV0QYAfrBT50siNt+Ax3Lc+YY5UnpZ8kKuugnlU8SKMS+nrZ2tuNWv95awMAlsORaPo2Vm35ySTdM1+v87A==",
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -34332,6 +34428,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.231.0.tgz",
       "integrity": "sha512-/q7BptaMiT6/wxW9vE/gcQuApMXio5vdTuqt77A6+mjqhNzYFfCn7RRS4BU8KEOpZObnYBKP3mYe3NDccEbMzQ==",
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -34372,6 +34469,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.231.0.tgz",
       "integrity": "sha512-yqEZW9/Q6VvMDMcQoE52oa/oa6F8z8cqyax7m29VpuVrncYcfELpkZKWPoaJVfierR5ysKfKiAU0acPgMpvllQ==",
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -34412,6 +34510,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.231.0.tgz",
       "integrity": "sha512-5WYqlcbM49ofOFBsu28QBt3t26M5D9XynhSaswSrCzawwdNkIMYQrKOCplF5mqOy+GywVIRrFeCVVrAKPMZJxQ==",
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -34456,6 +34555,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.231.0.tgz",
       "integrity": "sha512-qpjV4Fw/NQ4a0p5/qwzqaShflYRlY/SPcgA7N5GTJjIjZjg3NV+5BKJSF3VeZcNKfbXq68kkn207OSCpyheYxQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/signature-v4": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -34468,6 +34568,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
       "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -34478,6 +34579,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
       "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+      "dev": true,
       "requires": {
         "@aws-sdk/node-config-provider": "3.226.0",
         "@aws-sdk/property-provider": "3.226.0",
@@ -34490,6 +34592,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.231.0.tgz",
       "integrity": "sha512-4JJgrJg2O91Vki4m5nSQNZGX/5yAYgzG1IOjeZ+8vCDxfR+jA2O9+/Xhi2/8aDpb1da77OJ+cK1+ezzSMchIfQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.226.0",
         "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -34505,6 +34608,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.231.0.tgz",
       "integrity": "sha512-DOojjyYdLNeBQv9+PaDXmvvww9SmcZsaL1YCl27e5larcJSMfT41vn4WRnVRu2zBI2BIi464Z8ziRRKwd2YFVg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.226.0",
         "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -34522,6 +34626,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
       "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.226.0",
         "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -34533,6 +34638,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.231.0.tgz",
       "integrity": "sha512-aImUD+PAqZ7A2C1ef7gskMN3KuxFT4Am1Vrl6M0oLGyrhKG2QtRT/UaXJE+Yt6d/C2qc2OsQ9j2oim7D6Qha/A==",
+      "dev": true,
       "requires": {
         "@aws-sdk/client-sso": "3.231.0",
         "@aws-sdk/property-provider": "3.226.0",
@@ -34546,6 +34652,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
       "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -34556,6 +34663,8 @@
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.208.0.tgz",
       "integrity": "sha512-MkrCvaZhTb1qZCjcDH73t5n43h0Kr0GS+30lpXZ9PAnHJZPqv+vhWFPK0ZsFe1XktbS0WOoDR4ED+lWm0Dw7Rg==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "mnemonist": "0.38.3",
         "tslib": "^2.3.1"
@@ -34669,6 +34778,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
       "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.226.0",
         "@aws-sdk/querystring-builder": "3.226.0",
@@ -34701,6 +34811,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
       "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.226.0",
         "@aws-sdk/util-buffer-from": "3.208.0",
@@ -34729,6 +34840,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
       "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -34738,6 +34850,7 @@
       "version": "3.201.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
       "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -34746,6 +34859,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.231.0.tgz",
       "integrity": "sha512-q1gvuxBQGR+xflaTbEP9Q+jCqnuqtznVrKt26skVUvzjmJJLB1dxHxwUPHv6SKO3R+bby7ATlVGQwQkZxViSGA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/util-dynamodb": "3.231.0",
         "tslib": "^2.3.1"
@@ -34844,6 +34958,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
       "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -34854,6 +34969,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
       "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/middleware-serde": "3.226.0",
         "@aws-sdk/protocol-http": "3.226.0",
@@ -34869,6 +34985,8 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.231.0.tgz",
       "integrity": "sha512-8HRZRrZWuAlm/I8uwFG8+iK8TCJWHSizRTEZfNazx7V5anOk55UeCVg3ifuXnFPmGeb4VDBRTn4h2dUx4LRKLQ==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/config-resolver": "3.231.0",
         "@aws-sdk/endpoint-cache": "3.208.0",
@@ -34951,6 +35069,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
       "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -34979,6 +35098,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
       "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -34988,6 +35108,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
       "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -34998,6 +35119,7 @@
       "version": "3.229.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.229.0.tgz",
       "integrity": "sha512-/y0BWio9b2RRH2QvRTohbuqE0vhH4IZKlc6k+JRbGV9aSwyOzACU/L/qkGftC/W0puvgNvZYjGxmB6cGHAEZaw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.226.0",
         "@aws-sdk/service-error-classification": "3.229.0",
@@ -35070,6 +35192,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
       "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/middleware-signing": "3.226.0",
         "@aws-sdk/property-provider": "3.226.0",
@@ -35083,6 +35206,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
       "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -35092,6 +35216,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
       "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.226.0",
         "@aws-sdk/protocol-http": "3.226.0",
@@ -35123,6 +35248,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
       "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -35131,6 +35257,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
       "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -35141,6 +35268,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
       "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.226.0",
         "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -35152,6 +35280,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
       "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/abort-controller": "3.226.0",
         "@aws-sdk/protocol-http": "3.226.0",
@@ -35164,6 +35293,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
       "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -35173,6 +35303,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
       "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -35182,6 +35313,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
       "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.226.0",
         "@aws-sdk/util-uri-escape": "3.201.0",
@@ -35192,6 +35324,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
       "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -35200,12 +35333,14 @@
     "@aws-sdk/service-error-classification": {
       "version": "3.229.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg=="
+      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+      "dev": true
     },
     "@aws-sdk/shared-ini-file-loader": {
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
       "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -35215,6 +35350,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
       "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.201.0",
         "@aws-sdk/types": "3.226.0",
@@ -35309,6 +35445,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.226.0.tgz",
       "integrity": "sha512-BWr1FhWSUhkSBp0TLzliD5AQBjA2Jmo9FlOOt+cBwd9BKkSGlGj+HgATYJ83Sjjg2+J6qvEZBxB78LKVHhorBw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/middleware-stack": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -35319,6 +35456,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.231.0.tgz",
       "integrity": "sha512-sxx6X/moSdukyrnoBtLxmgQQLWqixMc/qAM5yNg5lfNoGamWslH6CnT1HlxTFv71q8/1xwnvZ4LC2kbD6vDc6Q==",
+      "dev": true,
       "requires": {
         "@aws-sdk/client-sso-oidc": "3.231.0",
         "@aws-sdk/property-provider": "3.226.0",
@@ -35331,6 +35469,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
       "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -35339,6 +35478,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
       "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/querystring-parser": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -35358,6 +35498,7 @@
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
       "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
@@ -35407,6 +35548,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
       "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -35415,6 +35557,7 @@
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
       "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -35423,6 +35566,7 @@
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
       "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.201.0",
         "tslib": "^2.3.1"
@@ -35432,6 +35576,7 @@
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
       "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -35440,6 +35585,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.226.0.tgz",
       "integrity": "sha512-chLx+6AeMSjuPsCVbI1B4Pg3jftjjcsuTsJucjo0DKBb1VSWqPCitmOILQVvKiA2Km8TSs3VcbUuOCyDExkzAg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -35451,6 +35597,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.231.0.tgz",
       "integrity": "sha512-jH+9z96x8Oxv+bqBdD7x8CRvbKzM9id+VHzI9+h1oTY9J+6MkUubPshliBTQeus5pD03NBOS/2F3GX2rJ9Avuw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/config-resolver": "3.231.0",
         "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -35464,6 +35611,7 @@
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.231.0.tgz",
       "integrity": "sha512-7+Mj3wBqUdgV0U+9Va+89qafclXhEsjULTbfNdfic4C3PVtcRb1B5on5EPg3g2r3OlDoJBYFjoyW4CAro7TCiA==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -35472,6 +35620,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
       "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -35481,6 +35630,7 @@
       "version": "3.201.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
       "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -35489,6 +35639,7 @@
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
       "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -35497,6 +35648,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
       "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -35505,6 +35657,7 @@
       "version": "3.229.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
       "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+      "dev": true,
       "requires": {
         "@aws-sdk/service-error-classification": "3.229.0",
         "tslib": "^2.3.1"
@@ -35680,6 +35833,7 @@
       "version": "3.201.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
       "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -35688,6 +35842,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
       "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.226.0",
         "bowser": "^2.11.0",
@@ -35698,6 +35853,7 @@
       "version": "3.226.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
       "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+      "dev": true,
       "requires": {
         "@aws-sdk/node-config-provider": "3.226.0",
         "@aws-sdk/types": "3.226.0",
@@ -35708,6 +35864,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
       "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -35716,6 +35873,7 @@
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
       "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
@@ -37508,12 +37666,9 @@
       }
     },
     "@nasa-gcn/dynamodb-autoincrement": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@nasa-gcn/dynamodb-autoincrement/-/dynamodb-autoincrement-0.0.4.tgz",
-      "integrity": "sha512-vX1w2dVFKZbZF+u2JoRSvDdIu9D6P6SeRNyC+pXzOdzVMjOJmc+iEWmARwrNLIYLdCiWGWYbrM5JpzNWnhVKSQ==",
-      "requires": {
-        "@aws-sdk/client-dynamodb": "^3.188.0"
-      }
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@nasa-gcn/dynamodb-autoincrement/-/dynamodb-autoincrement-0.0.5.tgz",
+      "integrity": "sha512-hu6Rj3/l45Zw6kus592ZbOK6JKtYVesXeoyhlA0X96nDGxVhIPdeC2tQZ/nLSbQIr/z8gCzFXTivjgbQ8pzRsg=="
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -39494,7 +39649,8 @@
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "dev": true
     },
     "boxen": {
       "version": "5.1.2",
@@ -42205,6 +42361,7 @@
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
       "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "dev": true,
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -46582,6 +46739,7 @@
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dev": true,
       "requires": {
         "obliterator": "^1.6.1"
       }
@@ -47168,7 +47326,8 @@
     "obliterator": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
-      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "dev": true
     },
     "oidc-provider": {
       "version": "8.1.0",
@@ -50042,7 +50201,8 @@
     "strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
     },
     "style-to-object": {
       "version": "0.3.0",
@@ -50962,7 +51122,8 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
     },
     "uvu": {
       "version": "0.5.6",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,8 @@
   },
   "dependencies": {
     "@architect/functions": "^5.3.3",
-    "@aws-sdk/client-cognito-identity-provider": "^3.223.0",
-    "@aws-sdk/client-sesv2": "^3.223.0",
     "@balavishnuvj/remix-seo": "^1.0.2",
-    "@nasa-gcn/dynamodb-autoincrement": "^0.0.4",
+    "@nasa-gcn/dynamodb-autoincrement": "^0.0.5",
     "@octokit/rest": "^19.0.7",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.34.0",
     "@opentelemetry/sdk-trace-base": "^1.9.0",
@@ -54,6 +52,8 @@
   },
   "devDependencies": {
     "@architect/architect": "^10.9.1",
+    "@aws-sdk/client-cognito-identity-provider": "^3.223.0",
+    "@aws-sdk/client-sesv2": "^3.223.0",
     "@aws-sdk/lib-dynamodb": "^3.188.0",
     "@aws-sdk/util-dynamodb": "^3.188.0",
     "@remix-run/dev": "^1.11.1",


### PR DESCRIPTION
Since they are already present in the Lambda runtime, we can save space and startup time by omitting them from our deployment archive.