### PR TITLE
Improve wording in client credentials UI

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -98,7 +98,7 @@ export function Header({ email }: { email?: string }) {
                         to="/user/credentials"
                         onClick={() => setUserMenuIsOpen(!userMenuIsOpen)}
                       >
-                        Credentials
+                        Client Credentials
                       </Link>,
                       <Link
                         key="email"

--- a/app/routes/docs/client.mdx
+++ b/app/routes/docs/client.mdx
@@ -7,7 +7,7 @@ import { ClientSampleCode } from '~/components/ClientSampleCode'
 
 # Client Configuration
 
-See our [quickstart](/quickstart) for a step-by-step walkthrough to begin streaming alerts now!
+See our [Start Streaming GCN Notices quick start guide](/quickstart) for a step-by-step walkthrough to begin streaming alerts now!
 
 ## Python
 

--- a/app/routes/user/credentials/index.tsx
+++ b/app/routes/user/credentials/index.tsx
@@ -55,11 +55,11 @@ export default function Index() {
       </div>
       <p>
         Manage your client credentials here. Client credentials allow your
-        scripts to interact with GCN on your behalf. These credentials are the
-        same as those generated through the{' '}
-        <Link to="/quickstart">Start Streaming GCN Notices</Link>. For an
-        example of how to use these, see the{' '}
-        <Link to="/docs/client">client docs</Link>.
+        scripts to interact with GCN on your behalf. You can also create client
+        credentials through the{' '}
+        <Link to="/quickstart">Start Streaming GCN Notices</Link> quick start
+        guide. For sample code demonstrating usage of client credentials, see
+        the <Link to="/docs/client">client documentation</Link>.
       </p>
       <SegmentedCards>
         {client_credentials.map((credential) => (


### PR DESCRIPTION
- Fix a grammatical error.
- Ensure that page titles are the same in the side nav and the navbar dropdown.