### PR TITLE
Don't emit '?' if query string is empty

### DIFF
--- a/app/routes/circulars/index.tsx
+++ b/app/routes/circulars/index.tsx
@@ -73,7 +73,9 @@ function getPageLink(
   searchParams.set('page', page.toString() || '1')
   if (startDate) searchParams.set('startDate', startDate)
   if (endDate) searchParams.set('endDate', endDate)
-  return `?${searchParams.toString()}`
+
+  const searchParamsString = searchParams.toString()
+  return searchParamsString && `?${searchParamsString}`
 }
 
 function Pagination({


### PR DESCRIPTION
This leads to nicer looking URLs.