### PR TITLE
Add feature flags docs to contributing guide

### DIFF
--- a/app/components/SideNavSub.tsx
+++ b/app/components/SideNavSub.tsx
@@ -1,0 +1,19 @@
+/*!
+ * Copyright © 2022 United States Government as represented by the Administrator
+ * of the National Aeronautics and Space Administration. No copyright is claimed
+ * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ *
+ * SPDX-License-Identifier: NASA-1.3
+ */
+import { SideNav } from '@trussworks/react-uswds'
+import type { To } from 'react-router'
+
+import { useActiveLink } from '~/lib/remix'
+
+export function SideNavSub({
+  base,
+  ...props
+}: Omit<Parameters<typeof SideNav>[0], 'isSubNav'> & { base: To }) {
+  const isActive = useActiveLink({ to: base })
+  return isActive ? <SideNav {...props} isSubnav /> : <></>
+}

--- a/app/lib/env.server.ts
+++ b/app/lib/env.server.ts
@@ -41,7 +41,9 @@ export function getHostname() {
 }
 
 export function getFeatures() {
-  return process.env.GCN_FEATURES?.split(',').filter(Boolean) ?? []
+  return (
+    process.env.GCN_FEATURES?.toUpperCase().split(',').filter(Boolean) ?? []
+  )
 }
 
 /**
@@ -51,5 +53,6 @@ export function getFeatures() {
  * is a comma-separated list of enabled features.
  */
 export function feature(feature: string) {
-  return getFeatures().includes(feature)
+  const featureUppercase = feature.toUpperCase()
+  return getFeatures().includes(featureUppercase)
 }

--- a/app/lib/remix.ts
+++ b/app/lib/remix.ts
@@ -6,11 +6,50 @@
  * SPDX-License-Identifier: NASA-1.3
  */
 import type { AppData, SerializeFrom } from '@remix-run/node'
-import { useRouteLoaderData as useRouteLoaderDataRR } from 'react-router'
+import type { NavLinkProps } from '@remix-run/react'
+import { useContext } from 'react'
+import {
+  UNSAFE_NavigationContext as NavigationContext,
+  useLocation,
+  useResolvedPath,
+  useRouteLoaderData as useRouteLoaderDataRR,
+} from 'react-router'
 
 // FIXME: Remove once https://github.com/remix-run/remix/pull/5157 is merged
 export function useRouteLoaderData<T = AppData>(
   routeId: string
 ): SerializeFrom<T> {
   return useRouteLoaderDataRR(routeId) as SerializeFrom<T>
+}
+
+/** Hook version of active link test from react-router's NavLink.
+ * Adapted from https://github.com/remix-run/react-router/blob/main/packages/react-router-dom/index.tsx.
+ */
+export function useActiveLink({
+  to,
+  caseSensitive = false,
+  end = false,
+  relative,
+}: Pick<NavLinkProps, 'to' | 'caseSensitive' | 'end' | 'relative'>) {
+  let path = useResolvedPath(to, { relative })
+  let location = useLocation()
+  let { navigator } = useContext(NavigationContext)
+
+  let toPathname = navigator.encodeLocation
+    ? navigator.encodeLocation(path).pathname
+    : path.pathname
+  let locationPathname = location.pathname
+
+  if (!caseSensitive) {
+    locationPathname = locationPathname.toLowerCase()
+    toPathname = toPathname.toLowerCase()
+  }
+
+  let isActive =
+    locationPathname === toPathname ||
+    (!end &&
+      locationPathname.startsWith(toPathname) &&
+      locationPathname.charAt(toPathname.length) === '/')
+
+  return isActive
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -38,6 +38,7 @@ import {
   useNavigation,
 } from '@remix-run/react'
 import { ButtonGroup, GovBanner, GridContainer } from '@trussworks/react-uswds'
+import type { ReactNode } from 'react'
 import TopBarProgress from 'react-topbar-progress-indicator'
 import { useSpinDelay } from 'spin-delay'
 
@@ -157,7 +158,18 @@ export function useRecaptchaSiteKey() {
  * is a comma-separated list of enabled features.
  */
 export function useFeature(feature: string) {
-  return useLoaderDataRoot().features.includes(feature)
+  const featureUppercase = feature.toUpperCase()
+  return useLoaderDataRoot().features.includes(featureUppercase)
+}
+
+export function WithFeature({
+  children,
+  ...features
+}: {
+  children: ReactNode
+} & Record<string, boolean>) {
+  console.log('***', Object.keys(features)[0])
+  return <>{useFeature(Object.keys(features)[0]) && children}</>
 }
 
 export function useUrl() {

--- a/app/routes/docs.tsx
+++ b/app/routes/docs.tsx
@@ -8,6 +8,8 @@
 import { NavLink, Outlet } from '@remix-run/react'
 import { SideNav } from '@trussworks/react-uswds'
 
+import { SideNavSub } from '~/components/SideNavSub'
+
 export const handle = {
   breadcrumb: 'Documentation',
 }
@@ -30,6 +32,19 @@ export default function () {
             <NavLink key="contributing" to="contributing">
               Contributing
             </NavLink>,
+            <SideNavSub
+              base="contributing"
+              key="contributing-sub"
+              isSubnav
+              items={[
+                <NavLink key="index" to="contributing" end>
+                  Getting Started
+                </NavLink>,
+                <NavLink key="feature-flags" to="contributing/feature-flags">
+                  Feature Flags
+                </NavLink>,
+              ]}
+            />,
             <NavLink key="producers" to="producers">
               New Notice Producers
             </NavLink>,

--- a/app/routes/docs/contributing.tsx
+++ b/app/routes/docs/contributing.tsx
@@ -1,0 +1,12 @@
+/*!
+ * Copyright © 2022 United States Government as represented by the Administrator
+ * of the National Aeronautics and Space Administration. No copyright is claimed
+ * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ *
+ * SPDX-License-Identifier: NASA-1.3
+ */
+export { Outlet as default } from 'react-router'
+
+export const handle = {
+  breadcrumb: 'Contributing',
+}

--- a/app/routes/docs/contributing/feature-flags.mdx
+++ b/app/routes/docs/contributing/feature-flags.mdx
@@ -1,0 +1,87 @@
+---
+handle:
+  breadcrumb: Feature Flags
+---
+
+import { Highlight } from '~/components/Highlight.tsx'
+
+# Feature Flags
+
+The GCN project uses [feature flags](https://www.atlassian.com/continuous-delivery/principles/feature-flags) to turn on parts of the web site that are under development. Feature flags allow us to merge new capabilities into the Git main branch without exposing them immediately to end users.
+
+## Configuration
+
+On the production web site (https://gcn.nasa.gov), all feature flags are disabled by default.
+
+Turn feature flags on in your local development environment by adding them to the `GCN_FEATURES` environment variable in your `.env` file (see [quick start instructions for local development](/contributing#quick-start)). The format of this environment variable is a comma-separated list.
+
+For example, if you set `GCN_FEATURES=ANTIGRAVITY,TIME_TRAVEL,PYROKINESIS`, then the features `ANTIGRAVITY`, `TIME_TRAVEL`, and `PYROKINESIS` are enabled.
+
+## Usage in Server Code
+
+To customize the server-side behavior of the code, use the `feature()` function. For example, to make a page return a 404 Not Found error if a feature is off, add the following code:
+
+```text
+import { feature } from '~/lib/env.server'
+
+export function loader() {
+  if (!feature('PYROKINESIS')) throw new Response(null, { status: 404 })
+}
+
+# Pyrokinesis
+
+Fwoosh!
+```
+
+## Usage in Client Side Code
+
+In client-side code (Markdown documents and React components), use the `useFeature()` [React hook](https://react.dev/learn/reusing-logic-with-custom-hooks) to add content that is displayed conditionally if a feature flag is enabled.
+
+```text
+import { useFeature } from '~/root'
+
+# Superpowers
+
+## X-ray vision
+
+GCN can see through walls!
+
+## Antigravity
+
+It's a bird! It's a plane! It's GCN! {
+  // Display text if the feauture is ON
+  useFeature('ANTIGRAVITY') && 'Now with less gravity.'
+}
+
+## Time Travel
+
+GCN can travel through time. {
+  // Dispaly text if the feature is OFF
+  useFeature('TIME_TRAVEL') || 'Time travel is coming soon.'
+}
+
+## Pyrokinesis
+
+GCN can light things on fire with its mind! {
+  // Display different text whether the feature is ON or OFF
+  useFeature('PYROKINESIS') ? 'Fwoosh!' : 'Pyrokinesis is coming soon!'
+}
+```
+
+**_Important_**: The `useFeature()` method above does not render Markdown that is inside the conditionally displayed text. If you need conditionally rendered Markdown, then use the `<WithFeature>` React component.
+
+```text
+import { WithFeature } from '~/root'
+
+# Superpowers
+
+## X-ray vision
+
+GCN can see through walls!
+
+<WithFeature pyrokinesis>
+  ## Pyrokinesis
+
+  Fwoosh!
+</WithFeature>
+```

--- a/app/routes/docs/contributing/index.mdx
+++ b/app/routes/docs/contributing/index.mdx
@@ -1,6 +1,6 @@
 ---
 handle:
-  breadcrumb: Contributing
+  breadcrumb: Getting Started
 ---
 
 import {
@@ -101,6 +101,12 @@ Here are instructions for getting the GCN site set up and running on your own co
     # addresses, and so on. Leave this unset for local development so that it
     # defaults to http://localhost:3333.
     # ORIGIN=https://gcn.nasa.gov
+
+    # (Optional) Feature flags turn on parts of the web site that are under
+    # development. On the production web site (https://gcn.nasa.gov), all
+    # feature flags are disabled by default. Turn feature flags for local
+    # development by adding them to this comma-separated list.
+    # GCN_FEATURES=ANTIGRAVITY,TIME_TRAVEL,PYROKINESIS
     ```
 
   </ProcessListItem>


### PR DESCRIPTION
This includes a few incidental changes:

- Add a `<SideNavSub>` component for a second-level side nav that is displayed only if the current page belongs to the subsection in question.
- Add a `useActiveLink()` React hook which makes the active URL detection behavior of React Router's `<NavLink>` available to other components.
- Make feature flags functions case insensitive.
- Add a `<WithFeature>` component for Markdown-friendly conditional rendering.