### PR TITLE
Fix 404 error in circular detail route

### DIFF
--- a/app/routes/circulars/$circularId.tsx
+++ b/app/routes/circulars/$circularId.tsx
@@ -14,12 +14,11 @@ import { get } from './circulars.server'
 import TimeAgo from '~/components/TimeAgo'
 
 export const handle = {
-  breadcrumb({
-    data: { circularId, subject },
-  }: {
-    data: SerializeFrom<typeof loader>
-  }) {
-    return `${circularId}: ${subject}`
+  breadcrumb({ data }: { data: SerializeFrom<typeof loader> }) {
+    if (data) {
+      const { circularId, subject } = data
+      return `${circularId}: ${subject}`
+    }
   },
 }
 


### PR DESCRIPTION
The `handle.breadcrumb` function failed to handle the possibility of the loader data being undefined because the loader failed with a 404 error. Navigating to a nonexistent Circular was throwing an internal server error rather than a 404 error.