### PR TITLE
Ignore `*.server.*` files as routes

### DIFF
--- a/remix.config.mjs
+++ b/remix.config.mjs
@@ -34,7 +34,7 @@ export const mdx = {
 
 const isProduction = process.env.NODE_ENV === 'production'
 
-export const ignoredRouteFiles = ['**/.*', '**/*.lib.*']
+export const ignoredRouteFiles = ['**/.*', '**/*.lib.*', '**/*.server.*']
 export const assetsBuildDirectory = 'build/static'
 export const publicPath = '/_static/'
 export const server = './server.js'


### PR DESCRIPTION
I'm not sure why Remix doesn't do this by default, given that it has a convention to exclude `*.server.*` files from the client bundle.