### PR TITLE
Activate Remix v2_headers future flag

### DIFF
--- a/remix.config.mjs
+++ b/remix.config.mjs
@@ -43,6 +43,7 @@ export default {
     : undefined,
   future: {
     v2_dev: true,
+    v2_headers: true,
     v2_meta: true,
     v2_errorBoundary: true,
     v2_normalizeFormMethod: true,


### PR DESCRIPTION
We don't actually use the [`headers` route module API](https://remix.run/docs/en/main/route/headers) anyway, so there is no code to update!

See https://remix.run/docs/en/main/pages/v2#route-headers.