### PR TITLE
Fix subtle doubled line in docs side nav

### DIFF
--- a/app/routes/docs.tsx
+++ b/app/routes/docs.tsx
@@ -28,22 +28,24 @@ export default function () {
             <NavLink key="styleguide" to="styleguide">
               Circulars Style Guide
             </NavLink>,
-            <NavLink key="contributing" to="contributing">
-              Contributing
-            </NavLink>,
-            <SideNavSub
-              base="contributing"
-              key="contributing-sub"
-              isSubnav
-              items={[
-                <NavLink key="index" to="contributing" end>
-                  Getting Started
-                </NavLink>,
-                <NavLink key="feature-flags" to="contributing/feature-flags">
-                  Feature Flags
-                </NavLink>,
-              ]}
-            />,
+            <>
+              <NavLink key="contributing" to="contributing">
+                Contributing
+              </NavLink>
+              <SideNavSub
+                base="contributing"
+                key="contributing-sub"
+                isSubnav
+                items={[
+                  <NavLink key="index" to="contributing" end>
+                    Getting Started
+                  </NavLink>,
+                  <NavLink key="feature-flags" to="contributing/feature-flags">
+                    Feature Flags
+                  </NavLink>,
+                ]}
+              />
+            </>,
             <NavLink key="producers" to="producers">
               New Notice Producers
             </NavLink>,


### PR DESCRIPTION
# Before

![Screenshot 2023-04-13 at 13 30 55](https://user-images.githubusercontent.com/728407/231839045-ade8d23d-d4b9-4ecd-af26-3493c9222d48.png)

# After

![Screenshot 2023-04-13 at 13 30 26](https://user-images.githubusercontent.com/728407/231839103-4df2130c-e6c2-434f-915b-07a1f220e636.png)
