### PR TITLE
Display just-submitted Circular in index

### DIFF
--- a/app/events/email-incoming/index.ts
+++ b/app/events/email-incoming/index.ts
@@ -44,7 +44,7 @@ interface EmailProps {
   to: string[]
   body: string
   parsedSubmissionSubject: string
-  newCircularId?: number
+  circularId?: number
 }
 
 const fromName = 'GCN Circulars'
@@ -117,16 +117,16 @@ module.exports.handler = createTriggerHandler(
 
     // Removes sub as a property if it is undefined from the legacy users
     if (!circular.sub) delete circular.sub
-    const newCircularId = await putRaw(circular)
+    const { circularId } = await putRaw(circular)
 
     // Send a success email
     await sendSuccessEmail({
       userEmail,
       to,
-      subjectMessage: `${newCircularId}`,
+      subjectMessage: `${circularId}`,
       body: '',
       parsedSubmissionSubject: parsed.subject,
-      newCircularId,
+      circularId,
     })
   }
 )
@@ -258,7 +258,7 @@ async function sendSuccessEmail(props: EmailProps) {
       successMessage(
         props.userEmail,
         props.parsedSubmissionSubject,
-        `The email message you submitted to the GCN Circular service has been received and is being distributed to the GCN Circulars subscribers, and posted to the GCN Circulars archive (${origin}/circulars/${props.newCircularId}). If you have selected to receive Circulars, then you will receive your copy shortly.`
+        `The email message you submitted to the GCN Circular service has been received and is being distributed to the GCN Circulars subscribers, and posted to the GCN Circulars archive (${origin}/circulars/${props.circularId}). If you have selected to receive Circulars, then you will receive your copy shortly.`
       ) + sharedEmailBody,
   })
 }

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -136,11 +136,13 @@ export async function remove(circularId: number, request: Request) {
 /**
  * Adds a new entry into the GCN Circulars table WITHOUT authentication
  */
-export async function putRaw<T>(item: T) {
+export async function putRaw(
+  item: Omit<Circular, 'createdOn' | 'circularId'>
+): Promise<Circular> {
   const autoincrement = await getDynamoDBAutoIncrement()
   const createdOn = Date.now()
   const circularId = await autoincrement.put({ createdOn, ...item })
-  return circularId
+  return { ...item, createdOn, circularId }
 }
 
 /**
@@ -163,7 +165,7 @@ export async function put(subject: string, body: string, request: Request) {
     throw new Response('subject is invalid', { status: 400 })
   if (!bodyIsValid(body)) throw new Response('body is invalid', { status: 400 })
 
-  await putRaw({
+  return await putRaw({
     subject,
     body,
     sub: user.sub,

--- a/app/routes/circulars/index.tsx
+++ b/app/routes/circulars/index.tsx
@@ -9,6 +9,7 @@ import type { DataFunctionArgs } from '@remix-run/node'
 import {
   Form,
   Link,
+  useActionData,
   useLoaderData,
   useSearchParams,
   useSubmit,
@@ -45,8 +46,7 @@ export async function action({ request }: DataFunctionArgs) {
   const subject = getFormDataString(data, 'subject')
   if (!body || !subject)
     throw new Response('Body and subject are required', { status: 400 })
-  await put(subject, body, request)
-  return null
+  return await put(subject, body, request)
 }
 
 function getPageLink(page: number, query?: string) {
@@ -140,7 +140,11 @@ function Pagination({
 }
 
 export default function () {
+  const newItem = useActionData<typeof action>()
   const { items, page, totalPages, totalItems } = useLoaderData<typeof loader>()
+
+  // Concatenate items from the action and loader functions
+  const allItems = [...(newItem ? [newItem] : []), ...(items || [])]
 
   const [searchParams] = useSearchParams()
   const query = searchParams.get('query') ?? undefined
@@ -208,7 +212,7 @@ export default function () {
             </h3>
           )}
           <ol>
-            {items.map(({ circularId, subject }) => (
+            {allItems.map(({ circularId, subject }) => (
               <li key={circularId} value={circularId}>
                 <Link to={`/circulars/${circularId}`}>{subject}</Link>
               </li>


### PR DESCRIPTION
Add optimistic UI to the Circular index to include the just-submitted Circular in the list.

The list of Circulars comes from OpenSearch, which is updated asynchronously in the table streams Lambda. If a new Circular has been submitted, add it to the list to provide visible feedback that the form was processed.