### PR TITLE
Fix title of Missions page

### DIFF
--- a/app/routes/missions/index.md
+++ b/app/routes/missions/index.md
@@ -1,8 +1,3 @@
----
-handle:
-  breadcrumb: Missions
----
-
 # Missions, Instruments, and Facilities
 
 Observatories that generate GCN notices for transient alerts, as consumed by the science community. Explore mission resources and GCN notice details in the menu.


### PR DESCRIPTION
It should be `GCN - Missions`, not `GCN - Missions - Missions`.