### PR TITLE
Use the `timeout` kwarg to `consume()` in Python example

### DIFF
--- a/app/components/ClientSampleCode.tsx
+++ b/app/components/ClientSampleCode.tsx
@@ -88,7 +88,7 @@ export function ClientSampleCode({
             consumer.subscribe([${topics.map((topic) => `'${topic}'`).join(`,
                                 `)}])
             while True:
-                for message in consumer.consume():
+                for message in consumer.consume(timeout=1):
                     value = message.value()
                     print(value)
 


### PR DESCRIPTION
This addresses https://github.com/nasa-gcn/gcn-kafka-python/issues/13 as indicated by @lpsinger.