### PR TITLE
Fix misspelled Architect pragma

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -10,7 +10,7 @@ remix-gcn
 email-incoming
   src build/events/email-incoming
 
-@table-streams
+@tables-streams
 circulars
   src build/table-streams/circulars
 


### PR DESCRIPTION
Because of this misspelling, our table streams Lambda event handler was not being created!