### PR TITLE
Use boolean, not Boolean

### DIFF
--- a/app/components/SideNav.tsx
+++ b/app/components/SideNav.tsx
@@ -24,7 +24,7 @@ export function SideNavSub({
   ...props
 }: Omit<Parameters<typeof BaseSideNav>[0], 'isSubNav'> & {
   base: Parameters<typeof Link>[0]['to']
-  isVisible?: Boolean
+  isVisible?: boolean
 }) {
   const isActive = useActiveLink({ to: base })
   return isActive || isVisible ? <BaseSideNav {...props} isSubnav /> : <></>


### PR DESCRIPTION
Fixes this TypeScript warning:

```
Don't use `Boolean` as a type. Use boolean instead
```