### PR TITLE
adding documentation about a known kafka bug

### DIFF
--- a/app/routes/docs/client.mdx
+++ b/app/routes/docs/client.mdx
@@ -38,3 +38,11 @@ For C, use [librdkafka](https://github.com/edenhill/librdkafka) and the followin
 For C#, use the [Confluent.Kafka](https://www.nuget.org/packages/Confluent.Kafka/) NuGet package. The code sample was based on Confluent's [Kafka .NET Client](https://docs.confluent.io/kafka-clients/dotnet/current/overview.html#consumer) documentation.
 
 <ClientSampleCode language="cs" />
+
+## Known Issues
+
+### confluent-kafka-python
+
+If you use confluent-kafka-python v2.1.0 or v2.1.1 with librdkafka v2.1.1 you will encounter a segmentation fault when subscribed to inactive topics.
+
+Please refer to [the confluent-kafka-python github issue](https://github.com/confluentinc/confluent-kafka-python/issues/1547) for updates on the issue.

--- a/app/routes/docs/client.mdx
+++ b/app/routes/docs/client.mdx
@@ -43,6 +43,6 @@ For C#, use the [Confluent.Kafka](https://www.nuget.org/packages/Confluent.Kafka
 
 ### confluent-kafka-python
 
-If you use confluent-kafka-python v2.1.0 or v2.1.1 with librdkafka v2.1.1 you will encounter a segmentation fault when subscribed to inactive topics.
+If you use confluent-kafka-python v2.1.0 or v2.1.1 with librdkafka v2.1.1 you will encounter a segmentation fault when subscribed to unavailable topics.
 
 Please refer to [the confluent-kafka-python github issue](https://github.com/confluentinc/confluent-kafka-python/issues/1547) for updates on the issue.

--- a/app/routes/docs/contributing/index.mdx
+++ b/app/routes/docs/contributing/index.mdx
@@ -134,9 +134,3 @@ Here are instructions for getting the GCN site set up and running on your own co
 
   </ProcessListItem>
 </ProcessList>
-
-## Known Issues
-
-### confluent-kafka-python
-
-If you encounter a segmentation fault, please refer to [this github link](https://github.com/confluentinc/confluent-kafka-python/issues/1547) for help troubleshooting. The bug in the confluent-kafka-python package leads to a segmentation fault when a subscribed topic is unavailable.

--- a/app/routes/docs/contributing/index.mdx
+++ b/app/routes/docs/contributing/index.mdx
@@ -134,3 +134,9 @@ Here are instructions for getting the GCN site set up and running on your own co
 
   </ProcessListItem>
 </ProcessList>
+
+## Known Issues
+
+### confluent-kafka-python
+
+If you encounter a segmentation fault, please refer to [this github link](https://github.com/confluentinc/confluent-kafka-python/issues/1547) for help troubleshooting. The bug in the confluent-kafka-python package leads to a segmentation fault when a subscribed topic is unavailable.


### PR DESCRIPTION
A [known bug](https://github.com/confluentinc/confluent-kafka-python/issues/1547) in the confluent-kafka-python package causes a hard to diagnose issue. Improving documentation to help our users figure out the issue faster.
