### PR TITLE
Exclude aws-sdk from server bundles

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -11,7 +11,7 @@ await build({
   logLevel: 'info',
   outdir: 'build',
   outbase: 'app',
-  external: ['@aws-sdk/*'],
+  external: ['@aws-sdk/*', 'aws-sdk'],
   platform: 'node',
   minify: true,
   target: ['node18'],

--- a/remix.config.mjs
+++ b/remix.config.mjs
@@ -38,4 +38,4 @@ export const publicPath = '/_static/'
 export const server = './server.js'
 export const serverBuildPath = 'build/server/index.js'
 export const serverMinify = true
-export const serverDependenciesToBundle = [/^(?!@aws-sdk\/)/]
+export const serverDependenciesToBundle = [/^(?!@?aws-sdk\/)/]


### PR DESCRIPTION
It's only used by @architect/functions, and only conditionally if it finds that it is running under a NodeJS < 18 Lambda runtime (which we are not).

This reduces the server bundle sizes a little bit and should improve Lambda cold start times.