### PR TITLE
Avoid direct dependencies on react-router

### DIFF
--- a/app/components/SideNav.tsx
+++ b/app/components/SideNav.tsx
@@ -5,8 +5,8 @@
  *
  * SPDX-License-Identifier: NASA-1.3
  */
+import type { Link } from '@remix-run/react'
 import { SideNav as BaseSideNav } from '@trussworks/react-uswds'
-import type { To } from 'react-router'
 
 import { useActiveLink } from '~/lib/remix'
 
@@ -23,7 +23,7 @@ export function SideNavSub({
   isVisible,
   ...props
 }: Omit<Parameters<typeof BaseSideNav>[0], 'isSubNav'> & {
-  base: To
+  base: Parameters<typeof Link>[0]['to']
   isVisible?: Boolean
 }) {
   const isActive = useActiveLink({ to: base })

--- a/app/lib/remix.ts
+++ b/app/lib/remix.ts
@@ -7,11 +7,10 @@
  */
 import type { AppData, SerializeFrom } from '@remix-run/node'
 import type { NavLinkProps } from '@remix-run/react'
+import { useLocation, useResolvedPath } from '@remix-run/react'
 import { useContext } from 'react'
 import {
   UNSAFE_NavigationContext as NavigationContext,
-  useLocation,
-  useResolvedPath,
   useRouteLoaderData as useRouteLoaderDataRR,
 } from 'react-router'
 

--- a/app/routes/circulars.tsx
+++ b/app/routes/circulars.tsx
@@ -6,8 +6,8 @@
  * SPDX-License-Identifier: NASA-1.3
  */
 import type { DataFunctionArgs } from '@remix-run/node'
+import { Outlet } from '@remix-run/react'
 import { GridContainer } from '@trussworks/react-uswds'
-import { Outlet } from 'react-router'
 
 import { put } from './circulars/circulars.server'
 import { getFormDataString } from '~/lib/utils'

--- a/app/routes/docs.tsx
+++ b/app/routes/docs.tsx
@@ -7,9 +7,9 @@
  */
 import { Link, NavLink, Outlet } from '@remix-run/react'
 import { GridContainer } from '@trussworks/react-uswds'
-import { useMatch } from 'react-router'
 
 import { SideNav, SideNavSub } from '~/components/SideNav'
+import { useActiveLink } from '~/lib/remix'
 import { useFeature } from '~/root'
 
 export const handle = {
@@ -18,7 +18,7 @@ export const handle = {
 
 export default function () {
   const enableSchemaBrowser = useFeature('SCHEMA')
-  const isSchemaBrowser = useMatch('/docs/schema-browser/*')
+  const isSchemaBrowser = useActiveLink({ to: '/docs/schema-browser' })
 
   return (
     <GridContainer className="usa-section">

--- a/app/routes/docs/circulars.ts
+++ b/app/routes/docs/circulars.ts
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: NASA-1.3
  */
-export { Outlet as default } from 'react-router'
+export { Outlet as default } from '@remix-run/react'
 
 export const handle = {
   breadcrumb: 'Circulars',

--- a/app/routes/docs/contributing.ts
+++ b/app/routes/docs/contributing.ts
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: NASA-1.3
  */
-export { Outlet as default } from 'react-router'
+export { Outlet as default } from '@remix-run/react'
 
 export const handle = {
   breadcrumb: 'Contributing',

--- a/app/routes/unsubscribe/$jwt.tsx
+++ b/app/routes/unsubscribe/$jwt.tsx
@@ -6,7 +6,14 @@
  * SPDX-License-Identifier: NASA-1.3
  */
 import type { DataFunctionArgs } from '@remix-run/node'
-import { Form, Link, useActionData, useLoaderData } from '@remix-run/react'
+import {
+  Form,
+  Link,
+  isRouteErrorResponse,
+  useActionData,
+  useLoaderData,
+  useRouteError,
+} from '@remix-run/react'
 import {
   Button,
   ButtonGroup,
@@ -15,7 +22,6 @@ import {
 } from '@trussworks/react-uswds'
 import capitalize from 'lodash/capitalize'
 import { useState } from 'react'
-import { isRouteErrorResponse, useRouteError } from 'react-router'
 
 import { unsubscribeActions } from './actions.server'
 import { maxTokenAge } from './jwt.lib'

--- a/app/routes/unsubscribe/jwt.server.ts
+++ b/app/routes/unsubscribe/jwt.server.ts
@@ -5,8 +5,8 @@
  *
  * SPDX-License-Identifier: NASA-1.3
  */
+import type { Params } from '@remix-run/react'
 import { SignJWT, jwtVerify } from 'jose'
-import type { Params } from 'react-router'
 import invariant from 'tiny-invariant'
 
 import { maxTokenAge } from './jwt.lib'

--- a/app/routes/user/credentials.ts
+++ b/app/routes/user/credentials.ts
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: NASA-1.3
  */
 
-export { Outlet as default } from 'react-router'
+export { Outlet as default } from '@remix-run/react'
 
 export const handle = {
   breadcrumb: 'Client Credentials',

--- a/app/routes/user/email.ts
+++ b/app/routes/user/email.ts
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: NASA-1.3
  */
 
-export { Outlet as default } from 'react-router'
+export { Outlet as default } from '@remix-run/react'
 
 export const handle = {
   breadcrumb: 'Email Notifications',


### PR DESCRIPTION
The `@remix-run/react` package re-exports most of react-router. Avoid direct dependencies on react-router so that we can avoid manually keeping its version in sync with `@remix-run/react` in our package.json file.