### PR TITLE
Coalesce multiple imports of the same module

### DIFF
--- a/app/components/CredentialCard.tsx
+++ b/app/components/CredentialCard.tsx
@@ -7,10 +7,10 @@
  */
 import { Form, useFetcher } from '@remix-run/react'
 import type { ModalRef } from '@trussworks/react-uswds'
-import { Icon } from '@trussworks/react-uswds'
 import {
   Button,
   Grid,
+  Icon,
   Modal,
   ModalFooter,
   ModalHeading,

--- a/app/components/EmailNotificationCard.tsx
+++ b/app/components/EmailNotificationCard.tsx
@@ -1,11 +1,13 @@
 import { Form, useFetcher } from '@remix-run/react'
 import type { ModalRef } from '@trussworks/react-uswds'
-import { Modal, ModalFooter, ModalHeading } from '@trussworks/react-uswds'
 import {
   Button,
   ButtonGroup,
   Grid,
   Icon,
+  Modal,
+  ModalFooter,
+  ModalHeading,
   ModalToggleButton,
 } from '@trussworks/react-uswds'
 import { useEffect, useRef } from 'react'

--- a/app/lib/email.server.ts
+++ b/app/lib/email.server.ts
@@ -11,10 +11,10 @@ import type {
   SendBulkEmailCommandInput,
   SendEmailCommandInput,
 } from '@aws-sdk/client-sesv2'
-import { SendBulkEmailCommand } from '@aws-sdk/client-sesv2'
 import {
   SESv2Client,
   SESv2ServiceException,
+  SendBulkEmailCommand,
   SendEmailCommand,
 } from '@aws-sdk/client-sesv2'
 import chunk from 'lodash/chunk'


### PR DESCRIPTION
Fixes the following ESLint warning that was revealed by #1131:

https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md