### PR TITLE
Fix Remix v2 fetcher API warnings

### DIFF
--- a/app/components/EmailNotificationCard.tsx
+++ b/app/components/EmailNotificationCard.tsx
@@ -28,10 +28,14 @@ export default function EmailNotificationCard({
   const disabled = deleteFetcher.state !== 'idle'
 
   useEffect(() => {
-    if (testFetcher.type === 'done' && testModalRef.current) {
+    if (
+      testFetcher.state === 'idle' &&
+      testFetcher.data !== undefined &&
+      testModalRef.current
+    ) {
       testModalRef.current.toggleModal(undefined, true)
     }
-  }, [testFetcher.type, testModalRef])
+  }, [testFetcher.state, testFetcher.data, testModalRef])
 
   return (
     <>

--- a/app/routes/user/email/index.tsx
+++ b/app/routes/user/email/index.tsx
@@ -93,7 +93,7 @@ function CircularsSubscriptionForm({ value }: { value: boolean }) {
               <Spinner /> Saving...
             </>
           )}
-          {fetcher.type === 'done' && (
+          {fetcher.state === 'idle' && fetcher.data !== undefined && (
             <>
               <Icon.Check color="green" /> Saved
             </>

--- a/app/routes/user/index.tsx
+++ b/app/routes/user/index.tsx
@@ -144,7 +144,7 @@ export default function () {
             <Spinner /> Saving...
           </>
         )}
-        {fetcher.type === 'done' && !dirty && (
+        {fetcher.state === 'idle' && fetcher.data !== undefined && !dirty && (
           <>
             <Icon.Check color="green" /> Saved
           </>


### PR DESCRIPTION
Fix this warning:

> REMIX FUTURE CHANGE: `fetcher.type` will be removed in v2. Please use `fetcher.state`, `fetcher.formData`, and `fetcher.data` to achieve the same UX.For instructions on making this change see https://remix.run/docs/en/v1.15.0/pages/v2#usefetcher