### PR TITLE
Use `fields`, not `_source`, to control data returned by OpenSearch

### DIFF
--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -101,9 +101,8 @@ export async function search({
           },
         },
       },
-      _source: {
-        includes: ['subject', 'createdOn'],
-      },
+      fields: ['subject'],
+      _source: false,
       sort: {
         circularId: {
           order: 'desc',
@@ -118,17 +117,15 @@ export async function search({
   const items = hits.map(
     ({
       _id: circularId,
-      _source: { subject, createdOn },
+      fields: {
+        subject: [subject],
+      },
     }: {
       _id: string
-      _source: {
-        subject?: string
-        createdOn?: string
-      }
+      fields: { subject: string[] }
     }) => ({
       circularId,
       subject,
-      createdOn,
     })
   )
 


### PR DESCRIPTION
The Elasticsearch documentation hints that this should be more efficient. See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#field-retrieval-methods.