### PR TITLE
Remove duplicate subject keyword

### DIFF
--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -103,7 +103,6 @@ export const validSubjectKeywords = [
   'Chandra',
   'Fermi',
   'FXT',
-  'grb',
   'GRB',
   'GW',
   'HAWC',


### PR DESCRIPTION
The comparison is case insensitive, so we need not include both `grb` and `GRB`.