### PR TITLE
Disallow use of silly browser globals

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,12 @@
       "prettier"
     ],
     "rules": {
+      "no-restricted-globals": [
+        "error",
+        "event",
+        "name",
+        "origin"
+      ],
       "prefer-const": "error"
     },
     "overrides": [


### PR DESCRIPTION
Configure ESLint to disallow references to browser builtin globals that have very generic names which are highly likely to give false negatives for undefined variables in local scopes.

In the future, this will catch issues like #1203 and #1204.