### PR TITLE
Fixes an issue where the Items would be an empty array and cause a ValidationException

### DIFF
--- a/app/routes/unsubscribe/actions.server.ts
+++ b/app/routes/unsubscribe/actions.server.ts
@@ -37,7 +37,7 @@ async function nukeSubscriptions(
 
   const promises = []
   for await (const { Items } of pages) {
-    if (Items) {
+    if (Items?.length) {
       promises.push(
         client.batchWrite({
           RequestItems: {


### PR DESCRIPTION
The item array could potentially be empty, which would cause errors like:

ValidationException: 1 validation error detected: Value '{EmailNotificationSubscriptionTable=[]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]
    at throwDefaultError (/var/runtime/node_modules/@aws-sdk/smithy-client/dist-cjs/default-error-handler.js:8:22)
    at deserializeAws_json1_0BatchWriteItemCommandError (/var/runtime/node_modules/@aws-sdk/client-dynamodb/dist-cjs/protocols/Aws_json1_0.js:665:51)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at /var/runtime/node_modules/@aws-sdk/middleware-serde/dist-cjs/deserializerMiddleware.js:7:24
    at /var/runtime/node_modules/@aws-sdk/lib-dynamodb/dist-cjs/baseCommand/DynamoDBDocumentClientCommand.js:18:34
    at /var/runtime/node_modules/@aws-sdk/middleware-signing/dist-cjs/middleware.js:13:20
    at StandardRetryStrategy.retry (/var/runtime/node_modules/@aws-sdk/middleware-retry/dist-cjs/StandardRetryStrategy.js:51:46)
    at /var/runtime/node_modules/@aws-sdk/middleware-logger/dist-cjs/loggerMiddleware.js:6:22
    at async Promise.all (index 0)