### PR TITLE
Don't use public, static cacheing for GCN Circulars

### DIFF
--- a/app/routes/circulars/$circularId.json.ts
+++ b/app/routes/circulars/$circularId.json.ts
@@ -10,10 +10,7 @@ import { json } from '@remix-run/node'
 
 import { get } from './circulars.server'
 import { getOrigin } from '~/lib/env.server'
-import {
-  getCanonicalUrlHeaders,
-  publicStaticCacheControlHeaders,
-} from '~/lib/headers.server'
+import { getCanonicalUrlHeaders } from '~/lib/headers.server'
 
 export async function loader({ params: { circularId } }: DataFunctionArgs) {
   if (!circularId)
@@ -21,11 +18,8 @@ export async function loader({ params: { circularId } }: DataFunctionArgs) {
   const result = await get(parseInt(circularId))
   delete result.sub
   return json(result, {
-    headers: {
-      ...publicStaticCacheControlHeaders,
-      ...getCanonicalUrlHeaders(
-        new URL(`/circulars/${circularId}`, getOrigin())
-      ),
-    },
+    headers: getCanonicalUrlHeaders(
+      new URL(`/circulars/${circularId}`, getOrigin())
+    ),
   })
 }

--- a/app/routes/circulars/$circularId.raw.ts
+++ b/app/routes/circulars/$circularId.raw.ts
@@ -10,10 +10,7 @@ import type { DataFunctionArgs } from '@remix-run/node'
 import { formatCircular } from './circulars.lib'
 import { get } from './circulars.server'
 import { getOrigin } from '~/lib/env.server'
-import {
-  getCanonicalUrlHeaders,
-  publicStaticCacheControlHeaders,
-} from '~/lib/headers.server'
+import { getCanonicalUrlHeaders } from '~/lib/headers.server'
 
 export async function loader({ params: { circularId } }: DataFunctionArgs) {
   if (!circularId)
@@ -21,11 +18,8 @@ export async function loader({ params: { circularId } }: DataFunctionArgs) {
   const result = await get(parseInt(circularId))
   delete result.sub
   return new Response(formatCircular(result), {
-    headers: {
-      ...publicStaticCacheControlHeaders,
-      ...getCanonicalUrlHeaders(
-        new URL(`/circulars/${circularId}`, getOrigin())
-      ),
-    },
+    headers: getCanonicalUrlHeaders(
+      new URL(`/circulars/${circularId}`, getOrigin())
+    ),
   })
 }

--- a/app/routes/circulars/$circularId.tsx
+++ b/app/routes/circulars/$circularId.tsx
@@ -6,14 +6,12 @@
  * SPDX-License-Identifier: NASA-1.3
  */
 import type { DataFunctionArgs, SerializeFrom } from '@remix-run/node'
-import { json } from '@remix-run/node'
 import { Link, useLoaderData, useSearchParams } from '@remix-run/react'
 import { ButtonGroup, Grid, Icon } from '@trussworks/react-uswds'
 
 import { formatDateISO } from './circulars.lib'
 import { get } from './circulars.server'
 import TimeAgo from '~/components/TimeAgo'
-import { publicStaticCacheControlHeaders } from '~/lib/headers.server'
 
 export const handle = {
   breadcrumb({
@@ -28,10 +26,7 @@ export const handle = {
 export async function loader({ params: { circularId } }: DataFunctionArgs) {
   if (!circularId)
     throw new Response('circularId must be defined', { status: 400 })
-  const result = await get(parseInt(circularId))
-  return json(result, {
-    headers: publicStaticCacheControlHeaders,
-  })
+  return await get(parseInt(circularId))
 }
 
 export default function () {

--- a/app/routes/circulars/index.tsx
+++ b/app/routes/circulars/index.tsx
@@ -214,10 +214,11 @@ export default function () {
             </h3>
           )}
           <ol>
-            
             {allItems.map(({ circularId, subject }) => (
               <li key={circularId} value={circularId}>
-                <Link to={`/circulars/${circularId}${searchParamsString}`}>{subject}</Link>
+                <Link to={`/circulars/${circularId}${searchParamsString}`}>
+                  {subject}
+                </Link>
               </li>
             ))}
           </ol>


### PR DESCRIPTION
We issue corrections sometimes, so they aren't completely static.