### PR TITLE
Fix serverDependenciesToBundle

### DIFF
--- a/remix.config.mjs
+++ b/remix.config.mjs
@@ -41,7 +41,7 @@ export const server = './server.js'
 export const serverBuildPath = 'build/server/index.js'
 export const serverMinify = isProduction
 export const serverDependenciesToBundle = isProduction
-  ? [/^(?!@?aws-sdk\/)/, /^(@nasa-gcn\/schema\/)/]
+  ? [/^(?!@?aws-sdk(\/|$))/]
   : undefined
 export const future = {
   v2_meta: true,


### PR DESCRIPTION
- Fix the regex to properly exclude the AWS SDK v2. This significantly decreases the Lambda code size.
- Don't explicitly bundle @nasa-gcn/gcn-schema, because it is implicitly bundled by the regex that includes everything except for the AWS SDK.