### PR TITLE
Add function to get basic auth headers

### DIFF
--- a/app/lib/__tests__/headers.server.ts
+++ b/app/lib/__tests__/headers.server.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright © 2022 United States Government as represented by the Administrator
+ * of the National Aeronautics and Space Administration. No copyright is claimed
+ * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ *
+ * SPDX-License-Identifier: NASA-1.3
+ */
+import { getBasicAuthHeaders } from '../headers.server'
+
+describe('getBasicAuthHeaders', () => {
+  test('forbids colons in the username', () => {
+    expect(() => getBasicAuthHeaders('foo:bar', 'bat')).toThrow(
+      'Usernames for basic auth must not contain colons'
+    )
+  })
+  test('returns correct value for a test username and password', () => {
+    expect(getBasicAuthHeaders('foobar', 'bat')).toStrictEqual({
+      Authorization: 'Basic Zm9vYmFyOmJhdA==',
+    })
+  })
+})

--- a/app/lib/headers.server.ts
+++ b/app/lib/headers.server.ts
@@ -26,3 +26,15 @@ export function getCanonicalUrlHeaders(url: string | URL) {
     Link: `<${url}>; rel="canonical"`,
   }
 }
+
+/**
+ * Get HTTP Basic auth request headers for a username and password.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc7617
+ */
+export function getBasicAuthHeaders(username: string, password: string) {
+  if (username.includes(':'))
+    throw new Error('Usernames for basic auth must not contain colons')
+  const userpass = Buffer.from(`${username}:${password}`).toString('base64')
+  return { Authorization: `Basic ${userpass}` }
+}


### PR DESCRIPTION
We will need this for interacting with the ZenDesk and DataCite APIs.