### PR TITLE
Move GridContainer from root route to top-level routes

### DIFF
--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -6,39 +6,48 @@
  * SPDX-License-Identifier: NASA-1.3
  */
 import { Link } from '@remix-run/react'
-import { ButtonGroup } from '@trussworks/react-uswds'
+import { ButtonGroup, Grid, GridContainer } from '@trussworks/react-uswds'
 
 import gcn_diagram from '~/img/gcn-diagram.jpg'
 
 export function Hero() {
   return (
-    <div
-      className="grid-row usa-hero margin-0 padding-0 bg-base-darkest"
-      style={{ backgroundImage: 'none' }}
-    >
-      <div className="bg-base-darkest padding-4 tablet:grid-col-5">
-        <h1 className="usa-hero__heading">
-          <span className="usa-hero__heading--alt">GCN:</span> NASA's
-          Time-Domain and Multimessenger Alert System
-        </h1>
-        <p className="usa-paragraph text-base-lightest">
-          GCN distributes alerts between space- and ground-based observatories,
-          physics experiments, and thousands of astronomers around the world.
-        </p>
-        <ButtonGroup>
-          <Link to="/quickstart" className="usa-button">
-            <>Start streaming GCN Notices</>
-          </Link>
-          <Link to="/circulars" className="usa-button usa-button--secondary">
-            <>Post a GCN Circular</>
-          </Link>
-        </ButtonGroup>
-      </div>
-      <img
-        src={gcn_diagram}
-        className="hero-image-right tablet:grid-col-7 padding-4"
-        alt="GCN Diagram"
-      />
+    <div className="bg-base-darkest">
+      <GridContainer>
+        <Grid
+          row
+          className="usa-hero margin-0 padding-0"
+          style={{ backgroundImage: 'none' }}
+        >
+          <div className="bg-base-darkest padding-4 tablet:grid-col-5">
+            <h1 className="usa-hero__heading">
+              <span className="usa-hero__heading--alt">GCN:</span> NASA's
+              Time-Domain and Multimessenger Alert System
+            </h1>
+            <p className="usa-paragraph text-base-lightest">
+              GCN distributes alerts between space- and ground-based
+              observatories, physics experiments, and thousands of astronomers
+              around the world.
+            </p>
+            <ButtonGroup>
+              <Link to="/quickstart" className="usa-button">
+                <>Start streaming GCN Notices</>
+              </Link>
+              <Link
+                to="/circulars"
+                className="usa-button usa-button--secondary"
+              >
+                <>Post a GCN Circular</>
+              </Link>
+            </ButtonGroup>
+          </div>
+          <img
+            src={gcn_diagram}
+            className="hero-image-right tablet:grid-col-7 padding-4"
+            alt="GCN Diagram"
+          />
+        </Grid>
+      </GridContainer>
     </div>
   )
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -223,9 +223,7 @@ function Document({ children }: { children?: React.ReactNode }) {
         <DevBanner />
         <Header />
         <NewsBanner message="GCN Circulars are now part of the new GCN!" />
-        <main className="usa-section" id="main-content">
-          <GridContainer>{children}</GridContainer>
-        </main>
+        <main id="main-content">{children}</main>
         <Footer />
         <ScrollRestoration />
         <Scripts />
@@ -238,13 +236,15 @@ function Document({ children }: { children?: React.ReactNode }) {
 function ErrorUnexpected({ children }: { children?: ReactNode }) {
   return (
     <Document>
-      <h1>Unexpected error {children}</h1>
-      <p className="usa-intro">An unexpected error occurred.</p>
-      <ButtonGroup>
-        <Link to="/" className="usa-button">
-          Go home
-        </Link>
-      </ButtonGroup>
+      <GridContainer className="usa-content">
+        <h1>Unexpected error {children}</h1>
+        <p className="usa-intro">An unexpected error occurred.</p>
+        <ButtonGroup>
+          <Link to="/" className="usa-button">
+            Go home
+          </Link>
+        </ButtonGroup>
+      </GridContainer>
     </Document>
   )
 }
@@ -253,22 +253,24 @@ function ErrorUnauthorized() {
   const url = useUrl()
   return (
     <Document>
-      <h1>Unauthorized</h1>
-      <p className="usa-intro">
-        We're sorry, you must log in to access the page you're looking for.
-      </p>
-      <p className="usa-paragraph">Log in to access that page, or go home.</p>
-      <ButtonGroup>
-        <Link
-          to={`/login?redirect=${encodeURIComponent(url)}`}
-          className="usa-button"
-        >
-          Log in and take me there
-        </Link>
-        <Link to="/" className="usa-button usa-button--outline">
-          Go home
-        </Link>
-      </ButtonGroup>
+      <GridContainer className="usa-content">
+        <h1>Unauthorized</h1>
+        <p className="usa-intro">
+          We're sorry, you must log in to access the page you're looking for.
+        </p>
+        <p className="usa-paragraph">Log in to access that page, or go home.</p>
+        <ButtonGroup>
+          <Link
+            to={`/login?redirect=${encodeURIComponent(url)}`}
+            className="usa-button"
+          >
+            Log in and take me there
+          </Link>
+          <Link to="/" className="usa-button usa-button--outline">
+            Go home
+          </Link>
+        </ButtonGroup>
+      </GridContainer>
     </Document>
   )
 }
@@ -276,23 +278,25 @@ function ErrorUnauthorized() {
 function ErrorNotFound() {
   return (
     <Document>
-      <h1>Page not found</h1>
-      <p className="usa-intro">
-        We're sorry, we can't find the page you're looking for. It might have
-        been removed, changed its name, or is otherwise unavailable.
-      </p>
-      <p className="usa-paragraph">
-        Visit our homepage for helpful tools and resources, or contact us and
-        we'll point you in the right direction.
-      </p>
-      <ButtonGroup>
-        <Link to="/" className="usa-button">
-          Visit homepage
-        </Link>
-        <Link to="/contact" className="usa-button usa-button--outline">
-          Contact us
-        </Link>
-      </ButtonGroup>
+      <GridContainer className="usa-content">
+        <h1>Page not found</h1>
+        <p className="usa-intro">
+          We're sorry, we can't find the page you're looking for. It might have
+          been removed, changed its name, or is otherwise unavailable.
+        </p>
+        <p className="usa-paragraph">
+          Visit our homepage for helpful tools and resources, or contact us and
+          we'll point you in the right direction.
+        </p>
+        <ButtonGroup>
+          <Link to="/" className="usa-button">
+            Visit homepage
+          </Link>
+          <Link to="/contact" className="usa-button usa-button--outline">
+            Contact us
+          </Link>
+        </ButtonGroup>
+      </GridContainer>
     </Document>
   )
 }

--- a/app/routes/circulars.tsx
+++ b/app/routes/circulars.tsx
@@ -5,8 +5,17 @@
  *
  * SPDX-License-Identifier: NASA-1.3
  */
-export { Outlet as default } from 'react-router'
+import { GridContainer } from '@trussworks/react-uswds'
+import { Outlet } from 'react-router'
 
 export const handle = {
   breadcrumb: 'Circulars',
+}
+
+export default function () {
+  return (
+    <GridContainer className="usa-section">
+      <Outlet />
+    </GridContainer>
+  )
 }

--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -10,6 +10,7 @@ import { Form, Link, useActionData } from '@remix-run/react'
 import {
   Button,
   ButtonGroup,
+  GridContainer,
   Label,
   TextInput,
   Textarea,
@@ -59,7 +60,7 @@ export default function () {
   const submitted = useActionData<typeof action>()
 
   return (
-    <>
+    <GridContainer className="usa-section">
       <h1>Contact Us</h1>
       {submitted ? (
         <>
@@ -133,6 +134,6 @@ export default function () {
           </ButtonGroup>
         </Form>
       )}
-    </>
+    </GridContainer>
   )
 }

--- a/app/routes/docs.tsx
+++ b/app/routes/docs.tsx
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: NASA-1.3
  */
 import { Link, NavLink, Outlet } from '@remix-run/react'
+import { GridContainer } from '@trussworks/react-uswds'
 
 import { SideNav, SideNavSub } from '~/components/SideNav'
 
@@ -15,87 +16,92 @@ export const handle = {
 
 export default function () {
   return (
-    <div className="grid-row grid-gap">
-      <div className="desktop:grid-col-3">
-        <SideNav
-          items={[
-            <NavLink key="." to="." end>
-              About GCN
-            </NavLink>,
-            <NavLink key="client" to="client">
-              Kafka Client Setup
-            </NavLink>,
-            <>
-              <NavLink key="circulars" to="circulars" end>
-                Circulars
-              </NavLink>
-              <SideNavSub
-                base="circulars"
-                items={[
-                  <NavLink key="subscribing" to="circulars/subscribing">
-                    Subscribing
-                  </NavLink>,
-                  <NavLink key="submitting" to="circulars/submitting">
-                    Submitting
-                  </NavLink>,
-                  <NavLink key="styleguide" to="circulars/styleguide">
-                    Style Guide
-                  </NavLink>,
-                  <NavLink key="archive" to="circulars/archive">
-                    Archive
-                  </NavLink>,
-                ]}
-              />
-            </>,
-            <>
-              <NavLink key="contributing" to="contributing">
-                Contributing
-              </NavLink>
-              <SideNavSub
-                base="contributing"
-                key="contributing-sub"
-                items={[
-                  <NavLink key="index" to="contributing" end>
-                    Getting Started
-                  </NavLink>,
-                  <NavLink key="feature-flags" to="contributing/feature-flags">
-                    Feature Flags
-                  </NavLink>,
-                ]}
-              />
-            </>,
-            <NavLink key="producers" to="producers">
-              New Notice Producers
-            </NavLink>,
-            <NavLink key="roadmap" to="roadmap">
-              Road Map
-            </NavLink>,
-            <>
-              <NavLink key="faq" to="faq">
-                Frequently Asked Questions
-              </NavLink>
-              <SideNavSub
-                base="faq"
-                key="faq-sub"
-                items={[
-                  <Link key="kafka" to="faq#kafka">
-                    Kafka
-                  </Link>,
-                  <Link key="circulars" to="faq#circulars">
-                    Circulars
-                  </Link>,
-                  <Link key="accounts" to="faq#accounts">
-                    Accounts
-                  </Link>,
-                ]}
-              />
-            </>,
-          ]}
-        />
+    <GridContainer className="usa-section">
+      <div className="grid-row grid-gap">
+        <div className="desktop:grid-col-3">
+          <SideNav
+            items={[
+              <NavLink key="." to="." end>
+                About GCN
+              </NavLink>,
+              <NavLink key="client" to="client">
+                Kafka Client Setup
+              </NavLink>,
+              <>
+                <NavLink key="circulars" to="circulars" end>
+                  Circulars
+                </NavLink>
+                <SideNavSub
+                  base="circulars"
+                  items={[
+                    <NavLink key="subscribing" to="circulars/subscribing">
+                      Subscribing
+                    </NavLink>,
+                    <NavLink key="submitting" to="circulars/submitting">
+                      Submitting
+                    </NavLink>,
+                    <NavLink key="styleguide" to="circulars/styleguide">
+                      Style Guide
+                    </NavLink>,
+                    <NavLink key="archive" to="circulars/archive">
+                      Archive
+                    </NavLink>,
+                  ]}
+                />
+              </>,
+              <>
+                <NavLink key="contributing" to="contributing">
+                  Contributing
+                </NavLink>
+                <SideNavSub
+                  base="contributing"
+                  key="contributing-sub"
+                  items={[
+                    <NavLink key="index" to="contributing" end>
+                      Getting Started
+                    </NavLink>,
+                    <NavLink
+                      key="feature-flags"
+                      to="contributing/feature-flags"
+                    >
+                      Feature Flags
+                    </NavLink>,
+                  ]}
+                />
+              </>,
+              <NavLink key="producers" to="producers">
+                New Notice Producers
+              </NavLink>,
+              <NavLink key="roadmap" to="roadmap">
+                Road Map
+              </NavLink>,
+              <>
+                <NavLink key="faq" to="faq">
+                  Frequently Asked Questions
+                </NavLink>
+                <SideNavSub
+                  base="faq"
+                  key="faq-sub"
+                  items={[
+                    <Link key="kafka" to="faq#kafka">
+                      Kafka
+                    </Link>,
+                    <Link key="circulars" to="faq#circulars">
+                      Circulars
+                    </Link>,
+                    <Link key="accounts" to="faq#accounts">
+                      Accounts
+                    </Link>,
+                  ]}
+                />
+              </>,
+            ]}
+          />
+        </div>
+        <div className="desktop:grid-col-9">
+          <Outlet />
+        </div>
       </div>
-      <div className="desktop:grid-col-9">
-        <Outlet />
-      </div>
-    </div>
+    </GridContainer>
   )
 }

--- a/app/routes/index.mdx
+++ b/app/routes/index.mdx
@@ -11,6 +11,7 @@ import {
   CardGroup,
   CardHeader,
   CardMedia,
+  GridContainer,
   Icon,
 } from '@trussworks/react-uswds'
 
@@ -22,12 +23,12 @@ import gcn_kafka from '~/img/gcn-kafka.svg'
 
 <Hero />
 
-The General Coordinates Network (GCN) is a public collaboration platform run by NASA for the astronomy research community to share alerts and rapid communications about high-energy, multimessenger, and transient phenomena. For more information, see [What is GCN?](/docs/#what-is-gcn) or check out our [slide deck](https://nasa-gcn.github.io/gcn-presentation/).
+<GridContainer className="usa-section">
+  The General Coordinates Network (GCN) is a public collaboration platform run by NASA for the astronomy research community to share alerts and rapid communications about high-energy, multimessenger, and transient phenomena. For more information, see [What is GCN?](/docs/#what-is-gcn) or check out our [slide deck](https://nasa-gcn.github.io/gcn-presentation/).
 
 There are three ways to stream GCN Notices in real time:
 
 <br />
-
 <CardGroup>
   <Card gridLayout={{ tablet: { col: 4 } }} headerFirst>
     <CardHeader className="bg-base-lighter">
@@ -89,7 +90,7 @@ There are three ways to stream GCN Notices in real time:
 
 ## Why switch from GCN Classic to Kafka?
 
-<div className="overflow-table">
+  <div className="overflow-table">
 
 |                                                                      | GCN Classic                                                                                                                           | GCN Classic over Kafka                                                                                                                    |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
@@ -99,10 +100,12 @@ There are three ways to stream GCN Notices in real time:
 | <div><Icon.Cloud size="3"/></div> **Highly available**               | <span className="text-red text-bold">NO.</span> Notices are broadcast by a single server                                              | <span className="text-green text-bold">YES.</span> Notices are broadcast by a cluster of highly-available Kafka brokers in the cloud      |
 | <div><Icon.Security size="3"/></div> **Secure**                      | <span className="text-red text-bold">NO.</span> Notices are sent as plaintext                                                         | <span className="text-green text-bold">YES.</span> Notices are protected with SSL/TLS                                                     |
 
-</div>
+  </div>
 
 ## Coming Soon
 
 The [GCN Viewer](https://heasarc.gsfc.nasa.gov/tachgcn) is an interactive, searchable, filterable index of all GCN Notices and Circulars, updated in real time. In the near future, it will be integrated with this web site.
 
 See the [GCN Road Map](docs/roadmap) for more features that are coming soon to GCN.
+
+</GridContainer>

--- a/app/routes/missions.tsx
+++ b/app/routes/missions.tsx
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: NASA-1.3
  */
 import { NavLink, Outlet } from '@remix-run/react'
+import { GridContainer } from '@trussworks/react-uswds'
 
 import { SideNav } from '~/components/SideNav'
 
@@ -13,61 +14,63 @@ export const handle = { breadcrumb: 'Missions' }
 
 export default function () {
   return (
-    <div className="grid-row grid-gap">
-      <div className="desktop:grid-col-4">
-        <SideNav
-          items={[
-            <NavLink key="." to="." end>
-              Missions, Instruments, and Facilities
-            </NavLink>,
-            <NavLink key="fermi" to="fermi">
-              Fermi Gamma-ray Space Telescope
-            </NavLink>,
-            <NavLink key="swift" to="swift">
-              Neil Gehrels Swift Observatory
-            </NavLink>,
-            <NavLink key="lvk" to="lvk">
-              LIGO/Virgo/KAGRA
-            </NavLink>,
-            <NavLink key="icecube" to="icecube">
-              IceCube Neutrino Observatory
-            </NavLink>,
-            <NavLink key="hawc" to="hawc">
-              HAWC
-            </NavLink>,
-            <NavLink key="calet" to="calet">
-              CALET
-            </NavLink>,
-            <NavLink key="maxi" to="maxi">
-              MAXI
-            </NavLink>,
-            <NavLink key="integral" to="integral">
-              INTEGRAL
-            </NavLink>,
-            <NavLink key="agile" to="agile">
-              AGILE
-            </NavLink>,
-            <NavLink key="konus" to="konus">
-              Konus-Wind
-            </NavLink>,
-            <NavLink key="moa" to="moa">
-              MOA
-            </NavLink>,
-            <NavLink key="snews" to="snews">
-              SNEWS
-            </NavLink>,
-            <NavLink key="sksn" to="sksn">
-              Super-Kamiokande
-            </NavLink>,
-            <NavLink key="gecam" to="gecam">
-              GECAM
-            </NavLink>,
-          ]}
-        />
+    <GridContainer className="usa-section">
+      <div className="grid-row grid-gap">
+        <div className="desktop:grid-col-4">
+          <SideNav
+            items={[
+              <NavLink key="." to="." end>
+                Missions, Instruments, and Facilities
+              </NavLink>,
+              <NavLink key="fermi" to="fermi">
+                Fermi Gamma-ray Space Telescope
+              </NavLink>,
+              <NavLink key="swift" to="swift">
+                Neil Gehrels Swift Observatory
+              </NavLink>,
+              <NavLink key="lvk" to="lvk">
+                LIGO/Virgo/KAGRA
+              </NavLink>,
+              <NavLink key="icecube" to="icecube">
+                IceCube Neutrino Observatory
+              </NavLink>,
+              <NavLink key="hawc" to="hawc">
+                HAWC
+              </NavLink>,
+              <NavLink key="calet" to="calet">
+                CALET
+              </NavLink>,
+              <NavLink key="maxi" to="maxi">
+                MAXI
+              </NavLink>,
+              <NavLink key="integral" to="integral">
+                INTEGRAL
+              </NavLink>,
+              <NavLink key="agile" to="agile">
+                AGILE
+              </NavLink>,
+              <NavLink key="konus" to="konus">
+                Konus-Wind
+              </NavLink>,
+              <NavLink key="moa" to="moa">
+                MOA
+              </NavLink>,
+              <NavLink key="snews" to="snews">
+                SNEWS
+              </NavLink>,
+              <NavLink key="sksn" to="sksn">
+                Super-Kamiokande
+              </NavLink>,
+              <NavLink key="gecam" to="gecam">
+                GECAM
+              </NavLink>,
+            ]}
+          />
+        </div>
+        <div className="desktop:grid-col-8 grid-col-12">
+          <Outlet />
+        </div>
       </div>
-      <div className="desktop:grid-col-8 grid-col-12">
-        <Outlet />
-      </div>
-    </div>
+    </GridContainer>
   )
 }

--- a/app/routes/news.mdx
+++ b/app/routes/news.mdx
@@ -9,136 +9,142 @@ import {
   CollectionDescription,
   CollectionHeading,
   CollectionItem,
+  GridContainer,
   Link,
 } from '@trussworks/react-uswds'
 
+<GridContainer className="usa-section">
+
 # GCN News and Events
 
-<Collection>
+  <Collection>
 
 ## 2023
 
-  <CollectionItem
-    className="maxw-none"
-    variantComponent={
-      <CollectionCalendarDate datetime={'May 6, 2023'} />
-    }
-  >
-    <CollectionHeading headingLevel="h3">
-      GCN Classic Outage Due to Local Network Maintenance
-    </CollectionHeading>
-    <CollectionDescription>
-    Due to planned network maintenance at GSFC, the connections to GCN Classic will be offline on Saturday, May 6 from 8AM ET (12:00 UTC) and concluding no later than 3PM ET (19:00 UTC).  This affects the following GCN services:
-    * GCN Classic Notices distribution via socket, VOEvent, and email
-    * GCN Classic Notices web site archive
-    * GCN Classic-to-Kafka connection and distribution of Notices via Kafka and email
-    * Forwarding of GCN Circulars submitted to gcncirc@capella2.gsfc.nasa.gov, however submission to circulars@gcn.nasa.gov and the [web form](/circulars) will be unaffected.
-    </CollectionDescription>
-  </CollectionItem>
-  <CollectionItem
-    className="maxw-none"
-    variantComponent={
-      <CollectionCalendarDate datetime={'April 6, 2023'} />
-    }
-  >
-    <CollectionHeading headingLevel="h3">
-      New GCN Circulars Service Coming April 17, 2023
-    </CollectionHeading>
-    <CollectionDescription>
-     We are pleased to announce that on April 17, 2023, the General Coordinates Network will launch the most significant overhaul of GCN Circulars since its inception in 1997. The modernized GCN Circulars experience will be part of the new GCN web site.
-     After the transition on April 17, you will be able to:
-      - Browse and search Circulars in our all-new [archive](/circulars).
-      - Sign up for and manage your own email subscriptions.
-      - Enroll yourself and your colleagues to submit Circulars with arXiv-style peer endorsements for new contributors.
-      - Submit Circulars with our new Web form, or continue to submit by email.
+    <CollectionItem
+      className="maxw-none"
+      variantComponent={
+        <CollectionCalendarDate datetime={'May 6, 2023'} />
+      }
+    >
+      <CollectionHeading headingLevel="h3">
+        GCN Classic Outage Due to Local Network Maintenance
+      </CollectionHeading>
+      <CollectionDescription>
+      Due to planned network maintenance at GSFC, the connections to GCN Classic will be offline on Saturday, May 6 from 8AM ET (12:00 UTC) and concluding no later than 3PM ET (19:00 UTC).  This affects the following GCN services:
+      * GCN Classic Notices distribution via socket, VOEvent, and email
+      * GCN Classic Notices web site archive
+      * GCN Classic-to-Kafka connection and distribution of Notices via Kafka and email
+      * Forwarding of GCN Circulars submitted to gcncirc@capella2.gsfc.nasa.gov, however submission to circulars@gcn.nasa.gov and the [web form](/circulars) will be unaffected.
+      </CollectionDescription>
+    </CollectionItem>
+    <CollectionItem
+      className="maxw-none"
+      variantComponent={
+        <CollectionCalendarDate datetime={'April 6, 2023'} />
+      }
+    >
+      <CollectionHeading headingLevel="h3">
+        New GCN Circulars Service Coming April 17, 2023
+      </CollectionHeading>
+      <CollectionDescription>
+      We are pleased to announce that on April 17, 2023, the General Coordinates Network will launch the most significant overhaul of GCN Circulars since its inception in 1997. The modernized GCN Circulars experience will be part of the new GCN web site.
+      After the transition on April 17, you will be able to:
+        - Browse and search Circulars in our all-new [archive](/circulars).
+        - Sign up for and manage your own email subscriptions.
+        - Enroll yourself and your colleagues to submit Circulars with arXiv-style peer endorsements for new contributors.
+        - Submit Circulars with our new Web form, or continue to submit by email.
 
-      Here is what you need to know about preparing for the transition on April 17.
-      - If you use Circulars now, we will transfer your settings automatically.
-      - If you receive Circulars now, you will continue to receive them.
-      - If you submit Circulars now, you will still be able to submit from the same email addresses.
-      - Emails from Circulars will come from a new address, no-reply@gcn.nasa.gov.
-      - We will encourage you to submit Circulars to the new address, circulars@gcn.nasa.gov, but we will still support the old address gcncirc@capella2.gsfc.nasa.gov.
-      - The [new archive](/circulars) will include all past Circulars. We will freeze the old archive,
-        https://gcn.gsfc.nasa.gov/gcn3_archive.html.
+        Here is what you need to know about preparing for the transition on April 17.
+        - If you use Circulars now, we will transfer your settings automatically.
+        - If you receive Circulars now, you will continue to receive them.
+        - If you submit Circulars now, you will still be able to submit from the same email addresses.
+        - Emails from Circulars will come from a new address, no-reply@gcn.nasa.gov.
+        - We will encourage you to submit Circulars to the new address, circulars@gcn.nasa.gov, but we will still support the old address gcncirc@capella2.gsfc.nasa.gov.
+        - The [new archive](/circulars) will include all past Circulars. We will freeze the old archive,
+          https://gcn.gsfc.nasa.gov/gcn3_archive.html.
 
-      To introduce GCN users to the [new GCN Circular system](/circulars), we invite you to join one of our three public Zoom webinars:
+        To introduce GCN users to the [new GCN Circular system](/circulars), we invite you to join one of our three public Zoom webinars:
 
-      - April 18, 2023 12:00-13:00 UTC (best for Atlantic):
-        https://bit.ly/3nSOqLN
+        - April 18, 2023 12:00-13:00 UTC (best for Atlantic):
+          https://bit.ly/3nSOqLN
 
-      - April 18, 2023 20:00-21:00 UTC (best for Pacific):
-        https://bit.ly/3mdmAt7
+        - April 18, 2023 20:00-21:00 UTC (best for Pacific):
+          https://bit.ly/3mdmAt7
 
-      - April 19, 2023 04:00-05:00 UTC (best for Asia and Oceania):
-        https://bit.ly/3UcHogZ
-    </CollectionDescription>
+        - April 19, 2023 04:00-05:00 UTC (best for Asia and Oceania):
+          https://bit.ly/3UcHogZ
+      </CollectionDescription>
 
-  </CollectionItem>
+    </CollectionItem>
 
 ## 2022
 
-  <CollectionItem
-    className="maxw-none"
-    variantComponent={
-      <CollectionCalendarDate datetime={'September 22, 2022'} />
-    }
-  >
-    <CollectionHeading headingLevel="h3">
-      New GECAM Notice Types Available
-    </CollectionHeading>
-    <CollectionDescription>
-      GCN now distributes notices from the
-      [GECAM](https://gcn.nasa.gov/missions/gecam) mission. Start streaming
-      GECAM notices using [GCN Classic over Kafka](/quickstart), have them
-      [delivered to your email inbox using self-service email
-      subscriptions](#Self-Service-Configuration-of-Email-Notifications-for-GCN-Notices),
-      or receive them as legacy notices using GCN Classic. To modify GCN Classic
-      subscriptions, please [contact
-      us](/contact?service=gcn-classic).
-    </CollectionDescription>
-  </CollectionItem>
-  <CollectionItem
-    className="maxw-none"
-    variantComponent={<CollectionCalendarDate datetime={'September 2, 2022'} />}
-  >
-    <CollectionHeading headingLevel="h3">
-      Self-Service Configuration of Email Notifications for GCN Notices
-    </CollectionHeading>
-    <CollectionDescription>
-      Have GCN Notices delivered to your email inbox by signing up and managing
-      your subscriptions through this web site. To get started, sign in or sign
-      up and then select "Email Notifications" from the account dropdown menu.
-      Note that signing up here does not affect prior subscriptions on the old
-      web site, https://gcn.gsfc.nasa.gov. To unsubscribe from the old web site,
-      please [contact
-      us](/contact?service=gcn-classic).
-      See [GCN Circular 32517](https://gcn.gsfc.nasa.gov/gcn3/32517.gcn3).
-    </CollectionDescription>
-  </CollectionItem>
-  <CollectionItem
-    className="maxw-none"
-    variantComponent={<CollectionCalendarDate datetime={'August 1, 2022'} />}
-  >
-    <CollectionHeading headingLevel="h3">New GCN Webinars</CollectionHeading>
-    <CollectionDescription>
-      GCN held three public webinars to introduce the new GCN, the GCN Classic
-      over Kafka service, and plans for new features and feedback. See the
-      [slides](https://nasa-gcn.github.io/gcn-presentation/).
-    </CollectionDescription>
-  </CollectionItem>
-  <CollectionItem
-    className="maxw-none"
-    variantComponent={<CollectionCalendarDate datetime={'July 20, 2022'} />}
-  >
-    <CollectionHeading headingLevel="h3">
-      GCN Classic over Kafka Now Available
-    </CollectionHeading>
-    <CollectionDescription>
-      All three classic GCN Notice formats (text, VOEvent, 160-byte binary
-      packet) are now also available over Kafka. This new Kafka streaming
-      service can be used as a drop-in replacement for GCN Classic socket and
-      VOEvent subscribers, with an upcoming release serving email subscribers.
-      See [GCN Circular 32419](https://gcn.gsfc.nasa.gov/gcn3/32419.gcn3).
-    </CollectionDescription>
-  </CollectionItem>
-</Collection>
+    <CollectionItem
+      className="maxw-none"
+      variantComponent={
+        <CollectionCalendarDate datetime={'September 22, 2022'} />
+      }
+    >
+      <CollectionHeading headingLevel="h3">
+        New GECAM Notice Types Available
+      </CollectionHeading>
+      <CollectionDescription>
+        GCN now distributes notices from the
+        [GECAM](https://gcn.nasa.gov/missions/gecam) mission. Start streaming
+        GECAM notices using [GCN Classic over Kafka](/quickstart), have them
+        [delivered to your email inbox using self-service email
+        subscriptions](#Self-Service-Configuration-of-Email-Notifications-for-GCN-Notices),
+        or receive them as legacy notices using GCN Classic. To modify GCN Classic
+        subscriptions, please [contact
+        us](/contact?service=gcn-classic).
+      </CollectionDescription>
+    </CollectionItem>
+    <CollectionItem
+      className="maxw-none"
+      variantComponent={<CollectionCalendarDate datetime={'September 2, 2022'} />}
+    >
+      <CollectionHeading headingLevel="h3">
+        Self-Service Configuration of Email Notifications for GCN Notices
+      </CollectionHeading>
+      <CollectionDescription>
+        Have GCN Notices delivered to your email inbox by signing up and managing
+        your subscriptions through this web site. To get started, sign in or sign
+        up and then select "Email Notifications" from the account dropdown menu.
+        Note that signing up here does not affect prior subscriptions on the old
+        web site, https://gcn.gsfc.nasa.gov. To unsubscribe from the old web site,
+        please [contact
+        us](/contact?service=gcn-classic).
+        See [GCN Circular 32517](https://gcn.gsfc.nasa.gov/gcn3/32517.gcn3).
+      </CollectionDescription>
+    </CollectionItem>
+    <CollectionItem
+      className="maxw-none"
+      variantComponent={<CollectionCalendarDate datetime={'August 1, 2022'} />}
+    >
+      <CollectionHeading headingLevel="h3">New GCN Webinars</CollectionHeading>
+      <CollectionDescription>
+        GCN held three public webinars to introduce the new GCN, the GCN Classic
+        over Kafka service, and plans for new features and feedback. See the
+        [slides](https://nasa-gcn.github.io/gcn-presentation/).
+      </CollectionDescription>
+    </CollectionItem>
+    <CollectionItem
+      className="maxw-none"
+      variantComponent={<CollectionCalendarDate datetime={'July 20, 2022'} />}
+    >
+      <CollectionHeading headingLevel="h3">
+        GCN Classic over Kafka Now Available
+      </CollectionHeading>
+      <CollectionDescription>
+        All three classic GCN Notice formats (text, VOEvent, 160-byte binary
+        packet) are now also available over Kafka. This new Kafka streaming
+        service can be used as a drop-in replacement for GCN Classic socket and
+        VOEvent subscribers, with an upcoming release serving email subscribers.
+        See [GCN Circular 32419](https://gcn.gsfc.nasa.gov/gcn3/32419.gcn3).
+      </CollectionDescription>
+    </CollectionItem>
+
+  </Collection>
+
+</GridContainer>

--- a/app/routes/notices.tsx
+++ b/app/routes/notices.tsx
@@ -4,6 +4,7 @@ import {
   CardFooter,
   CardGroup,
   CardHeader,
+  GridContainer,
   Icon,
   Tag,
 } from '@trussworks/react-uswds'
@@ -98,7 +99,7 @@ export default function () {
   const tagNames = tags.map(({ label }) => label)
 
   return (
-    <>
+    <GridContainer className="usa-section">
       <h1>GCN Notices</h1>
       <p className="usa-paragraph">
         GCN Notices are real-time, machine-readable alerts that are submitted by
@@ -429,6 +430,6 @@ export default function () {
           Status of the CGRO spacecraft.
         </NoticeCard>
       </CardGroup>
-    </>
+    </GridContainer>
   )
 }

--- a/app/routes/quickstart.tsx
+++ b/app/routes/quickstart.tsx
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: NASA-1.3
  */
 import { Outlet } from '@remix-run/react'
+import { GridContainer } from '@trussworks/react-uswds'
 
 import { NavStepIndicator } from '~/components/NavStepIndicator'
 
@@ -15,7 +16,7 @@ export const handle = {
 
 export default function () {
   return (
-    <>
+    <GridContainer className="usa-section">
       <h1>Start Streaming GCN Notices</h1>
       <NavStepIndicator
         counters="small"
@@ -28,6 +29,6 @@ export default function () {
         ]}
       />
       <Outlet />
-    </>
+    </GridContainer>
   )
 }

--- a/app/routes/user.tsx
+++ b/app/routes/user.tsx
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: NASA-1.3
  */
 import { NavLink, Outlet } from '@remix-run/react'
+import { GridContainer } from '@trussworks/react-uswds'
 
 import { SideNav } from '~/components/SideNav'
 
@@ -13,7 +14,7 @@ export const handle = { breadcrumb: 'User', getSitemapEntries: () => null }
 
 export default function () {
   return (
-    <>
+    <GridContainer className="usa-section">
       <div className="grid-row grid-gap">
         <div className="desktop:grid-col-3">
           <SideNav
@@ -40,6 +41,6 @@ export default function () {
           <Outlet />
         </div>
       </div>
-    </>
+    </GridContainer>
   )
 }


### PR DESCRIPTION
This lays the groundwork for elements on selected pages that extend into the margins, chiefly a full-width hero on the main page.

Note: merge #919 first.