### PR TITLE
Makes the announcement banner reusable with message and event props

### DIFF
--- a/app/components/AnnounceBanner.tsx
+++ b/app/components/AnnounceBanner.tsx
@@ -16,10 +16,10 @@ type AnnouncedEvents = {
 
 export default function AnnounceBanner({
   message,
-  events,
+  children,
 }: {
   message: string
-  events?: AnnouncedEvents[]
+  children?: React.ReactNode
 }) {
   const [showFullBanner, setShowFullBanner] = useState(true)
 
@@ -55,13 +55,7 @@ export default function AnnounceBanner({
             className="usa-banner__content usa-accordion__content padding-top-2"
             id="announcement-banner-blue"
           >
-            {events && (
-              <div className="grid-row">
-                {events.map((event) => (
-                  <AnnouncementEvent key={event.link} {...event} />
-                ))}
-              </div>
-            )}
+            {children}
             <p>
               If you cannot attend live, then you can get the{' '}
               <Link

--- a/app/components/AnnounceBanner.tsx
+++ b/app/components/AnnounceBanner.tsx
@@ -49,7 +49,7 @@ export default function AnnounceBanner({
             className="usa-banner__content usa-accordion__content padding-top-2"
             id="announcement-banner-blue"
           >
-            {children}
+            <Grid row>{children}</Grid>
             <p>
               If you cannot attend live, then you can get the{' '}
               <Link

--- a/app/components/AnnounceBanner.tsx
+++ b/app/components/AnnounceBanner.tsx
@@ -8,7 +8,19 @@
 import { Button, Link } from '@trussworks/react-uswds'
 import { useState } from 'react'
 
-export default function AnnounceBanner() {
+type announcedEvents = {
+  time: string
+  link: string
+  region: 'Atlantic' | 'Pacific' | 'Asia and Oceania'
+}
+
+export default function AnnounceBanner({
+  message,
+  events,
+}: {
+  message: string
+  events?: announcedEvents[]
+}) {
   const [showFullBanner, setShowFullBanner] = useState(true)
 
   function toggleShowBanner() {
@@ -24,10 +36,7 @@ export default function AnnounceBanner() {
         <header className="usa-banner__header">
           <div className="usa-banner__inner">
             <div className="grid-col-fill tablet:grid-col-auto">
-              <h2 className="usa-banner__header-text">
-                We invite you to join one of our three public Zoom webinars for
-                an overview of the new GCN.
-              </h2>
+              <h2 className="usa-banner__header-text">{message}</h2>
             </div>
             <Button
               type="button"
@@ -46,30 +55,19 @@ export default function AnnounceBanner() {
             className="usa-banner__content usa-accordion__content padding-top-2"
             id="announcement-banner-blue"
           >
-            <div className="grid-row">
-              <div className="mobile-lg:grid-col-4">
-                August 1, 2022 12:00-13:00 UTC
-                <div>(best for Atlantic):</div>
-                <Link rel="external" href="https://bit.ly/3Pt2TH9">
-                  https://bit.ly/3Pt2TH9
-                </Link>
+            {events && (
+              <div className="grid-row">
+                {events.map((event) => (
+                  <div key={event.link} className="mobile-lg:grid-col-4">
+                    {event.time}
+                    <div>(best for {event.region}):</div>
+                    <Link rel="external" href={event.link}>
+                      {event.link}
+                    </Link>
+                  </div>
+                ))}
               </div>
-              <div className="mobile-lg:grid-col-4">
-                August 1, 2022 20:00-21:00 UTC <br /> (best for Pacific):
-                <br />
-                <Link rel="external" href="https://bit.ly/3IT7Qqc">
-                  https://bit.ly/3IT7Qqc
-                </Link>
-              </div>
-              <div className="mobile-lg:grid-col-4">
-                August 2, 2022 04:00-05:00 UTC <br /> (best for Asia and
-                Oceania):
-                <br />
-                <Link rel="external" href="https://bit.ly/3v2pNwV">
-                  https://bit.ly/3v2pNwV
-                </Link>
-              </div>
-            </div>
+            )}
             <p>
               If you cannot attend live, then you can get the{' '}
               <Link

--- a/app/components/AnnounceBanner.tsx
+++ b/app/components/AnnounceBanner.tsx
@@ -8,7 +8,7 @@
 import { Button, Link } from '@trussworks/react-uswds'
 import { useState } from 'react'
 
-type announcedEvents = {
+type AnnouncedEvents = {
   time: string
   link: string
   region: 'Atlantic' | 'Pacific' | 'Asia and Oceania'
@@ -19,7 +19,7 @@ export default function AnnounceBanner({
   events,
 }: {
   message: string
-  events?: announcedEvents[]
+  events?: AnnouncedEvents[]
 }) {
   const [showFullBanner, setShowFullBanner] = useState(true)
 
@@ -58,13 +58,7 @@ export default function AnnounceBanner({
             {events && (
               <div className="grid-row">
                 {events.map((event) => (
-                  <div key={event.link} className="mobile-lg:grid-col-4">
-                    {event.time}
-                    <div>(best for {event.region}):</div>
-                    <Link rel="external" href={event.link}>
-                      {event.link}
-                    </Link>
-                  </div>
+                  <AnnouncementEvent key={event.link} {...event} />
                 ))}
               </div>
             )}
@@ -82,5 +76,17 @@ export default function AnnounceBanner({
         )}
       </div>
     </section>
+  )
+}
+
+export function AnnouncementEvent(event: AnnouncedEvents) {
+  return (
+    <div className="mobile-lg:grid-col-4">
+      {event.time}
+      <div>(best for {event.region}):</div>
+      <Link rel="external" href={event.link}>
+        {event.link}
+      </Link>
+    </div>
   )
 }

--- a/app/components/AnnounceBanner.tsx
+++ b/app/components/AnnounceBanner.tsx
@@ -73,7 +73,7 @@ export default function AnnounceBanner({
   )
 }
 
-export function AnnouncementEvent(event: AnnouncedEvents) {
+export function AnnouncementEvent(props: AnnouncedEvents) {
   return (
     <div className="mobile-lg:grid-col-4">
       {event.time}

--- a/app/components/AnnounceBanner.tsx
+++ b/app/components/AnnounceBanner.tsx
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: NASA-1.3
  */
-import { Button, Link } from '@trussworks/react-uswds'
+import { Button, Grid, Link } from '@trussworks/react-uswds'
 import { useState } from 'react'
 
 export default function AnnounceBanner({
@@ -73,12 +73,12 @@ export function AnnouncementEvent(props: {
   region: 'Atlantic' | 'Pacific' | 'Asia and Oceania'
 }) {
   return (
-    <Grid mobileLg={{col: 4}}>
+    <Grid mobileLg={{ col: 4 }}>
       {props.time}
       <div>(best for {props.region}):</div>
       <Link rel="external" href={props.link}>
         {props.link}
       </Link>
-    </div>
+    </Grid>
   )
 }

--- a/app/components/AnnounceBanner.tsx
+++ b/app/components/AnnounceBanner.tsx
@@ -8,12 +8,6 @@
 import { Button, Link } from '@trussworks/react-uswds'
 import { useState } from 'react'
 
-type AnnouncedEvents = {
-  time: string
-  link: string
-  region: 'Atlantic' | 'Pacific' | 'Asia and Oceania'
-}
-
 export default function AnnounceBanner({
   message,
   children,
@@ -73,13 +67,17 @@ export default function AnnounceBanner({
   )
 }
 
-export function AnnouncementEvent(props: AnnouncedEvents) {
+export function AnnouncementEvent(props: {
+  time: string
+  link: string
+  region: 'Atlantic' | 'Pacific' | 'Asia and Oceania'
+}) {
   return (
     <div className="mobile-lg:grid-col-4">
-      {event.time}
-      <div>(best for {event.region}):</div>
-      <Link rel="external" href={event.link}>
-        {event.link}
+      {props.time}
+      <div>(best for {props.region}):</div>
+      <Link rel="external" href={props.link}>
+        {props.link}
       </Link>
     </div>
   )

--- a/app/components/AnnounceBanner.tsx
+++ b/app/components/AnnounceBanner.tsx
@@ -73,7 +73,7 @@ export function AnnouncementEvent(props: {
   region: 'Atlantic' | 'Pacific' | 'Asia and Oceania'
 }) {
   return (
-    <div className="mobile-lg:grid-col-4">
+    <Grid mobileLg={{col: 4}}>
       {props.time}
       <div>(best for {props.region}):</div>
       <Link rel="external" href={props.link}>


### PR DESCRIPTION
How it would look:

![image](https://user-images.githubusercontent.com/11023698/229616858-74a9b043-3e12-4246-b253-429eee69a2eb.png)

How to use:

![image](https://user-images.githubusercontent.com/11023698/229616780-07ce1a1f-ad7b-492e-b8b1-236c52289a6a.png)

