### PR TITLE
Make concurrency and tracing settings apply only to web site lambda

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -58,9 +58,6 @@ runtime nodejs18.x
 region us-east-1
 architecture arm64
 memory 256
-concurrency 100
-provisionedConcurrency 5
-timeout 10  # Allow extra time because Cognito's .well-known/openid-configuration endpoint can take several seconds.
 
 @plugins
 tracing  # Enable AWS X-Ray distributed tracing

--- a/server/config.arc
+++ b/server/config.arc
@@ -1,0 +1,4 @@
+@aws
+concurrency 100
+provisionedConcurrency 5
+timeout 10  # Allow extra time because Cognito's .well-known/openid-configuration endpoint can take several seconds.

--- a/src/plugins/tracing.mjs
+++ b/src/plugins/tracing.mjs
@@ -14,6 +14,7 @@ export const deploy = {
     const lambdaProps =
       cloudformation.Resources.AnyCatchallHTTPLambda.Properties
     const roleProps = cloudformation.Resources.Role.Properties
+
     lambdaProps.Tracing = 'Active'
     ;(lambdaProps.Layers ?? (lambdaProps.Layers = [])).push({
       'Fn::Sub':
@@ -23,18 +24,13 @@ export const deploy = {
     ;(roleProps.ManagedPolicyArns ?? (roleProps.ManagedPolicyArns = [])).push(
       'arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess'
     )
-    return cloudformation
-  },
-}
 
-export const set = {
-  env() {
-    return {
-      production: {
-        AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-handler',
-        NODE_OPTIONS: '--require /var/task/tracing.js',
-        OPENTELEMETRY_COLLECTOR_CONFIG_FILE: '/var/task/collector.yaml',
-      },
-    }
+    Object.assign(lambdaProps.Environment.Variables, {
+      AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-handler',
+      NODE_OPTIONS: '--require /var/task/tracing.js',
+      OPENTELEMETRY_COLLECTOR_CONFIG_FILE: '/var/task/collector.yaml',
+    })
+
+    return cloudformation
   },
 }


### PR DESCRIPTION
These settings should not apply to the email-incoming lambda.