### PR TITLE
Allow sending emails from a configuration set

### DIFF
--- a/src/plugins/sendEmailPermissions.mjs
+++ b/src/plugins/sendEmailPermissions.mjs
@@ -16,9 +16,14 @@ export const deploy = {
           {
             Effect: 'Allow',
             Action: ['ses:SendEmail'],
-            Resource: {
-              'Fn::Sub': `arn:aws:ses:\${AWS::Region}:\${AWS::AccountId}:identity/*`,
-            },
+            Resource: [
+              {
+                'Fn::Sub': `arn:aws:ses:\${AWS::Region}:\${AWS::AccountId}:identity/*`,
+              },
+              {
+                'Fn::Sub': `arn:aws:ses:\${AWS::Region}:\${AWS::AccountId}:configuration-set/*`,
+              },
+            ],
           },
         ],
       },


### PR DESCRIPTION
You have to create a configuration set in Amazon SES in order to log bounces or set up a dedicated sending IP address pool.