### PR TITLE
Fix 400 error on delete and send test forms

### DIFF
--- a/app/routes/user/email/index.tsx
+++ b/app/routes/user/email/index.tsx
@@ -43,11 +43,13 @@ export async function action({ request }: DataFunctionArgs) {
       if (uuid) {
         await deleteEmailNotification(uuid, user.sub)
       }
+      break
     case 'sendTest':
       const recipient = getFormDataString(data, 'recipient')
       if (recipient) {
         await sendTestEmail(recipient)
       }
+      break
     case 'subscribe':
       if (!feature('circulars')) throw new Response(null, { status: 400 })
       await createCircularEmailNotification(user.sub, user.email)


### PR DESCRIPTION
There were missing `break` statements in a `switch` block.