### PR TITLE
Document hosts and ports required for Kafka clients

### DIFF
--- a/app/routes/docs/faq.md
+++ b/app/routes/docs/faq.md
@@ -19,12 +19,42 @@ See [Client Configuration](docs/client).
 
 ## What ports do I need to open in order to receive or send GCN notices with Kafka?
 
-Clients connecting to GCN only need to be able to make _outbound_ (egress) TCP connections. The client uses the following ports.
+Clients connecting to GCN only need to be able to make _outbound_ (egress) TCP connections. The client connects to the following hosts and ports.
 
-| Protocol | Direction | Port | Purpose |
-| -------- | --------- | ---- | ------- |
-| TCP      | outbound  | 443  | HTTPS   |
-| TCP      | outbound  | 9092 | Kafka   |
+<table className="usa-table">
+  <thead>
+    <tr>
+      <th>Direction</th>
+      <th>Protocol</th>
+      <th>Purpose</th>
+      <th>Port</th>
+      <th>Host</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowSpan="5">outbound</td>
+      <td rowSpan="5">TCP</td>
+      <td>HTTPS</td>
+      <td>443</td>
+      <td>auth.gcn.nasa.gov</td>
+    </tr>
+    <tr>
+      <td rowSpan="4">Kafka</td>
+      <td rowSpan="4">9092</td>
+      <td>kafka.gcn.nasa.gov</td>
+    </tr>
+    <tr>
+      <td>kafka1.gcn.nasa.gov</td>
+    </tr>
+    <tr>
+      <td>kafka2.gcn.nasa.gov</td>
+    </tr>
+    <tr>
+      <td>kafka3.gcn.nasa.gov</td>
+    </tr>
+  </tbody>
+</table>
 
 ## What does the warning `Subscribed topic not available: gcn.classic.text.AGILE_GRB_GROUND: Broker: Unknown topic or partition'` mean?
 


### PR DESCRIPTION
A user asked for both the hosts and the ports that the client needs to talk to.

<img width="730" alt="Screenshot 2023-03-31 at 10 51 45" src="https://user-images.githubusercontent.com/728407/229154718-55a7f903-56ad-452b-bdc2-a4b6f349c8e9.png">
