### PR TITLE
Refactor date parsing for circulars search

### DIFF
--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -76,11 +76,6 @@ export function formatDateISO(date: number) {
   return new Date(date).toISOString().replace(/\.\d+Z$/, 'Z')
 }
 
-/** convert a date in format mm-dd-yyyy (or YYYY-MM_DD) to ms since 01/01/1970 */
-export function formatDateEpoch(date: string) {
-  return new Date(date).getTime()
-}
-
 /** Return true if the subject is valid, false if it is invalid, or undefined if it is an empty string */
 export function subjectIsValid(subject: string) {
   if (subject.length) {

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -15,7 +15,6 @@ import memoizee from 'memoizee'
 import { getUser } from '../__auth/user.server'
 import { bodyIsValid, formatAuthor, subjectIsValid } from './circulars.lib'
 import type { Circular, CircularMetadata } from './circulars.lib'
-import { formatDateEpoch } from './circulars.lib'
 import { search as getSearch } from '~/lib/search.server'
 
 export const group = 'gcn.nasa.gov/circular-submitter'
@@ -45,6 +44,11 @@ export const getDynamoDBAutoIncrement = memoizee(
   { promise: true }
 )
 
+/** convert a date in format mm-dd-yyyy (or YYYY-MM_DD) to ms since 01/01/1970 */
+function parseDate(date?: string) {
+  return date ? new Date(date).getTime() : NaN
+}
+
 export async function search({
   query,
   page,
@@ -64,8 +68,8 @@ export async function search({
 }> {
   const client = await getSearch()
 
-  const startTime = formatDateEpoch(startDate!) || -Infinity
-  const endTime = formatDateEpoch(endDate!) + 86400000 || Infinity
+  const startTime = parseDate(startDate) || undefined
+  const endTime = parseDate(endDate) + 86400000 || undefined
 
   const {
     body: {


### PR DESCRIPTION
* Don't export the parsing function since it is only used in one place.
* Eliminate non-null assertion operators.
* Replace invalid values with `undefined`, not `Infinity`.