### PR TITLE
Remove News from primary nav

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -47,9 +47,6 @@ export function Header({ email }: { email?: string }) {
           <PrimaryNav
             mobileExpanded={expanded}
             items={[
-              <NavLink className="usa-nav__link" to="/news" key="/news">
-                News
-              </NavLink>,
               <NavLink className="usa-nav__link" to="/missions" key="/missions">
                 Missions
               </NavLink>,


### PR DESCRIPTION
It looks really bad when the user is logged in:

<img width="1174" alt="Screenshot 2023-04-04 at 10 49 09" src="https://user-images.githubusercontent.com/728407/229831310-9cf52886-fd87-4c05-87ec-0ca1fffc5ab1.png">
