### PR TITLE
Use parseFloat to process circular IDs for DDB lookup

### DIFF
--- a/app/routes/circulars/$circularId.json.ts
+++ b/app/routes/circulars/$circularId.json.ts
@@ -15,7 +15,7 @@ import { getCanonicalUrlHeaders } from '~/lib/headers.server'
 export async function loader({ params: { circularId } }: DataFunctionArgs) {
   if (!circularId)
     throw new Response('circularId must be defined', { status: 400 })
-  const result = await get(parseInt(circularId))
+  const result = await get(parseFloat(circularId))
   delete result.sub
   return json(result, {
     headers: getCanonicalUrlHeaders(

--- a/app/routes/circulars/$circularId.raw.ts
+++ b/app/routes/circulars/$circularId.raw.ts
@@ -15,7 +15,7 @@ import { getCanonicalUrlHeaders } from '~/lib/headers.server'
 export async function loader({ params: { circularId } }: DataFunctionArgs) {
   if (!circularId)
     throw new Response('circularId must be defined', { status: 400 })
-  const result = await get(parseInt(circularId))
+  const result = await get(parseFloat(circularId))
   delete result.sub
   return new Response(formatCircular(result), {
     headers: getCanonicalUrlHeaders(

--- a/app/routes/circulars/$circularId.tsx
+++ b/app/routes/circulars/$circularId.tsx
@@ -26,7 +26,7 @@ export const handle = {
 export async function loader({ params: { circularId } }: DataFunctionArgs) {
   if (!circularId)
     throw new Response('circularId must be defined', { status: 400 })
-  return await get(parseInt(circularId))
+  return await get(parseFloat(circularId))
 }
 
 export default function () {


### PR DESCRIPTION
This fixes a bug that would have made it impossible to view circulars with half-integer IDs.