### PR TITLE
Remove guesswork about URL origin, refactor email sending

### DIFF
--- a/app/lib/email.ts
+++ b/app/lib/email.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright © 2022 United States Government as represented by the Administrator
+ * of the National Aeronautics and Space Administration. No copyright is claimed
+ * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ *
+ * SPDX-License-Identifier: NASA-1.3
+ */
+
+import {
+  SendEmailCommand,
+  SESv2Client,
+  SESv2ServiceException,
+} from '@aws-sdk/client-sesv2'
+import { getHostname } from './env'
+
+const client = new SESv2Client({})
+
+export async function sendEmail(
+  fromName: string,
+  recipient: string,
+  subject: string,
+  body: string
+) {
+  const hostname = getHostname()
+
+  const command = new SendEmailCommand({
+    Destination: {
+      ToAddresses: [recipient],
+    },
+    FromEmailAddress: `${fromName} <no-reply@${hostname}>`,
+    Content: {
+      Simple: {
+        Subject: {
+          Data: subject,
+        },
+        Body: {
+          Text: {
+            Data: body,
+          },
+        },
+      },
+    },
+  })
+
+  try {
+    await client.send(command)
+  } catch (e) {
+    if (
+      !(
+        e instanceof SESv2ServiceException &&
+        ['InvalidClientTokenId', 'UnrecognizedClientException'].includes(e.name)
+      ) ||
+      process.env.NODE_ENV === 'production'
+    ) {
+      throw e
+    } else {
+      console.warn(`SES threw ${e.name}. This would be an error in production.`)
+    }
+  }
+}

--- a/app/lib/env.ts
+++ b/app/lib/env.ts
@@ -24,3 +24,18 @@ export function getEnvOrDieInProduction(key: string) {
   }
   return result
 }
+
+function getOriginSandbox() {
+  const {
+    ports: { http },
+  } = JSON.parse(getEnvOrDie('ARC_SANDBOX'))
+  return `http://localhost:${http}`
+}
+
+export function getOrigin() {
+  return getEnvOrDieInProduction('ORIGIN') || getOriginSandbox()
+}
+
+export function getHostname() {
+  return new URL(getOrigin()).hostname
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -64,6 +64,7 @@ import favicon_114 from '~/theme/img/favicons/favicon-114.png'
 import favicon_144 from '~/theme/img/favicons/favicon-144.png'
 import favicon_192 from '~/theme/img/favicons/favicon-192.png'
 import { useRouteLoaderData } from './lib/remix'
+import { getOrigin } from './lib/env'
 const favicons = {
   16: favicon_16,
   40: favicon_40,
@@ -110,7 +111,7 @@ export const links: LinksFunction = () => [
 ]
 
 export async function loader({ request }: DataFunctionArgs) {
-  const { origin } = new URL(request.url)
+  const origin = getOrigin()
 
   const user = await getUser(request)
   const email = user?.email

--- a/app/routes/docs/contributing.mdx
+++ b/app/routes/docs/contributing.mdx
@@ -95,6 +95,11 @@ Here are instructions for getting the GCN site set up and running on your own co
     # these lines must be uncommented and filled in.
     # RECAPTCHA_SITE_KEY=fill-me-in
     # RECAPTCHA_SECRET_KEY=fill-me-in
+
+    # (Optional) URL origin to be used for external redirects, email From
+    # addresses, and so on. Leave this unset for local development so that it
+    # defaults to http://localhost:3333.
+    # ORIGIN=https://gcn.nasa.gov
     ```
 
   </ProcessListItem>

--- a/src/plugins/emailIncoming.mjs
+++ b/src/plugins/emailIncoming.mjs
@@ -19,9 +19,12 @@ export const set = {
 
 export const deploy = {
   start({ cloudformation }) {
-    const { DOMAIN } =
+    const { ORIGIN } =
       cloudformation.Resources.EmailIncomingEventLambda.Properties.Environment
         .Variables
+    if (!ORIGIN) throw new Error('Environment variable ORIGIN must be defined')
+    const hostname = new URL(ORIGIN).hostname
+
     Object.assign(cloudformation.Resources, {
       EmailIncomingReceiptRuleSet: { Type: 'AWS::SES::ReceiptRuleSet' },
       EmailIncomingReceiptRule: {
@@ -29,7 +32,7 @@ export const deploy = {
         Properties: {
           RuleSetName: { Ref: 'EmailIncomingReceiptRuleSet' },
           Enabled: true,
-          Recipients: [`circulars@${DOMAIN}`],
+          Recipients: [`circulars@${hostname}`],
           Actions: [
             {
               SNSAction: {


### PR DESCRIPTION
Having added the `DOMAIN` environment variable, we no longer need to guess the URL origin from the request headers. Not only is this more secure, but it allows several simplifying refactorings:

- Unify the subdomain, parent domain, port, and URL scheme  under a single `ORIGIN` environemt variable.
- Reuse the `ORIGIN` environmet variable for both external HTTP redirects and email From addresses.
- Refactor the two instances of email sending into a single `sendEmail` function.

Also, document the `ORIGIN` environment variable in the contributing guide.