### PR TITLE
Import individual lodash function

### DIFF
--- a/app/lib/email.server.ts
+++ b/app/lib/email.server.ts
@@ -11,7 +11,7 @@ import {
   SESv2ServiceException,
   SendEmailCommand,
 } from '@aws-sdk/client-sesv2'
-import { chunk } from 'lodash'
+import chunk from 'lodash/chunk'
 
 import { getHostname } from './env.server'
 


### PR DESCRIPTION
This results in a smaller bundle size because esbuild can treeshake away the unused bits of lodash.