### PR TITLE
Enable client-side routing for all Markdown links

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -38,8 +38,9 @@ import {
   useRouteError,
 } from '@remix-run/react'
 import { ButtonGroup, GovBanner, GridContainer } from '@trussworks/react-uswds'
-import type { ReactNode } from 'react'
+import { type ReactNode, useRef } from 'react'
 import TopBarProgress from 'react-topbar-progress-indicator'
+import { useDelegatedAnchors } from 'remix-utils'
 import { useSpinDelay } from 'spin-delay'
 
 import { DevBanner } from './components/DevBanner'
@@ -207,6 +208,11 @@ function Progress() {
 }
 
 function Document({ children }: { children?: React.ReactNode }) {
+  // Use client-side routing for anchors in Markdown content.
+  // See https://github.com/remix-run/remix/discussions/6048.
+  const ref = useRef<HTMLElement | null>(null)
+  useDelegatedAnchors(ref)
+
   return (
     <html lang="en-US">
       <head>
@@ -223,7 +229,9 @@ function Document({ children }: { children?: React.ReactNode }) {
         <DevBanner />
         <Header />
         <NewsBanner message="GCN Circulars are now part of the new GCN!" />
-        <main id="main-content">{children}</main>
+        <main id="main-content" ref={ref}>
+          {children}
+        </main>
         <Footer />
         <ScrollRestoration />
         <Scripts />

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react-router": "^6.10.0",
         "react-tag-autocomplete": "^7.0.0-rc.1",
         "react-topbar-progress-indicator": "^4.1.1",
+        "remix-utils": "github:lpsinger/remix-utils#route-data-moved-npm-prepare",
         "spin-delay": "^1.1.0",
         "ts-dedent": "^2.2.0"
       },
@@ -23776,6 +23777,14 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/intl-parse-accept-language": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/intl-parse-accept-language/-/intl-parse-accept-language-1.0.0.tgz",
+      "integrity": "sha512-YFMSV91JNBOSjw1cOfw2tup6hDP7mkz+2AUV7W1L1AM6ntgI75qC1ZeFpjPGMrWp+upmBRTX2fJWQ8c7jsUWpA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -23790,6 +23799,14 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
       "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
       "dev": true
+    },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -24199,6 +24216,17 @@
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "dependencies": {
+        "ip-regex": "^4.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -31912,6 +31940,39 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remix-utils": {
+      "version": "6.3.0",
+      "resolved": "git+ssh://git@github.com/lpsinger/remix-utils.git#bd504e66f6b11e3574681e39823c5a40467de5c6",
+      "license": "MIT",
+      "dependencies": {
+        "intl-parse-accept-language": "^1.0.0",
+        "is-ip": "^3.1.0",
+        "schema-dts": "^1.1.0",
+        "type-fest": "^2.5.2",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@remix-run/react": "^1.10.0",
+        "@remix-run/router": "^1.0.0",
+        "@remix-run/server-runtime": "^1.10.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "zod": "^3.19.1"
+      }
+    },
+    "node_modules/remix-utils/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/remove-bom-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
@@ -32491,6 +32552,14 @@
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/schema-dts": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-1.1.2.tgz",
+      "integrity": "sha512-MpNwH0dZJHinVxk9bT8XUdjKTxMYrA5bLtrrGmFA6PTLwlOKnhi67XoRd6/ty+Djt6ZC0slR57qFhZDNMI6DhQ==",
+      "peerDependencies": {
+        "typescript": ">=4.1.0"
       }
     },
     "node_modules/secure-json-parse": {
@@ -34339,7 +34408,6 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -36196,6 +36264,15 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {
@@ -54706,6 +54783,11 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
+    "intl-parse-accept-language": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/intl-parse-accept-language/-/intl-parse-accept-language-1.0.0.tgz",
+      "integrity": "sha512-YFMSV91JNBOSjw1cOfw2tup6hDP7mkz+2AUV7W1L1AM6ntgI75qC1ZeFpjPGMrWp+upmBRTX2fJWQ8c7jsUWpA=="
+    },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -54717,6 +54799,11 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
       "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
       "dev": true
+    },
+    "ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -54990,6 +55077,14 @@
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true
+    },
+    "is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "requires": {
+        "ip-regex": "^4.0.0"
+      }
     },
     "is-lambda": {
       "version": "1.0.1",
@@ -60723,6 +60818,24 @@
         "unified": "^10.0.0"
       }
     },
+    "remix-utils": {
+      "version": "git+ssh://git@github.com/lpsinger/remix-utils.git#bd504e66f6b11e3574681e39823c5a40467de5c6",
+      "from": "remix-utils@github:lpsinger/remix-utils#route-data-moved-npm-prepare",
+      "requires": {
+        "intl-parse-accept-language": "^1.0.0",
+        "is-ip": "^3.1.0",
+        "schema-dts": "^1.1.0",
+        "type-fest": "^2.5.2",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
+      }
+    },
     "remove-bom-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
@@ -61156,6 +61269,12 @@
       "requires": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "schema-dts": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-1.1.2.tgz",
+      "integrity": "sha512-MpNwH0dZJHinVxk9bT8XUdjKTxMYrA5bLtrrGmFA6PTLwlOKnhi67XoRd6/ty+Djt6ZC0slR57qFhZDNMI6DhQ==",
+      "requires": {}
     },
     "secure-json-parse": {
       "version": "2.7.0",
@@ -62637,8 +62756,7 @@
     "typescript": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
     },
     "uc.micro": {
       "version": "1.0.6",
@@ -63952,6 +64070,12 @@
         "insync": "2.1.1",
         "yazl": "2.5.1"
       }
+    },
+    "zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "peer": true
     },
     "zwitch": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-router": "^6.10.0",
     "react-tag-autocomplete": "^7.0.0-rc.1",
     "react-topbar-progress-indicator": "^4.1.1",
+    "remix-utils": "github:lpsinger/remix-utils#route-data-moved-npm-prepare",
     "spin-delay": "^1.1.0",
     "ts-dedent": "^2.2.0"
   },


### PR DESCRIPTION
This results in much faster navigation when following links that are defined in .md or .mdx documents using `[markdown](syntax)`.

See https://github.com/remix-run/remix/discussions/6048