### PR TITLE
Remove 'This feature has been implemented now' from FAQ

### DIFF
--- a/app/routes/docs/faq.md
+++ b/app/routes/docs/faq.md
@@ -62,7 +62,7 @@ This warning means that there have not been any recent alerts on that topic.
 
 ## How do I receive GCN Notices via email from GCN Classic over Kafka?
 
-This feature has been implemented now. To get started, [sign in or sign up](https://gcn.nasa.gov/login) and then select 'Email Notifications' from account dropdown menu. See also [GCN Circular 32517](https://gcn.gsfc.nasa.gov/gcn3/32517.gcn3).
+To get started, [sign in or sign up](https://gcn.nasa.gov/login) and then select 'Email Notifications' from account dropdown menu. See also [GCN Circular 32517](https://gcn.gsfc.nasa.gov/gcn3/32517.gcn3).
 
 ## Why do GCN Ciculars that I submit by email appear to be double spaced?
 


### PR DESCRIPTION
It seems redundant.