### PR TITLE
Clean up ternary expressions in React JSX fragments

### DIFF
--- a/app/components/NestedCheckboxes.tsx
+++ b/app/components/NestedCheckboxes.tsx
@@ -71,7 +71,7 @@ function NestedCheckboxNode({
         label={
           <>
             <span className="padding-right-1">{topLevelNodeProps.label}</span>
-            {link ? (
+            {link && (
               <>
                 (
                 <Link
@@ -84,7 +84,7 @@ function NestedCheckboxNode({
                 </Link>
                 )
               </>
-            ) : null}
+            )}
           </>
         }
         inputRef={topLevelRef}

--- a/app/routes/notices.tsx
+++ b/app/routes/notices.tsx
@@ -32,26 +32,30 @@ function NoticeCard({
   href: string
 }) {
   const tagSet = new Set(tags)
-  return selectedTags.length == 0 ||
-    selectedTags.every((tag) => tagSet.has(tag)) ? (
-    <a
-      href={href}
-      className="tablet:grid-col-4 usa-card notice-card"
-      data-testid="Card"
-    >
-      <div className="usa-card__container">
-        <CardHeader>
-          <h3>{name}</h3>
-        </CardHeader>
-        <CardBody>{children}</CardBody>
-        <CardFooter>
-          {tags?.map((tag) => (
-            <Tag key={tag}>{tag}</Tag>
-          ))}
-        </CardFooter>
-      </div>
-    </a>
-  ) : null
+  return (
+    <>
+      {selectedTags.length == 0 ||
+        (selectedTags.every((tag) => tagSet.has(tag)) && (
+          <a
+            href={href}
+            className="tablet:grid-col-4 usa-card notice-card"
+            data-testid="Card"
+          >
+            <div className="usa-card__container">
+              <CardHeader>
+                <h3>{name}</h3>
+              </CardHeader>
+              <CardBody>{children}</CardBody>
+              <CardFooter>
+                {tags?.map((tag) => (
+                  <Tag key={tag}>{tag}</Tag>
+                ))}
+              </CardFooter>
+            </div>
+          </a>
+        ))}
+    </>
+  )
 }
 
 function renderTag({

--- a/app/routes/user/email/index.tsx
+++ b/app/routes/user/email/index.tsx
@@ -78,13 +78,13 @@ export default function Index() {
         </a>
         .
       </p>
-      {data ? (
+      {data && (
         <SegmentedCards>
           {data.map((alert) => (
             <EmailNotificationCard key={alert.uuid} {...alert} />
           ))}
         </SegmentedCards>
-      ) : null}
+      )}
     </>
   )
 }

--- a/app/routes/user/endorsements.tsx
+++ b/app/routes/user/endorsements.tsx
@@ -110,7 +110,7 @@ export default function Index() {
             users may also request an endorsement from you, which you may
             approve, deny, or report in the case of spam.
           </p>
-          {awaitingEndorsements.length > 0 ? (
+          {awaitingEndorsements.length > 0 && (
             <Grid row>
               <h2>Requests awaiting your review</h2>
               <SegmentedCards>
@@ -123,7 +123,7 @@ export default function Index() {
                 ))}
               </SegmentedCards>
             </Grid>
-          ) : null}
+          )}
         </>
       ) : (
         <div>
@@ -132,7 +132,7 @@ export default function Index() {
             approved user.
           </p>
           <EndorsementRequestForm />
-          {requestedEndorsements.length > 0 ? (
+          {requestedEndorsements.length > 0 && (
             <div>
               <h2>Your Pending Requests</h2>
               <SegmentedCards>
@@ -145,7 +145,7 @@ export default function Index() {
                 ))}
               </SegmentedCards>
             </div>
-          ) : null}
+          )}
         </div>
       )}
     </Grid>
@@ -217,14 +217,14 @@ export function EndorsementRequestCard({
               {endorsementRequest.status}
             </div>
           </div>
-          {endorsementRequest.status ? (
+          {endorsementRequest.status && (
             <ButtonGroup className="tablet:grid-col flex-auto flex-align-center">
               <input
                 type="hidden"
                 name="endorserSub"
                 value={endorsementRequest.endorserSub}
               />
-              {endorsementRequest.status !== 'reported' ? (
+              {endorsementRequest.status !== 'reported' && (
                 <Button
                   type="submit"
                   secondary
@@ -234,9 +234,9 @@ export function EndorsementRequestCard({
                 >
                   Delete
                 </Button>
-              ) : null}
+              )}
             </ButtonGroup>
-          ) : null}
+          )}
         </Grid>
       )}
     </fetcher.Form>


### PR DESCRIPTION
React permits `false` or `undefined` in React fragments. Replace ternary expressions like this:

    <>{condition ? <Component/> : null}</>

with terser, short-circuit boolean expressions like this:

    <>{condition && <Component/>}</>