### PR TITLE
Endorsement UX

### DIFF
--- a/app/routes/user/endorsements.server.ts
+++ b/app/routes/user/endorsements.server.ts
@@ -119,7 +119,7 @@ export class EndorsementsServer {
         ':requestorSub': this.#sub,
       },
       ConditionExpression:
-        'NOT (endorserSub = :endorserSub and requestorSub = :requestorSub)',
+        'NOT (endorserSub = :endorserSub and requestorSub = :requestorSub and #status <> :status)',
     })
   }
 

--- a/app/routes/user/endorsements.server.ts
+++ b/app/routes/user/endorsements.server.ts
@@ -242,41 +242,21 @@ export class EndorsementsServer {
    * the current user to select from when creating a new endorsement request.
    *
    * @returns a list of users in the circular-submitter group,
-   * not including the current user.
+   * not including the current user or an users from which endorsements have
+   * already been requested.
    */
-  async getSubmitterUsers(): Promise<EndorsementUser[]> {
-    const command = new ListUsersInGroupCommand({
-      GroupName: group,
-      UserPoolId: process.env.COGNITO_USER_POOL_ID,
-    })
+  async getSubmitterUsers() {
+    const [users, requests] = await Promise.all([
+      getUsersInGroup(),
+      this.getEndorsements('requestor'),
+    ])
 
-    let response
-    try {
-      response = await client.send(command)
-    } catch (error) {
-      maybeThrow(error, 'returning fake users')
-      return [
-        {
-          sub: crypto.randomUUID(),
-          email: 'a.einstein@example.com',
-          name: 'Albert Einstein',
-        },
-        {
-          sub: crypto.randomUUID(),
-          email: 'c.sagan@example.com',
-          name: 'Carl Sagan',
-        },
-      ]
-    }
+    const excludedSubs = new Set([
+      this.#sub,
+      ...requests.map(({ endorserSub }) => endorserSub),
+    ])
 
-    return (
-      response.Users?.map((user) => ({
-        sub: extractAttributeRequired(user, 'sub'),
-        email: extractAttributeRequired(user, 'email'),
-        name: extractAttribute(user, 'name'),
-        affiliation: extractAttribute(user, 'custom:affiliation'),
-      })).filter(({ sub }) => sub !== this.#sub) ?? []
-    )
+    return users.filter(({ sub }) => !excludedSubs.has(sub))
   }
 
   /**
@@ -323,4 +303,39 @@ export class EndorsementsServer {
       })
     )
   }
+}
+
+async function getUsersInGroup(): Promise<EndorsementUser[]> {
+  const command = new ListUsersInGroupCommand({
+    GroupName: group,
+    UserPoolId: process.env.COGNITO_USER_POOL_ID,
+  })
+
+  let response
+  try {
+    response = await client.send(command)
+  } catch (error) {
+    maybeThrow(error, 'returning fake users')
+    return [
+      {
+        sub: crypto.randomUUID(),
+        email: 'a.einstein@example.com',
+        name: 'Albert Einstein',
+      },
+      {
+        sub: crypto.randomUUID(),
+        email: 'c.sagan@example.com',
+        name: 'Carl Sagan',
+      },
+    ]
+  }
+
+  return (
+    response.Users?.map((user) => ({
+      sub: extractAttributeRequired(user, 'sub'),
+      email: extractAttributeRequired(user, 'email'),
+      name: extractAttribute(user, 'name'),
+      affiliation: extractAttribute(user, 'custom:affiliation'),
+    })) ?? []
+  )
 }

--- a/app/routes/user/endorsements.tsx
+++ b/app/routes/user/endorsements.tsx
@@ -130,14 +130,14 @@ export default function () {
           )}
         </>
       ) : (
-        <div>
+        <>
           <p className="usa-paragraph">
             In order to submit GCN Circulars, you must be endorsed by an already
             approved user.
           </p>
           <EndorsementRequestForm />
           {requestedEndorsements.length > 0 && (
-            <div>
+            <>
               <h2>Your Pending Requests</h2>
               <SegmentedCards>
                 {requestedEndorsements.map((request) => (
@@ -148,9 +148,9 @@ export default function () {
                   />
                 ))}
               </SegmentedCards>
-            </div>
+            </>
           )}
-        </div>
+        </>
       )}
     </>
   )

--- a/app/routes/user/endorsements.tsx
+++ b/app/routes/user/endorsements.tsx
@@ -147,6 +147,25 @@ export default function () {
         </>
       ) : (
         <>
+          <h2>Request Endorsements</h2>
+          <p className="usa-paragraph">
+            <b>
+              You are not yet a GCN Circulars submitter. Use the form below to
+              request an endorsement from an existing GCN Circulars user.
+            </b>{' '}
+            This should be someone who you know and who knows you: a fellow
+            researcher, an advisor, or an instructor.
+          </p>
+          <p className="usa-paragraph">
+            If you don't find anyone who you recognize, then{' '}
+            <a
+              rel="external"
+              href="https://heasarc.gsfc.nasa.gov/cgi-bin/Feedback?selected=gcnclassic"
+            >
+              contact us for help
+            </a>
+            .
+          </p>
           <EndorsementRequestForm />
           {requestedEndorsements.length > 0 && (
             <>
@@ -418,25 +437,6 @@ export function EndorsementRequestForm() {
 
   return (
     <fetcher.Form method="post" onSubmit={() => setSubmitting(true)}>
-      <h2>Request Endorsement</h2>
-      <p className="usa-paragraph">
-        <b>
-          You are not yet a GCN Circulars submitter. Use the form below to
-          request an endorsement from an existing GCN Circulars user.
-        </b>{' '}
-        This should be someone who you know and who knows you: a fellow
-        researcher, an advisor, or an instructor.
-      </p>
-      <p className="usa-paragraph">
-        If you don't find anyone who you recognize, then{' '}
-        <a
-          rel="external"
-          href="https://heasarc.gsfc.nasa.gov/cgi-bin/Feedback?selected=gcnclassic"
-        >
-          contact us for help
-        </a>
-        .
-      </p>
       <input type="hidden" name="endorserSub" value={endorserSub} />
       <Grid row>
         <Grid col="fill">

--- a/app/routes/user/endorsements.tsx
+++ b/app/routes/user/endorsements.tsx
@@ -125,24 +125,43 @@ export default function () {
       </p>
       {userIsSubmitter ? (
         <>
+          <h2>Approve Endorsements</h2>
           <p className="usa-paragraph">
-            As an approved submitter, you may submit new GCN Circulars. Other
-            users may also request an endorsement from you, which you may
-            approve, deny, or report in the case of spam.
+            <b>You are a GCN Circulars submitter.</b> You can{' '}
+            <Link to="/circulars/new">submit GCN Circulars</Link>, and other
+            users can request peer endorsements from you. You may take any of
+            the following actions for peer endorsement requests:
           </p>
-          {awaitingEndorsements.length > 0 && (
-            <>
-              <h2>Requests awaiting your review</h2>
-              <SegmentedCards>
-                {awaitingEndorsements.map((request) => (
-                  <EndorsementRequestCard
-                    key={request.requestorSub}
-                    role="endorser"
-                    endorsementRequest={request}
-                  />
-                ))}
-              </SegmentedCards>
-            </>
+          <ol className="usa-list">
+            <li>
+              <b>Approve</b> if you know the user and you can vouch that they
+              are in good standing.
+            </li>
+            <li>
+              <b>Reject</b> if you do not know the user or cannot vouch for
+              them.
+            </li>
+            <li>
+              <b>Reject and Report</b> if you believe that the request is spam
+              or is from a bot.
+            </li>
+          </ol>
+          <h3>Requests awaiting your review</h3>
+          {awaitingEndorsements.length > 0 ? (
+            <SegmentedCards>
+              {awaitingEndorsements.map((request) => (
+                <EndorsementRequestCard
+                  key={request.requestorSub}
+                  role="endorser"
+                  endorsementRequest={request}
+                />
+              ))}
+            </SegmentedCards>
+          ) : (
+            <p className="usa-paragraph">
+              You have no peer endorsement requests right now. When you do, they
+              will appear here.
+            </p>
           )}
         </>
       ) : (

--- a/app/routes/user/endorsements.tsx
+++ b/app/routes/user/endorsements.tsx
@@ -7,7 +7,7 @@
  */
 
 import type { DataFunctionArgs } from '@remix-run/node'
-import { useFetcher, useLoaderData } from '@remix-run/react'
+import { Link, useFetcher, useLoaderData } from '@remix-run/react'
 import { Button, ButtonGroup, Grid, Label } from '@trussworks/react-uswds'
 import {
   forwardRef,
@@ -107,6 +107,22 @@ export default function () {
   return (
     <>
       <h1>Peer Endorsements</h1>
+      <p className="usa-intro">
+        Anyone can become a <Link to="/circulars">GCN Circulars</Link> submitter
+        by receiving a <i>peer endorsement</i> from an existing submitter. An
+        endorsement vouches that the user is in good standing with the astronomy
+        community.
+      </p>
+      <p className="usa-paragraph">
+        Peer endorsements (inspired by{' '}
+        <a rel="external" href="https://info.arxiv.org/help/endorsement.html">
+          arXiv
+        </a>
+        ) help us to grow the GCN community sustainably while protecting the
+        research integrity of GCN Circulars. We welcome submitters of diverse
+        backgrounds including professional astronomers, amateurs, educators, and
+        students.
+      </p>
       {userIsSubmitter ? (
         <>
           <p className="usa-paragraph">
@@ -131,14 +147,15 @@ export default function () {
         </>
       ) : (
         <>
-          <p className="usa-paragraph">
-            In order to submit GCN Circulars, you must be endorsed by an already
-            approved user.
-          </p>
           <EndorsementRequestForm />
           {requestedEndorsements.length > 0 && (
             <>
-              <h2>Your Pending Requests</h2>
+              <h3>Your Endorsement Requests</h3>
+              <p className="usa-paragraph">
+                You are waiting on pending endorsements. When any of the users
+                below approves your request, you will become a GCN Circulars
+                submitter.
+              </p>
               <SegmentedCards>
                 {requestedEndorsements.map((request) => (
                   <EndorsementRequestCard
@@ -401,12 +418,24 @@ export function EndorsementRequestForm() {
 
   return (
     <fetcher.Form method="post" onSubmit={() => setSubmitting(true)}>
-      <h2 id="modal-request-heading">Request Endorsement</h2>
+      <h2>Request Endorsement</h2>
       <p className="usa-paragraph">
-        Requesting an endorsement from another user will share your email with
-        that individual. Please keep this in mind when submitting. Enter the
-        email of the individual you want to be endorsed by. They will receive a
-        notification alerting them to this request.
+        <b>
+          You are not yet a GCN Circulars submitter. Use the form below to
+          request an endorsement from an existing GCN Circulars user.
+        </b>{' '}
+        This should be someone who you know and who knows you: a fellow
+        researcher, an advisor, or an instructor.
+      </p>
+      <p className="usa-paragraph">
+        If you don't find anyone who you recognize, then{' '}
+        <a
+          rel="external"
+          href="https://heasarc.gsfc.nasa.gov/cgi-bin/Feedback?selected=gcnclassic"
+        >
+          contact us for help
+        </a>
+        .
       </p>
       <input type="hidden" name="endorserSub" value={endorserSub} />
       <Grid row>


### PR DESCRIPTION
* Make creating endorsement requests idempotent so that double form submissions do not cause an error
* Exclude from potential endorsers users from which endorsements have already been requested
* Add pending UI for endorsement request form
* Rewrite instructions
* New circular form displays modal if user is not authorized

# What requestors see

https://user-images.githubusercontent.com/728407/219109437-ed300127-2e7c-47f8-a81d-31a468399e5d.mov

# What approvers see

![Screenshot 2023-02-15 at 12 32 28](https://user-images.githubusercontent.com/728407/219109348-41b41118-afea-41f6-bfcb-9563c6455d21.png)
