### PR TITLE
Refactor notice format types

### DIFF
--- a/app/components/NoticeFormat.tsx
+++ b/app/components/NoticeFormat.tsx
@@ -8,17 +8,17 @@
 import { Button, ButtonGroup } from '@trussworks/react-uswds'
 import { useState } from 'react'
 
-type ValueType = 'text' | 'voevent' | 'binary'
+export type NoticeFormat = 'text' | 'voevent' | 'binary'
 
-export function NoticeFormat({
+export function NoticeFormatInput({
   name,
   value,
 }: {
   name: string
-  value?: ValueType
+  value?: NoticeFormat
 }) {
   const [currentValue, setCurrentValue] = useState(value)
-  const [hover, setHover] = useState<ValueType | undefined>(undefined)
+  const [hover, setHover] = useState<NoticeFormat | undefined>(undefined)
 
   function clearHover() {
     setHover(undefined)
@@ -26,12 +26,12 @@ export function NoticeFormat({
 
   const options = [
     {
-      value: 'text' as ValueType,
+      value: 'text' as NoticeFormat,
       label: 'Text',
       description: <>Plain text key: value pairs separated by newlines.</>,
     },
     {
-      value: 'voevent' as ValueType,
+      value: 'voevent' as NoticeFormat,
       label: 'VOEvent',
       description: (
         <>
@@ -47,7 +47,7 @@ export function NoticeFormat({
       ),
     },
     {
-      value: 'binary' as ValueType,
+      value: 'binary' as NoticeFormat,
       label: 'Binary',
       description: (
         <>

--- a/app/routes/quickstart/alerts.tsx
+++ b/app/routes/quickstart/alerts.tsx
@@ -9,7 +9,7 @@ import { Form, Link, useSearchParams } from '@remix-run/react'
 import { Button, Label } from '@trussworks/react-uswds'
 import { useState } from 'react'
 
-import { NoticeFormat } from '~/components/NoticeFormat'
+import { NoticeFormatInput } from '~/components/NoticeFormat'
 import { NoticeTypeCheckboxes } from '~/components/NoticeTypeCheckboxes'
 
 export const handle = {
@@ -31,7 +31,7 @@ export default function () {
         <Link to="/missions">Missions</Link>.
       </p>
       <Label htmlFor="noticeFormat">Notice Format</Label>
-      <NoticeFormat name="noticeFormat" value="text" />
+      <NoticeFormatInput name="noticeFormat" value="text" />
       <Label htmlFor="noticeTypes">Notice Type</Label>
       <NoticeTypeCheckboxes validationFunction={setAlertsValid} />
       <input type="hidden" name="clientId" value={clientId} />

--- a/app/routes/user/email/edit.tsx
+++ b/app/routes/user/email/edit.tsx
@@ -20,7 +20,7 @@ import {
   getEmailNotification,
   updateEmailNotification,
 } from '../email_notices.server'
-import { NoticeFormat } from '~/components/NoticeFormat'
+import { type NoticeFormat, NoticeFormatInput } from '~/components/NoticeFormat'
 import { NoticeTypeCheckboxes } from '~/components/NoticeTypeCheckboxes'
 import { formatAndNoticeTypeToTopic } from '~/lib/utils'
 import { getUser } from '~/routes/__auth/user.server'
@@ -79,7 +79,7 @@ export async function loader({ request }: DataFunctionArgs) {
     notification = await getEmailNotification(uuid, user.sub)
     intent = 'update'
   }
-  const format = notification.format as 'text' | 'voevent' | 'binary'
+  const format = notification.format as NoticeFormat
   return { notification, intent, format }
 }
 
@@ -130,7 +130,7 @@ export default function () {
         onChange={(e) => setrecipientValid(!!e.target.value)}
       />
       <Label htmlFor="format">Format</Label>
-      <NoticeFormat name="noticeFormat" value={format} />
+      <NoticeFormatInput name="noticeFormat" value={format} />
       <Label htmlFor="noticeTypes">Types</Label>
       <NoticeTypeCheckboxes
         defaultSelected={notification.noticeTypes}


### PR DESCRIPTION
- Export the type for the value so that we can reuse it.
- Rename the type of the value to `NoticeFormat` and rename the component to `NoticeFormatInput` (as in, the `<input>` component for providing a NoticeFormat)