### PR TITLE
Support arbitrary " via " strings in emails from mailnull@capella2.gsfc.nasa.gov

### DIFF
--- a/app/events/email-incoming/__tests__/parse.ts
+++ b/app/events/email-incoming/__tests__/parse.ts
@@ -42,6 +42,16 @@ describe('getFromAddress', () => {
     ).toThrow('From address is missing')
   })
 
+  test("raises if the from address name does not contain ' via '", () => {
+    expect(() =>
+      getFromAddress(
+        parseFrom(
+          '"Example <example@example.com>" <mailnull@capella2.gsfc.nasa.gov>'
+        )
+      )
+    ).toThrow("Expected From name to contain ' via '")
+  })
+
   test('returns the address verbatim for a normal email address', () => {
     expect(getFromAddress(parseFrom('example@example.com'))).toBe(
       'example@example.com'
@@ -53,6 +63,16 @@ describe('getFromAddress', () => {
       getFromAddress(
         parseFrom(
           '"Example <example@example.com> via gcncirc" <mailnull@capella2.gsfc.nasa.gov>'
+        )
+      )
+    ).toBe('example@example.com')
+  })
+
+  test('returns the original address for a rewritten address with an alternative "via" name', () => {
+    expect(
+      getFromAddress(
+        parseFrom(
+          '"Example <example@example.com> via my mind" <mailnull@capella2.gsfc.nasa.gov>'
         )
       )
     ).toBe('example@example.com')

--- a/app/events/email-incoming/parse.ts
+++ b/app/events/email-incoming/parse.ts
@@ -10,7 +10,7 @@ import { simpleParser } from 'mailparser'
 import addressparser from 'nodemailer/lib/addressparser'
 
 const legacyAddress = 'mailnull@capella2.gsfc.nasa.gov'
-const legacyFromNameSuffix = ' via gcncirc'
+const legacyFromNameSplitter = ' via '
 
 /**
  * Parse rewritten From addresses from capella2.
@@ -25,11 +25,13 @@ const legacyFromNameSuffix = ' via gcncirc'
  */
 export function getFromAddress(fromAddressObject?: AddressObject) {
   let from = fromAddressObject?.value[0]
-  if (
-    from?.address === legacyAddress &&
-    from.name.endsWith(legacyFromNameSuffix)
-  ) {
-    from = addressparser(from.name.slice(0, -legacyFromNameSuffix.length), {
+  if (from?.address === legacyAddress) {
+    const i = from.name.lastIndexOf(legacyFromNameSplitter)
+    if (i === -1)
+      throw new Error(
+        `Expected From name to contain '${legacyFromNameSplitter}'`
+      )
+    from = addressparser(from.name.slice(0, i), {
       flatten: true,
     })[0]
   }


### PR DESCRIPTION
Sometimes the string is "via gcncirc" and sometimes "via NASA mail list". Support arbitrary strings.