### PR TITLE
Add required aria-selected attr to treeitems

### DIFF
--- a/app/components/NestedCheckboxes.tsx
+++ b/app/components/NestedCheckboxes.tsx
@@ -68,6 +68,7 @@ function NestedCheckboxNode({
     <li
       role="treeitem"
       aria-expanded={expanded}
+      aria-selected={false}
       onClick={() => setExpanded(!expanded)}
       className="nested-checkboxes__node"
     >
@@ -108,7 +109,7 @@ function NestedCheckboxNode({
       />
       <ul hidden={!expanded} className="nested-checkboxes__leaf">
         {nodes.map((node, index) => (
-          <li role="treeitem" key={index}>
+          <li role="treeitem" key={index} aria-selected={false}>
             <Checkbox
               {...node}
               inputRef={(instance) => {


### PR DESCRIPTION
Fix the following eslint warnings revealed by #1131:

```
app/components/NestedCheckboxes.tsx
   69:7   warning  Elements with the ARIA role "treeitem" must have the following attributes defined: aria-selected  jsx-a11y/role-has-required-aria-props
  111:15  warning  Elements with the ARIA role "treeitem" must have the following attributes defined: aria-selected  jsx-a11y/role-has-required-aria-props
```