### PR TITLE
Combine remix.config.mjs exports into one default export

### DIFF
--- a/remix.config.mjs
+++ b/remix.config.mjs
@@ -5,46 +5,45 @@ import rehypeHighlight from 'rehype-highlight'
 import rehypeSlug from 'rehype-slug'
 import remarkGfm from 'remark-gfm'
 
-/**
- * @type {import('@remix-run/dev/config').RemixMdxConfig}
- */
-export const mdx = {
-  rehypePlugins: [
-    rehypeHighlight,
-    rehypeSlug,
-    (options) =>
-      rehypeExternalLinks({
-        rel: 'external',
-        target: false,
-        ...options,
-      }),
-    (options) =>
-      rehypeAddClasses({
-        a: 'usa-link',
-        ol: 'usa-list',
-        p: 'usa-paragraph',
-        table: 'usa-table',
-        ul: 'usa-list',
-        ...options,
-      }),
-    (options) => rehypeAutolinkHeadings({ behavior: 'wrap', ...options }),
-  ],
-  remarkPlugins: [remarkGfm],
-}
-
 const isProduction = process.env.NODE_ENV === 'production'
 
-export const ignoredRouteFiles = ['**/.*', '**/*.lib.*', '**/*.server.*']
-export const assetsBuildDirectory = 'build/static'
-export const publicPath = '/_static/'
-export const server = './server.js'
-export const serverBuildPath = 'build/server/index.js'
-export const serverMinify = isProduction
-export const serverDependenciesToBundle = isProduction
-  ? [/^(?!@?aws-sdk(\/|$))/]
-  : undefined
-export const future = {
-  v2_meta: true,
-  v2_errorBoundary: true,
-  v2_normalizeFormMethod: true,
+/** @type {import('@remix-run/dev').AppConfig} */
+export default {
+  mdx: {
+    rehypePlugins: [
+      rehypeHighlight,
+      rehypeSlug,
+      (options) =>
+        rehypeExternalLinks({
+          rel: 'external',
+          target: false,
+          ...options,
+        }),
+      (options) =>
+        rehypeAddClasses({
+          a: 'usa-link',
+          ol: 'usa-list',
+          p: 'usa-paragraph',
+          table: 'usa-table',
+          ul: 'usa-list',
+          ...options,
+        }),
+      (options) => rehypeAutolinkHeadings({ behavior: 'wrap', ...options }),
+    ],
+    remarkPlugins: [remarkGfm],
+  },
+  ignoredRouteFiles: ['**/.*', '**/*.lib.*', '**/*.server.*'],
+  assetsBuildDirectory: 'build/static',
+  publicPath: '/_static/',
+  server: './server.js',
+  serverBuildPath: 'build/server/index.js',
+  serverMinify: isProduction,
+  serverDependenciesToBundle: isProduction
+    ? [/^(?!@?aws-sdk(\/|$))/]
+    : undefined,
+  future: {
+    v2_meta: true,
+    v2_errorBoundary: true,
+    v2_normalizeFormMethod: true,
+  },
 }


### PR DESCRIPTION
This improves autocompletion because Typescript now knows all of the fields on the Remix config object.