### PR TITLE
Remove names from default exports in route modules

### DIFF
--- a/app/routes/circulars/$circularId.tsx
+++ b/app/routes/circulars/$circularId.tsx
@@ -23,7 +23,7 @@ export async function loader({ params: { circularId } }: DataFunctionArgs) {
   })
 }
 
-export default function $circularId() {
+export default function () {
   const { circularId, subject, submitter, createdOn, body } =
     useLoaderData<typeof loader>()
   return (

--- a/app/routes/circulars/index.tsx
+++ b/app/routes/circulars/index.tsx
@@ -39,7 +39,7 @@ export async function action({ request }: DataFunctionArgs) {
   return null
 }
 
-export default function Index() {
+export default function () {
   const { page, totalPages, items } = useLoaderData<typeof loader>()
   const pages = usePagination({ currentPage: page, totalPages })
 

--- a/app/routes/circulars/new.tsx
+++ b/app/routes/circulars/new.tsx
@@ -50,7 +50,7 @@ function useBodyPlaceholder() {
     `)
 }
 
-export default function New() {
+export default function () {
   const { formattedAuthor } = useLoaderData<typeof loader>()
   const [subjectValid, setSubjectValid] = useState<boolean | undefined>()
   const [bodyValid, setBodyValid] = useState<boolean | undefined>()

--- a/app/routes/docs.tsx
+++ b/app/routes/docs.tsx
@@ -13,7 +13,7 @@ export const handle = {
   breadcrumb: 'Documentation',
 }
 
-export default function Docs() {
+export default function () {
   return (
     <div className="grid-row grid-gap">
       <div className="desktop:grid-col-3">

--- a/app/routes/missions.tsx
+++ b/app/routes/missions.tsx
@@ -11,7 +11,7 @@ import { NavLink, Outlet } from '@remix-run/react'
 
 export const handle = { breadcrumb: 'Missions' }
 
-export default function Missions() {
+export default function () {
   return (
     <div className="grid-row grid-gap">
       <div className="desktop:grid-col-4">

--- a/app/routes/notices.tsx
+++ b/app/routes/notices.tsx
@@ -92,7 +92,7 @@ function renderOption({
   )
 }
 
-export default function Notices() {
+export default function () {
   const [tags, setTags] = useState<ReactTag[]>([])
   const suggestions = ['gw', 'gamma', 'nu', 'x-ray', 'uv', 'optical']
   const tagNames = tags.map(({ label }) => label)

--- a/app/routes/quickstart.tsx
+++ b/app/routes/quickstart.tsx
@@ -13,7 +13,7 @@ export const handle = {
   breadcrumb: 'Start Streaming GCN Notices',
 }
 
-export default function Streaming() {
+export default function () {
   return (
     <>
       <h1>Start Streaming GCN Notices</h1>

--- a/app/routes/quickstart/alerts.tsx
+++ b/app/routes/quickstart/alerts.tsx
@@ -23,7 +23,7 @@ export function loader({ request: { url } }: DataFunctionArgs) {
   return clientId
 }
 
-export default function Alerts() {
+export default function () {
   const clientId = useLoaderData<typeof loader>()
   return (
     <Form method="get" action="../code">

--- a/app/routes/quickstart/code.tsx
+++ b/app/routes/quickstart/code.tsx
@@ -33,7 +33,7 @@ export async function loader({ request }: DataFunctionArgs) {
   }
 }
 
-export default function Code() {
+export default function () {
   const {
     client_id: clientId,
     client_secret: clientSecret,

--- a/app/routes/quickstart/credentials.tsx
+++ b/app/routes/quickstart/credentials.tsx
@@ -27,7 +27,7 @@ export async function action({ request }: DataFunctionArgs) {
   return handleCredentialActions(request, 'quickstart')
 }
 
-export default function Credentials() {
+export default function () {
   const { client_credentials } = useLoaderData<typeof loader>()
 
   const explanation = (

--- a/app/routes/quickstart/index.tsx
+++ b/app/routes/quickstart/index.tsx
@@ -19,7 +19,7 @@ export async function loader({ request }: DataFunctionArgs) {
   return { email: user?.email, idp: user?.idp, url: request.url }
 }
 
-export default function StreamingSteps() {
+export default function () {
   const { email, idp, url } = useLoaderData<typeof loader>()
   return (
     <>

--- a/app/routes/user.tsx
+++ b/app/routes/user.tsx
@@ -12,7 +12,7 @@ import { useFeature } from '~/root'
 
 export const handle = { breadcrumb: 'User', getSitemapEntries: () => null }
 
-export default function User() {
+export default function () {
   const enableCirculars = useFeature('circulars')
   return (
     <>

--- a/app/routes/user/credentials/edit.tsx
+++ b/app/routes/user/credentials/edit.tsx
@@ -21,7 +21,7 @@ export async function action({ request }: DataFunctionArgs) {
   return handleCredentialActions(request, 'user')
 }
 
-export default function Edit() {
+export default function () {
   return (
     <>
       <h1>New Client Credentials</h1>

--- a/app/routes/user/credentials/index.tsx
+++ b/app/routes/user/credentials/index.tsx
@@ -42,7 +42,7 @@ export async function action({ request }: DataFunctionArgs) {
   }
 }
 
-export default function Index() {
+export default function () {
   const { client_credentials } = useLoaderData<typeof loader>()
 
   return (

--- a/app/routes/user/email/edit.tsx
+++ b/app/routes/user/email/edit.tsx
@@ -76,7 +76,7 @@ export async function loader({ request }: DataFunctionArgs) {
   return { notification, intent, format }
 }
 
-export default function Edit() {
+export default function () {
   const { notification, intent, format } = useLoaderData<typeof loader>()
   const defaultNameValid = !!notification.name
   const [nameValid, setNameValid] = useState(defaultNameValid)

--- a/app/routes/user/email/index.tsx
+++ b/app/routes/user/email/index.tsx
@@ -43,7 +43,7 @@ export async function loader({ request }: DataFunctionArgs) {
   return data
 }
 
-export default function Index() {
+export default function () {
   const data = useLoaderData<typeof loader>()
   return (
     <>

--- a/app/routes/user/endorsements.tsx
+++ b/app/routes/user/endorsements.tsx
@@ -94,7 +94,7 @@ export async function action({ request }: DataFunctionArgs) {
   return null
 }
 
-export default function Index() {
+export default function () {
   const { awaitingEndorsements, requestedEndorsements, userIsSubmitter } =
     useLoaderData<typeof loader>()
 

--- a/app/routes/user/index.tsx
+++ b/app/routes/user/index.tsx
@@ -66,7 +66,7 @@ export async function action({ request }: DataFunctionArgs) {
   return null
 }
 
-export default function User() {
+export default function () {
   const { email, idp, name, affiliation } = useLoaderData<typeof loader>()
   const fetcher = useFetcher<typeof action>()
   const [dirty, setDirty] = useState(false)


### PR DESCRIPTION
Remix's eslint configuraiton does not require display names for default exports from route modules.

See https://github.com/remix-run/remix/blob/remix%401.12.0/packages/remix-eslint-config/index.js#L80-L88