### PR TITLE
Circulars search backend for date range

### DIFF
--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -76,6 +76,11 @@ export function formatDateISO(date: number) {
   return new Date(date).toISOString().replace(/\.\d+Z$/, 'Z')
 }
 
+/** convert a date in format mm-dd-yyyy (or YYYY-MM_DD) to ms since 01/01/1970 */
+export function formatDateEpoch(date: string) {
+  return new Date(date).getTime()
+}
+
 /** Return true if the subject is valid, false if it is invalid, or undefined if it is an empty string */
 export function subjectIsValid(subject: string) {
   if (subject.length) {


### PR DESCRIPTION
Backend for Issue #878 

Date range filter has been implemented inside circulars.server.ts with the addition of an advancedQuery optional argument, which contains optional start and end date arguments that will default to negative and positive infinity, respectively. When the frontend is added in a separate PR, react-uswds has a date range picker element that can be used.

Added functions to circulars.lib.ts for converting a unix time to mm-dd-yy format and another function to do the opposite. The URLSearchParams for the start and end dates are in unix time (the circular items store the createdOn time in unix time format). In the search function, the iso8061 format dates are converted to unix times to simplify the filter. However, as Leo said in the 06/12/23 GCN meeting, it would be better if the date range values were stored in the iso8061 format in the url so they're human readable. This would require changes to index.tsx, but the formatDateEpoch implementation in the search function shouldn't require any changes since it should be able to convert to unix time if provided an iso8061 string.

Currently, the changes made in index.tsx to incorporate the date range parameters cause an unintended issue with the way URLSearchParams are retreived by the loader function after initiating a search; in the loader function, it seems that the only parameter retreived is the query parameter. The lack of the page number parameter causes the query results to not display correctly, though logging the results variable does show that they're being loaded, so I don' think it's due to the search function. Inspecting the url parameters in other functions, which print in the client-side console, seem to have all of the expected parameters. This is explained in slightly more detail in [this comment](https://github.com/nasa-gcn/gcn.nasa.gov/issues/878#issuecomment-1583244451) in the related issue.

