### PR TITLE
Redirect to schema, don't bundle it

### DIFF
--- a/app/routes/schema/$.ts
+++ b/app/routes/schema/$.ts
@@ -5,36 +5,12 @@
  *
  * SPDX-License-Identifier: NASA-1.3
  */
-import '@nasa-gcn/schema'
-import type { DataFunctionArgs } from '@remix-run/node'
-import { readFile } from 'node:fs/promises'
-import { dirname, extname, join } from 'node:path'
-
-function isErrnoException(e: unknown): e is NodeJS.ErrnoException {
-  return e instanceof Error && 'code' in e && 'errno' in e
-}
+import { type DataFunctionArgs, redirect } from '@remix-run/node'
 
 /* Make all JSON files at https://github.com/nasa-gcn/gcn-schema available from
  * https://gcn.nasa.gov/schema */
-export async function loader({ params: { '*': subPath } }: DataFunctionArgs) {
-  if (!subPath) throw new Error('path must be defined')
-
-  if (extname(subPath) !== '.json')
-    throw new Response('not found', { status: 404 })
-
-  const path = join(dirname(require.resolve('@nasa-gcn/schema')), subPath)
-
-  let body
-  try {
-    body = await readFile(path, {
-      encoding: 'utf-8',
-    })
-  } catch (e) {
-    if (isErrnoException(e) && e.code === 'ENOENT') {
-      throw new Response('Not found', { status: 404 })
-    }
-    throw e
-  }
-
-  return new Response(body, { headers: { 'Content-Type': 'application/json' } })
+export async function loader({ params: { '*': path } }: DataFunctionArgs) {
+  return redirect(
+    `https://raw.githubusercontent.com/nasa-gcn/gcn-schema/main/${path ?? ''}`
+  )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@balavishnuvj/remix-seo": "^1.0.2",
         "@nasa-gcn/architect-functions-search": "^0.2.0",
         "@nasa-gcn/dynamodb-autoincrement": "^0.0.6",
-        "@nasa-gcn/schema": "github:nasa-gcn/gcn-schema",
         "@octokit/rest": "^19.0.7",
         "@opensearch-project/opensearch": "^2.2.0",
         "@remix-run/architect": "^1.15.0",
@@ -14131,9 +14130,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/@nasa-gcn/schema": {
-      "resolved": "git+ssh://git@github.com/nasa-gcn/gcn-schema.git#5cdb482e8baa689c9a0c487ef9c4a85589d90b85"
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -46900,10 +46896,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@nasa-gcn/dynamodb-autoincrement/-/dynamodb-autoincrement-0.0.6.tgz",
       "integrity": "sha512-+ecRUXHcGEqHGxhe5I1ApEAN745uauKpRfQliRMM6RK/NZNm0jDHfh9y63dRCuzunMWfVga4z3MB9gVkeUkLVw=="
-    },
-    "@nasa-gcn/schema": {
-      "version": "git+ssh://git@github.com/nasa-gcn/gcn-schema.git#5cdb482e8baa689c9a0c487ef9c4a85589d90b85",
-      "from": "@nasa-gcn/schema@github:nasa-gcn/gcn-schema"
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@balavishnuvj/remix-seo": "^1.0.2",
     "@nasa-gcn/architect-functions-search": "^0.2.0",
     "@nasa-gcn/dynamodb-autoincrement": "^0.0.6",
-    "@nasa-gcn/schema": "github:nasa-gcn/gcn-schema",
     "@octokit/rest": "^19.0.7",
     "@opensearch-project/opensearch": "^2.2.0",
     "@remix-run/architect": "^1.15.0",


### PR DESCRIPTION
This way, it is always up to date.

Fixes nasa-gcn/gcn-schema#49.