### PR TITLE
using light theme to avoid low contrast menu items

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -13,7 +13,7 @@ import {
   Title,
   Header as USWDSHeader,
 } from '@trussworks/react-uswds'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { useEmail } from '~/root'
 
@@ -69,27 +69,11 @@ export function Header() {
   const [expanded, setExpanded] = useState(false)
   const [userMenuIsOpen, setUserMenuIsOpen] = useState(false)
   const onClick = () => setExpanded((prvExpanded) => !prvExpanded)
-  const [isDesktop, setIsDesktop] = useState<boolean>(false)
-  const headerTheme = isDesktop ? 'usa-header--dark' : 'usa-header'
-
-  useEffect(() => {
-    const handleResize = () => {
-      const isDesktopView = window.innerWidth >= 768
-      setIsDesktop(isDesktopView)
-    }
-
-    handleResize()
-    window.addEventListener('resize', handleResize)
-
-    return () => {
-      window.removeEventListener('resize', handleResize)
-    }
-  }, [])
 
   return (
     <>
       <div className={`usa-overlay ${expanded ? 'is-visible' : ''}`}></div>
-      <USWDSHeader basic className={`usa-header ${headerTheme}`}>
+      <USWDSHeader basic className={'usa-header usa-header--dark'}>
         <div className="usa-nav-container">
           <div className="usa-navbar">
             <Title>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -73,7 +73,7 @@ export function Header() {
   return (
     <>
       <div className={`usa-overlay ${expanded ? 'is-visible' : ''}`}></div>
-      <USWDSHeader basic className={'usa-header usa-header--dark'}>
+      <USWDSHeader basic className="usa-header usa-header--dark">
         <div className="usa-nav-container">
           <div className="usa-navbar">
             <Title>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -13,7 +13,7 @@ import {
   Title,
   Header as USWDSHeader,
 } from '@trussworks/react-uswds'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { useEmail } from '~/root'
 
@@ -69,11 +69,27 @@ export function Header() {
   const [expanded, setExpanded] = useState(false)
   const [userMenuIsOpen, setUserMenuIsOpen] = useState(false)
   const onClick = () => setExpanded((prvExpanded) => !prvExpanded)
+  const [isDesktop, setIsDesktop] = useState<boolean>(false)
+  const headerTheme = isDesktop ? 'usa-header--dark' : 'usa-header'
+
+  useEffect(() => {
+    const handleResize = () => {
+      const isDesktopView = window.innerWidth >= 768
+      setIsDesktop(isDesktopView)
+    }
+
+    handleResize()
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [])
 
   return (
     <>
       <div className={`usa-overlay ${expanded ? 'is-visible' : ''}`}></div>
-      <USWDSHeader basic className="usa-header usa-header">
+      <USWDSHeader basic className={`usa-header ${headerTheme}`}>
         <div className="usa-nav-container">
           <div className="usa-navbar">
             <Title>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -73,7 +73,7 @@ export function Header() {
   return (
     <>
       <div className={`usa-overlay ${expanded ? 'is-visible' : ''}`}></div>
-      <USWDSHeader basic className="usa-header usa-header--dark">
+      <USWDSHeader basic className="usa-header usa-header">
         <div className="usa-nav-container">
           <div className="usa-navbar">
             <Title>

--- a/build/theme/custom.scss
+++ b/build/theme/custom.scss
@@ -548,3 +548,23 @@ a {
   margin-top: 0;
   margin-bottom: 0;
 }
+
+/*
+ * Override user nav text colors to add contrast when not desktop
+ */
+.usa-nav__primary a:not(.usa-button):not(.usa-current):not(.active) {
+  @media (max-width: 63.99em) {
+    color: white;
+  }
+}
+.usa-nav__primary a:not(.usa-button):not(.usa-current):hover {
+  @media (max-width: 63.99em) {
+    color: #0050d8;
+  }
+}
+
+ul#user {
+  @media (max-width: 63.99em) {
+    background-color: #1b1b1b;
+  }
+}

--- a/build/theme/custom.scss
+++ b/build/theme/custom.scss
@@ -551,6 +551,7 @@ a {
 
 /*
  * Override user nav text colors to add contrast when not desktop
+ * FIXME: remove once https://github.com/bruffridge/nasawds/issues/10 is fixed
  */
 .usa-nav__primary a:not(.usa-button):not(.usa-current):not(.active) {
   @media (max-width: 63.99em) {


### PR DESCRIPTION
This is a quick fix option to avoid the mobile contrast issue in the user navigation menu.