### PR TITLE
Remove public access block config from CloudFormation template

### DIFF
--- a/src/plugins/missionCloudPlatform.mjs
+++ b/src/plugins/missionCloudPlatform.mjs
@@ -13,6 +13,11 @@ export const deploy = {
     // they must be set manually by an administrator
     delete cloudformation.Resources.StaticBucketPolicy
 
+    // Mission Cloud Platform does not support user-defined public access block
+    // configurations; they must be set manually by an administrator
+    delete cloudformation.Resources.StaticBucket.Properties
+      .PublicAccessBlockConfiguration
+
     // Add required permissions boundary for working on the Mission Cloud Platform
     cloudformation.Resources.Role.Properties.PermissionsBoundary = {
       // eslint-disable-next-line no-template-curly-in-string


### PR DESCRIPTION
The latest version of architect sets the `PublicAccessBlockConfiguration` property on the static S3 bucket. Mission Cloud Platform does not allow tenants to set this property; it must be manually set by an administrator.