### PR TITLE
Accept default values for new Circular form from URL

### DIFF
--- a/app/routes/circulars.new.tsx
+++ b/app/routes/circulars.new.tsx
@@ -7,7 +7,13 @@
  */
 import type { DataFunctionArgs, HeadersFunction } from '@remix-run/node'
 import { json } from '@remix-run/node'
-import { Form, Link, useLoaderData, useNavigation } from '@remix-run/react'
+import {
+  Form,
+  Link,
+  useLoaderData,
+  useNavigation,
+  useSearchParams,
+} from '@remix-run/react'
 import {
   Button,
   ButtonGroup,
@@ -78,12 +84,24 @@ function useBodyPlaceholder() {
 export default function () {
   const { isAuthenticated, isAuthorized, formattedAuthor } =
     useLoaderData<typeof loader>()
-  const [subjectValid, setSubjectValid] = useState<boolean | undefined>()
-  const [bodyValid, setBodyValid] = useState<boolean | undefined>()
+
+  // Get default subject from search params, then strip out
+  let [searchParams] = useSearchParams()
+  const defaultSubject = searchParams.get('subject') || ''
+  const defaultBody = searchParams.get('body') || ''
+  searchParams = new URLSearchParams(searchParams)
+  searchParams.delete('subject')
+  searchParams.delete('body')
+  let searchString = searchParams.toString()
+  if (searchString) searchString = `?${searchString}`
+
+  const [subjectValid, setSubjectValid] = useState(
+    subjectIsValid(defaultSubject)
+  )
+  const [bodyValid, setBodyValid] = useState(bodyIsValid(defaultBody))
   const [showKeywords, setShowKeywords] = useState(false)
   const sending = Boolean(useNavigation().formData)
   const valid = subjectValid && bodyValid
-  const searchString = useSearchString()
 
   function toggleShowKeywords() {
     setShowKeywords(!showKeywords)
@@ -119,6 +137,7 @@ export default function () {
             id="subject"
             type="text"
             placeholder={useSubjectPlaceholder()}
+            defaultValue={defaultSubject}
             required={true}
             onChange={({ target: { value } }) => {
               setSubjectValid(subjectIsValid(value))
@@ -153,6 +172,7 @@ export default function () {
           id="body"
           aria-describedby="bodyDescription"
           placeholder={useBodyPlaceholder()}
+          defaultValue={defaultBody}
           required={true}
           className={classnames('maxw-full', {
             'usa-input--success': bodyValid,

--- a/app/routes/docs.circulars.submitting.mdx
+++ b/app/routes/docs.circulars.submitting.mdx
@@ -7,6 +7,7 @@ import { Link } from '@remix-run/react'
 import { Alert, Button, Icon } from '@trussworks/react-uswds'
 
 import { CircularsEmailAddress } from '~/components/CircularsEmailAddress'
+import { useOrigin } from '~/root'
 
 # Submitting Circulars
 
@@ -54,6 +55,19 @@ There are two ways to post a GCN Circular: via web form or via email.
 ### Post a GCN Circular by Web Form
 
 To post a GCN Circular via the web form, simply go to the [GCN Circulars archive](/circulars), click the <Link to="/circulars/new"><Button type="button" className="usa-button height-4 padding-y-0 padding-x-1 margin-x-05"><Icon.Edit /> New</Button></Link> button, and complete the form.
+
+<Alert
+  type="info"
+  heading="Pre-fill GCN Circulars web form with a hyperlink"
+  headingLevel="h4"
+>
+  **Tip:** You can pre-fill default values for the subject and body by passing
+  them to the web form in the [URL query
+  string](https://en.wikipedia.org/wiki/Query_string):
+  <pre>
+    <code>{useOrigin()}/circulars/new?subject=...&body=...</code>
+  </pre>
+</Alert>
 
 ### Post a GCN Circular by Email
 


### PR DESCRIPTION
The new GCN Circular form will accept default values for the subject and body from the URL query string. This will support third parties (e.g. Hermes) that want to pre-populate Circular drafts for users. As proposed in discussions with @phycodurus.

This is analogous to GitHub's ability to fill in default values for new issues and PRs from the query string.