### PR TITLE
Send Circulars using To addresses, not Bcc

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -107,7 +107,7 @@ sandboxOidcIdp  # Sandbox identity provider
 lambdaCognitoPermissions  # Grant the Lambda function access to Cognito to run the credential vending machine.
 lambdaMayNotWriteToStaticBucket  # the Lambda function should not be able to modify the static bucket
 missionCloudPlatform  # Custom permissions for deployment on Mission Cloud Platform
-sendEmailPermissions  # Grant the Lambda function permission to send email.
+emailOutgoing  # Grant the Lambda function permission to send email; add email templates.
 emailIncoming  # Enable notifications from SES to SNS to trigger email-incoming Lambda
 nasa-gcn/architect-plugin-search  # Add an AWS OpenSearch Serverless collection.
 architect/plugin-lambda-invoker

--- a/app/table-streams/circulars/index.ts
+++ b/app/table-streams/circulars/index.ts
@@ -16,7 +16,7 @@ import type {
   AttributeValue as LambdaTriggerAttributeValue,
 } from 'aws-lambda'
 
-import { sendEmailBcc } from '~/lib/email.server'
+import { sendEmailBulk } from '~/lib/email.server'
 import { createTriggerHandler } from '~/lib/lambdaTrigger.server'
 import { search as getSearchClient } from '~/lib/search.server'
 import type { Circular } from '~/routes/circulars/circulars.lib'
@@ -95,7 +95,7 @@ async function send(circular: Circular) {
     getLegacyEmails(),
   ])
   const to = [...emails, ...legacyEmails]
-  await sendEmailBcc({
+  await sendEmailBulk({
     fromName,
     to,
     subject: circular.subject,


### PR DESCRIPTION
There is one institution that is bouncing our messages because they don't have any To: or Cc: recipients set. I don't know if that is a common spam signal or not, but by setting the To: address we should at least unblock the messages for that institution.

I added an SES template that simply has a subject and a body field.