### PR TITLE
Add year headings to news page

### DIFF
--- a/app/routes/news.mdx
+++ b/app/routes/news.mdx
@@ -12,10 +12,11 @@ import {
   Link,
 } from '@trussworks/react-uswds'
 
-# GCN News
+# GCN News and Events
 
-<h2 className="">News and Events</h2>
 <Collection>
+
+## 2023
 
   <CollectionItem
     variantComponent={
@@ -71,6 +72,9 @@ import {
     </CollectionDescription>
 
   </CollectionItem>
+
+## 2022
+
   <CollectionItem
     variantComponent={
       <CollectionCalendarDate datetime={'September 22, 2022'} />


### PR DESCRIPTION
The CollectionCalendarDate component does not show the year of the announcement. Ideally we would design a new component based on it that is more appropriate for our usage. However, as a quick bandaid, add year headings to make the dates unambiguous.