### PR TITLE
Configure sandbox IdP to return cognito:groups claim

### DIFF
--- a/src/plugins/sandboxOidcIdp.mjs
+++ b/src/plugins/sandboxOidcIdp.mjs
@@ -52,7 +52,7 @@ export const sandbox = {
         }
       },
       claims: {
-        openid: ['sub', 'email', 'cognito:username'],
+        openid: ['sub', 'email', 'cognito:username', 'cognito:groups'],
       },
       // Register an app client for the web site
       clients: [


### PR DESCRIPTION
The claim was missing in the returned ID token.