### PR TITLE
Fix paragraph styling

### DIFF
--- a/app/components/CredentialCard.tsx
+++ b/app/components/CredentialCard.tsx
@@ -82,13 +82,11 @@ export default function CredentialCard({
           <ModalHeading id="modal-delete-heading">
             Delete Client Credential
           </ModalHeading>
-          <div className="usa-prose">
-            <p id="modal-delete-description">
-              Are you sure that you want to delete the client credential named “
-              {name}” with client ID <code>{client_id}</code>?
-            </p>
-            <p>This action cannot be undone.</p>
-          </div>
+          <p id="modal-delete-description">
+            Are you sure that you want to delete the client credential named “
+            {name}” with client ID <code>{client_id}</code>?
+          </p>
+          <p>This action cannot be undone.</p>
           <ModalFooter>
             <ModalToggleButton modalRef={ref} closer outline>
               Cancel

--- a/app/components/EmailNotificationCard.tsx
+++ b/app/components/EmailNotificationCard.tsx
@@ -101,13 +101,11 @@ export default function EmailNotificationCard({
           <ModalHeading id="modal-delete-heading">
             Delete Email Notification
           </ModalHeading>
-          <div className="usa-prose">
-            <p id="modal-delete-description">
-              Are you sure that you want to delete the email notification named
-              “{name}”?
-            </p>
-            <p>This action cannot be undone.</p>
-          </div>
+          <p id="modal-delete-description">
+            Are you sure that you want to delete the email notification named “
+            {name}”?
+          </p>
+          <p>This action cannot be undone.</p>
           <ModalFooter>
             <ModalToggleButton modalRef={deleteModalRef} closer outline>
               Cancel
@@ -128,11 +126,9 @@ export default function EmailNotificationCard({
         <ModalHeading id="modal-test-heading">
           Test Email Notification
         </ModalHeading>
-        <div className="usa-prose">
-          <p id="modal-test-description">
-            A test message has been sent to {recipient}.
-          </p>
-        </div>
+        <p id="modal-test-description">
+          A test message has been sent to {recipient}.
+        </p>
         <ModalFooter>
           <ModalToggleButton data-close-modal modalRef={testModalRef} closer>
             OK

--- a/app/components/NewCredentialForm.tsx
+++ b/app/components/NewCredentialForm.tsx
@@ -98,14 +98,14 @@ export function NewCredentialForm() {
   return (
     <Form method="post">
       <input type="hidden" name="intent" value="create" />
-      <div className="usa-prose">
-        <p>Choose a name for your new client credential.</p>
-        <p className="text-base">
-          The name should help you remember what you use the client credential
-          for, or where you use it. Examples: “My Laptop”, “Lab Desktop”, “GRB
-          Pipeline”.
-        </p>
-      </div>
+      <p className="usa-paragraph">
+        Choose a name for your new client credential.
+      </p>
+      <p className="usa-paragraph text-base">
+        The name should help you remember what you use the client credential
+        for, or where you use it. Examples: “My Laptop”, “Lab Desktop”, “GRB
+        Pipeline”.
+      </p>
       <Label htmlFor="name">Name</Label>
       <TextInput
         data-focus
@@ -130,7 +130,7 @@ export function NewCredentialForm() {
         ))}
       </Fieldset>
       {recaptchaSiteKey ? (
-        <p>
+        <p className="usa-paragraph">
           <ReCAPTCHA
             sitekey={recaptchaSiteKey}
             onChange={(value) => {
@@ -139,7 +139,7 @@ export function NewCredentialForm() {
           />
         </p>
       ) : (
-        <p className="usa-prose text-base">
+        <p className="text-base">
           You are working in a development environment, the ReCaptcha is
           currently hidden
         </p>

--- a/app/components/UserPageContainer.tsx
+++ b/app/components/UserPageContainer.tsx
@@ -12,7 +12,7 @@ import { Grid } from '@trussworks/react-uswds'
 export default function UserPageContainer({ header }: { header: string }) {
   return (
     <Grid row>
-      <div className="tablet:grid-col-10 flex-fill usa-prose">
+      <div className="tablet:grid-col-10 flex-fill">
         <h1 className="margin-y-0">{header}</h1>
       </div>
       <Outlet />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -228,7 +228,7 @@ export function CatchBoundary() {
         <p className="usa-intro">
           We're sorry, you must log in to access the page you're looking for.
         </p>
-        <p>Log in to access that page, or go home.</p>
+        <p className="usa-paragraph">Log in to access that page, or go home.</p>
         <ButtonGroup>
           <Link
             to={`/login?redirect=${encodeURIComponent(url)}`}

--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -19,7 +19,7 @@ export function CatchBoundary() {
         We're sorry, we can't find the page you're looking for. It might have
         been removed, changed its name, or is otherwise unavailable.
       </p>
-      <p>
+      <p className="usa-paragraph">
         Visit our homepage for helpful tools and resources, or contact us and
         we'll point you in the right direction.
       </p>

--- a/app/routes/__auth/post_logout.tsx
+++ b/app/routes/__auth/post_logout.tsx
@@ -46,7 +46,7 @@ export default function PostLogout() {
       <ModalHeading id="modal-existing-idp-heading">
         That email address is already registered
       </ModalHeading>
-      <div className="usa-prose" id="modal-existing-idp-description">
+      <div id="modal-existing-idp-description">
         <p>
           You already have an existing account with the same email address. Last
           time that you signed in, you used <b>{friendlyExistingIdp}</b>. Would

--- a/app/routes/circulars/$circularId.tsx
+++ b/app/routes/circulars/$circularId.tsx
@@ -30,7 +30,7 @@ export default function $circularId() {
     <>
       <Link to="/circulars">back to archive</Link>
       <h1>GCN Circular {circularId}</h1>
-      <p className="usa-prose">
+      <p className="usa-paragraph">
         <Grid row>
           <Grid col={1}>
             <b>Subject</b>

--- a/app/routes/circulars/index.tsx
+++ b/app/routes/circulars/index.tsx
@@ -46,7 +46,7 @@ export default function Index() {
   return (
     <>
       <h1>GCN Circulars</h1>
-      <p>
+      <p className="usa-paragraph">
         GCN Circulars are rapid astronomical bulletins submitted by and
         distributed to community members worldwide. For more information, see{' '}
         <Link to="">docs</Link>

--- a/app/routes/docs.tsx
+++ b/app/routes/docs.tsx
@@ -40,7 +40,7 @@ export default function Docs() {
           ]}
         />
       </div>
-      <div className="desktop:grid-col-9 usa-prose">
+      <div className="desktop:grid-col-9">
         <Outlet />
       </div>
     </div>

--- a/app/routes/missions.tsx
+++ b/app/routes/missions.tsx
@@ -65,7 +65,7 @@ export default function Missions() {
           ]}
         />
       </div>
-      <div className="desktop:grid-col-8 usa-prose grid-col-12">
+      <div className="desktop:grid-col-8 grid-col-12">
         <Outlet />
       </div>
     </div>

--- a/app/routes/notices.tsx
+++ b/app/routes/notices.tsx
@@ -100,7 +100,7 @@ export default function Notices() {
   return (
     <>
       <h1>GCN Notices</h1>
-      <p>
+      <p className="usa-paragraph">
         GCN Notices are real-time, machine-readable alerts that are submitted by
         participating facilities and redistributed publicly.
       </p>

--- a/app/routes/quickstart/alerts.tsx
+++ b/app/routes/quickstart/alerts.tsx
@@ -27,7 +27,7 @@ export default function Alerts() {
   const clientId = useLoaderData<typeof loader>()
   return (
     <Form method="get" action="../code">
-      <p>
+      <p className="usa-paragraph">
         Choose how you would like your results returned. Select a Format and
         Notice type for each alert you would like to subscribe to. More details
         on the Notice Types can be found their respective pages under{' '}

--- a/app/routes/quickstart/credentials.tsx
+++ b/app/routes/quickstart/credentials.tsx
@@ -40,7 +40,7 @@ export default function Credentials() {
     <>
       {client_credentials.length > 0 ? (
         <>
-          <p>
+          <p className="usa-paragraph">
             {explanation} Select one of your existing client credentials, or
             create a new one.
           </p>
@@ -56,7 +56,7 @@ export default function Credentials() {
         </>
       ) : (
         <>
-          <p>{explanation}</p>
+          <p className="usa-paragraph">{explanation}</p>
           <NewCredentialForm />
         </>
       )}

--- a/app/routes/quickstart/index.tsx
+++ b/app/routes/quickstart/index.tsx
@@ -25,18 +25,18 @@ export default function StreamingSteps() {
     <>
       <div className="maxw-tablet">
         {email ? (
-          <p>
+          <p className="usa-paragraph">
             Congratulations! You are signed in as <strong>{email}</strong> using{' '}
             <strong>{idp ?? 'username and password'}</strong>.
           </p>
         ) : (
-          <p>
+          <p className="usa-paragraph">
             To begin, click the button below to sign up or sign in with a
             username and password, Google, Facebook, or (for NASA employees and
             affiliates) LaunchPad.
           </p>
         )}
-        <p>
+        <p className="usa-paragraph">
           <strong>
             Important: make sure you sign in the same way each time.
           </strong>{' '}

--- a/app/routes/user.tsx
+++ b/app/routes/user.tsx
@@ -40,7 +40,7 @@ export default function User() {
             ]}
           />
         </div>
-        <div className="desktop:grid-col-9 usa-prose">
+        <div className="desktop:grid-col-9">
           <Outlet />
         </div>
       </div>

--- a/app/routes/user/credentials/index.tsx
+++ b/app/routes/user/credentials/index.tsx
@@ -53,7 +53,7 @@ export default function Index() {
           Add
         </Link>
       </div>
-      <p>
+      <p className="usa-paragraph">
         Manage your client credentials here. Client credentials allow your
         scripts to interact with GCN on your behalf. You can also create client
         credentials through the{' '}

--- a/app/routes/user/email/index.tsx
+++ b/app/routes/user/email/index.tsx
@@ -56,14 +56,14 @@ export default function Index() {
           Add
         </Link>
       </div>
-      <p>
+      <p className="usa-paragraph">
         Create and manage email subscriptions to GCN Notices here. You can
         create as many subscriptions as you like. To create a new alert, click
         the "Add" button. Once an alert has been created, you can click the
         "Test Message" button to send a test email to the listed recipient, to
         verify that the emails will make it into your inbox.
       </p>
-      <p>
+      <p className="usa-paragraph">
         Note that signing up here does not affect prior subscriptions on the old
         web site,{' '}
         <a rel="external" href="https://gcn.gsfc.nasa.gov/">

--- a/app/routes/user/endorsements.tsx
+++ b/app/routes/user/endorsements.tsx
@@ -100,12 +100,12 @@ export default function Index() {
 
   return (
     <Grid row>
-      <div className="tablet:grid-col-10 flex-fill usa-prose">
+      <div className="tablet:grid-col-10 flex-fill">
         <h1 className="margin-y-0">Peer Endorsements</h1>
       </div>
       {userIsSubmitter ? (
         <>
-          <p>
+          <p className="usa-paragraph">
             As an approved submitter, you may submit new GCN Circulars. Other
             users may also request an endorsement from you, which you may
             approve, deny, or report in the case of spam.
@@ -127,7 +127,7 @@ export default function Index() {
         </>
       ) : (
         <div>
-          <p>
+          <p className="usa-paragraph">
             In order to submit GCN Circulars, you must be endorsed by an already
             approved user.
           </p>
@@ -370,12 +370,12 @@ export function EndorsementRequestForm() {
   return (
     <Form method="post">
       <h2 id="modal-request-heading">Request Endorsement</h2>
-      <div className="usa-prose">
+      <p className="usa-paragraph">
         Requesting an endorsement from another user will share your email with
         that individual. Please keep this in mind when submitting. Enter the
         email of the individual you want to be endorsed by. They will receive a
         notification alerting them to this request.
-      </div>
+      </p>
       <input type="hidden" name="endorserSub" value={endorserSub} />
       <Grid row>
         <Grid col="fill">

--- a/app/routes/user/index.tsx
+++ b/app/routes/user/index.tsx
@@ -90,10 +90,12 @@ export default function User() {
   return (
     <>
       <h1>Welcome, {email}!</h1>
-      <p>You signed in with {idp || 'username and password'}.</p>
+      <p className="usa-paragraph">
+        You signed in with {idp || 'username and password'}.
+      </p>
       <h2>Profile</h2>
       <fetcher.Form method="post" onSubmit={() => setDirty(false)}>
-        <p>
+        <p className="usa-paragraph">
           Your profile affects how your name appears in GCN Circulars that you
           submit.
         </p>

--- a/remix.config.mjs
+++ b/remix.config.mjs
@@ -20,8 +20,11 @@ export const mdx = {
       }),
     (options) =>
       rehypeAddClasses({
-        table: 'usa-table',
         a: 'usa-link',
+        ol: 'usa-list',
+        p: 'usa-paragraph',
+        table: 'usa-table',
+        ul: 'usa-list',
         ...options,
       }),
     (options) => rehypeAutolinkHeadings({ behavior: 'wrap', ...options }),

--- a/theme/custom.scss
+++ b/theme/custom.scss
@@ -9,6 +9,22 @@
 @import 'styles';
 
 /*
+ * USWDS prose fix ups:
+ * - Unset max-width for paragraphs and list items in a grid container because
+ *   the intended maximum width is already provided by the grid container
+ *   itself.
+ * - No top margin for h1 if it is the first element in the containing element.
+ */
+.grid-container .usa-paragraph,
+.grid-container .usa-list > li {
+  max-width: none;
+}
+
+h1:first-child {
+  margin-top: 0;
+}
+
+/*
  * Size and position the NASA meatball logo in the header. 
  */
 


### PR DESCRIPTION
- Get rid of the usa-prose class. It is of limited use because it only affects direct children.
- Use usa-paragraph on all `p` tags except for those in dialog boxes and a few other UI contexts.
- Fix excesssive horizontal space around `p` and `li` elements in grid containers.