### PR TITLE
Fixes spacing on keywords display

### DIFF
--- a/app/components/CircularsKeywords.tsx
+++ b/app/components/CircularsKeywords.tsx
@@ -41,7 +41,7 @@ export function CircularsKeywords() {
   )
 }
 
-function CalculateAllowedKeywordClassName(length: number) {
+function getKeywordClassName(length: number) {
   let className = 'tablet:'
   if (length < 16) className += 'grid-col-2 grid-col-4'
   else if (length < 32) className += 'grid-col-4 grid-col-8'

--- a/app/components/CircularsKeywords.tsx
+++ b/app/components/CircularsKeywords.tsx
@@ -18,10 +18,7 @@ export function CircularsKeywords() {
       <h3>Allowed subject keywords</h3>
       <ul className="grid-row usa-list usa-list--unstyled">
         {validSubjectKeywords.map((keyword) => (
-          <li
-            key={keyword}
-            className={getKeywordClassName(keyword.length)}
-          >
+          <li key={keyword} className={getKeywordClassName(keyword.length)}>
             {keyword}
           </li>
         ))}

--- a/app/components/CircularsKeywords.tsx
+++ b/app/components/CircularsKeywords.tsx
@@ -18,10 +18,9 @@ export function CircularsKeywords() {
       <h3>Allowed subject keywords</h3>
       <ul className="grid-row usa-list usa-list--unstyled">
         {validSubjectKeywords.map((keyword) => (
-          /* special case grid length for 'Baksan Neutrino Observatory Alert' */
           <li
             key={keyword}
-            className={keyword.length < 20 ? 'grid-col-2' : 'grid-col-6'}
+            className={CalculateAllowedKeywordClassName(keyword.length)}
           >
             {keyword}
           </li>
@@ -30,7 +29,7 @@ export function CircularsKeywords() {
       <h3>Disallowed subject keywords</h3>
       <ul className="grid-row usa-list usa-list--unstyled">
         {emailAutoReplyChecklist.map((keyword) => (
-          <li key={keyword} className={'grid-col-3'}>
+          <li key={keyword} className={'tablet:grid-col-3'}>
             {keyword}
           </li>
         ))}
@@ -40,4 +39,12 @@ export function CircularsKeywords() {
       </p>
     </>
   )
+}
+
+function CalculateAllowedKeywordClassName(length: number) {
+  let className = 'tablet:'
+  if (length < 16) className += 'grid-col-2 grid-col-4'
+  else if (length < 32) className += 'grid-col-4 grid-col-8'
+  else className += 'grid-col-6'
+  return className
 }

--- a/app/components/CircularsKeywords.tsx
+++ b/app/components/CircularsKeywords.tsx
@@ -20,7 +20,7 @@ export function CircularsKeywords() {
         {validSubjectKeywords.map((keyword) => (
           <li
             key={keyword}
-            className={CalculateAllowedKeywordClassName(keyword.length)}
+            className={getKeywordClassName(keyword.length)}
           >
             {keyword}
           </li>


### PR DESCRIPTION
Old Desktop:
![image](https://github.com/nasa-gcn/gcn.nasa.gov/assets/11023698/a6ac897f-42fc-400b-8f49-30f263301e4f)

New Desktop:
![image](https://github.com/nasa-gcn/gcn.nasa.gov/assets/11023698/03d92db5-131a-485e-a163-9342b0908739)

Old Mobile:
![image](https://github.com/nasa-gcn/gcn.nasa.gov/assets/11023698/9197f687-2b7d-4fc1-9198-9436764e6299)

New Mobile:
![image](https://github.com/nasa-gcn/gcn.nasa.gov/assets/11023698/73c5e7e0-eb1f-4ed0-8a3c-b4a402a4572e)
