### PR TITLE
Provide canonical URLs for pages that with query params

### DIFF
--- a/app/lib/headers.server.ts
+++ b/app/lib/headers.server.ts
@@ -45,3 +45,12 @@ export function getBasicAuthHeaders(username: string, password: string) {
   const userpass = Buffer.from(`${username}:${password}`).toString('base64')
   return { Authorization: `Basic ${userpass}` }
 }
+
+export function pickHeaders(headers: Headers, keys: string[]) {
+  const result: [string, string][] = []
+  for (const key of keys) {
+    const value = headers.get(key)
+    if (value) result.push([key, value])
+  }
+  return result
+}

--- a/app/routes/circulars.$circularId.tsx
+++ b/app/routes/circulars.$circularId.tsx
@@ -5,13 +5,20 @@
  *
  * SPDX-License-Identifier: NASA-1.3
  */
-import type { DataFunctionArgs, SerializeFrom } from '@remix-run/node'
+import type {
+  DataFunctionArgs,
+  HeadersFunction,
+  SerializeFrom,
+} from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { Link, useLoaderData } from '@remix-run/react'
 import { ButtonGroup, Grid, Icon } from '@trussworks/react-uswds'
 
 import { formatDateISO } from './circulars/circulars.lib'
 import { get } from './circulars/circulars.server'
 import TimeAgo from '~/components/TimeAgo'
+import { origin } from '~/lib/env.server'
+import { getCanonicalUrlHeaders, pickHeaders } from '~/lib/headers.server'
 import { useSearchString } from '~/lib/utils'
 
 export const handle = {
@@ -26,8 +33,16 @@ export const handle = {
 export async function loader({ params: { circularId } }: DataFunctionArgs) {
   if (!circularId)
     throw new Response('circularId must be defined', { status: 400 })
-  return await get(parseFloat(circularId))
+  const result = await get(parseFloat(circularId))
+  return json(result, {
+    headers: getCanonicalUrlHeaders(
+      new URL(`/circulars/${circularId}`, origin)
+    ),
+  })
 }
+
+export const headers: HeadersFunction = ({ loaderHeaders }) =>
+  pickHeaders(loaderHeaders, ['Link'])
 
 const submittedHowMap = {
   web: 'Web form',

--- a/app/routes/circulars.new.tsx
+++ b/app/routes/circulars.new.tsx
@@ -5,7 +5,8 @@
  *
  * SPDX-License-Identifier: NASA-1.3
  */
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { DataFunctionArgs, HeadersFunction } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { Form, Link, useLoaderData, useNavigation } from '@remix-run/react'
 import {
   Button,
@@ -32,6 +33,8 @@ import {
 import { group } from './circulars/circulars.server'
 import { CircularsKeywords } from '~/components/CircularsKeywords'
 import Spinner from '~/components/Spinner'
+import { origin } from '~/lib/env.server'
+import { getCanonicalUrlHeaders, pickHeaders } from '~/lib/headers.server'
 import { useSearchString } from '~/lib/utils'
 import { useUrl } from '~/root'
 
@@ -47,8 +50,14 @@ export async function loader({ request }: DataFunctionArgs) {
     if (user.groups.includes(group)) isAuthorized = true
     formattedAuthor = formatAuthor(user)
   }
-  return { isAuthenticated, isAuthorized, formattedAuthor }
+  return json(
+    { isAuthenticated, isAuthorized, formattedAuthor },
+    { headers: getCanonicalUrlHeaders(new URL(`/circulars/new`, origin)) }
+  )
 }
+
+export const headers: HeadersFunction = ({ loaderHeaders }) =>
+  pickHeaders(loaderHeaders, ['Link'])
 
 function useSubjectPlaceholder() {
   const date = new Date()

--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -5,7 +5,8 @@
  *
  * SPDX-License-Identifier: NASA-1.3
  */
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { DataFunctionArgs, HeadersFunction } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { Form, Link, useActionData } from '@remix-run/react'
 import {
   Button,
@@ -24,13 +25,26 @@ import { useState } from 'react'
 import { ReCAPTCHA, verifyRecaptcha } from '~/components/ReCAPTCHA'
 import { sendEmail } from '~/lib/email.server'
 import { feature, getEnvOrDie } from '~/lib/env.server'
-import { getBasicAuthHeaders } from '~/lib/headers.server'
+import {
+  getBasicAuthHeaders,
+  getCanonicalUrlHeaders,
+  pickHeaders,
+} from '~/lib/headers.server'
 import { getFormDataString } from '~/lib/utils'
 import { useEmail, useName, useRecaptchaSiteKey } from '~/root'
 
 export const handle = {
   breadcrumb: 'Contact Us',
 }
+
+export async function loader() {
+  return json(null, {
+    headers: getCanonicalUrlHeaders(new URL('/contact', origin)),
+  })
+}
+
+export const headers: HeadersFunction = ({ loaderHeaders }) =>
+  pickHeaders(loaderHeaders, ['Link'])
 
 export async function action({ request }: DataFunctionArgs) {
   const data = await request.formData()


### PR DESCRIPTION
This fixes Google warnings for these pages about `Duplicate without user-selected canonical`.