### PR TITLE
Update copyright

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,10 +1,9 @@
 
 NASA Docket No. GSC-19,205-1, and identified as "General Coordinates Network
-(resubmission to change license to Apache-2.0)
+(resubmission to change license to Apache-2.0)"
 
-Copyright © 2022 United States Government as represented by the Administrator
-of the National Aeronautics and Space Administration. No copyright is claimed
-in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+Copyright © 2023 United States Government as represented by the Administrator
+of the National Aeronautics and Space Administration. All Rights Reserved.
 
                                  Apache License
                            Version 2.0, January 2004

--- a/__tests__/circulars.ts
+++ b/__tests__/circulars.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/__tests__/cognito.server.ts
+++ b/__tests__/cognito.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/__tests__/env.ts
+++ b/__tests__/env.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/AnnounceBanner.tsx
+++ b/app/components/AnnounceBanner.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/CircularsEmailAddress.tsx
+++ b/app/components/CircularsEmailAddress.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/CircularsKeywords.tsx
+++ b/app/components/CircularsKeywords.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/ClientSampleCode.tsx
+++ b/app/components/ClientSampleCode.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/CopyableCode.tsx
+++ b/app/components/CopyableCode.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/CredentialCard.tsx
+++ b/app/components/CredentialCard.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/DetailsDropdownButton.tsx
+++ b/app/components/DetailsDropdownButton.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/DetailsDropdownContent.tsx
+++ b/app/components/DetailsDropdownContent.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/DevBanner.tsx
+++ b/app/components/DevBanner.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/GitHubLabel.tsx
+++ b/app/components/GitHubLabel.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/HeadingWithAddButton.tsx
+++ b/app/components/HeadingWithAddButton.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/Highlight.tsx
+++ b/app/components/Highlight.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/Hint.tsx
+++ b/app/components/Hint.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/NavStepIndicator.tsx
+++ b/app/components/NavStepIndicator.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/NestedCheckboxes.tsx
+++ b/app/components/NestedCheckboxes.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/NewCredentialForm.tsx
+++ b/app/components/NewCredentialForm.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/NewsBanner.tsx
+++ b/app/components/NewsBanner.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/NoticeFormat.tsx
+++ b/app/components/NoticeFormat.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/NoticeTypeCheckboxes.tsx
+++ b/app/components/NoticeTypeCheckboxes.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/ReCAPTCHA.tsx
+++ b/app/components/ReCAPTCHA.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/SegmentedCards.tsx
+++ b/app/components/SegmentedCards.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/SideNav.tsx
+++ b/app/components/SideNav.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/Spinner.tsx
+++ b/app/components/Spinner.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/Tabs.tsx
+++ b/app/components/Tabs.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/components/TimeAgo.tsx
+++ b/app/components/TimeAgo.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/email-incoming/circulars/__tests__/parse.ts
+++ b/app/email-incoming/circulars/__tests__/parse.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/email-incoming/circulars/index.ts
+++ b/app/email-incoming/circulars/index.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/email-incoming/circulars/parse.ts
+++ b/app/email-incoming/circulars/parse.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/email-incoming/handler.ts
+++ b/app/email-incoming/handler.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/email-incoming/support/index.ts
+++ b/app/email-incoming/support/index.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/lib/__tests__/headers.server.ts
+++ b/app/lib/__tests__/headers.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/lib/cognito.server.ts
+++ b/app/lib/cognito.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/lib/email.server.ts
+++ b/app/lib/email.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/lib/env.server.ts
+++ b/app/lib/env.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/lib/headers.server.ts
+++ b/app/lib/headers.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/lib/lambdaTrigger.server.ts
+++ b/app/lib/lambdaTrigger.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/lib/remix.ts
+++ b/app/lib/remix.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/lib/schema-data.ts
+++ b/app/lib/schema-data.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/lib/search.server.ts
+++ b/app/lib/search.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/app/routes/_auth.login.ts
+++ b/app/routes/_auth.login.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/_auth.logout.ts
+++ b/app/routes/_auth.logout.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/_auth.post_logout.tsx
+++ b/app/routes/_auth.post_logout.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/_auth/auth.server.ts
+++ b/app/routes/_auth/auth.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/_auth/user.server.ts
+++ b/app/routes/_auth/user.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/circulars.$circularId.tsx
+++ b/app/routes/circulars.$circularId.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/circulars.$circularId[.]json.ts
+++ b/app/routes/circulars.$circularId[.]json.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/circulars.$circularId[.]txt.ts
+++ b/app/routes/circulars.$circularId[.]txt.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/circulars._index.tsx
+++ b/app/routes/circulars._index.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/circulars/route.tsx
+++ b/app/routes/circulars/route.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/docs.circulars.ts
+++ b/app/routes/docs.circulars.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/docs.contributing.ts
+++ b/app/routes/docs.contributing.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/docs.tsx
+++ b/app/routes/docs.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/docs_.schema.tsx
+++ b/app/routes/docs_.schema.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/missions.tsx
+++ b/app/routes/missions.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/quickstart._index.tsx
+++ b/app/routes/quickstart._index.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/quickstart.alerts.tsx
+++ b/app/routes/quickstart.alerts.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/quickstart.code.tsx
+++ b/app/routes/quickstart.code.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/quickstart.credentials.tsx
+++ b/app/routes/quickstart.credentials.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/quickstart.tsx
+++ b/app/routes/quickstart.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/schema.$.ts
+++ b/app/routes/schema.$.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/schema.stable.$.ts
+++ b/app/routes/schema.stable.$.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/unsubscribe.$jwt/actions.server.ts
+++ b/app/routes/unsubscribe.$jwt/actions.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/unsubscribe.$jwt/jwt.lib.ts
+++ b/app/routes/unsubscribe.$jwt/jwt.lib.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/unsubscribe.$jwt/jwt.server.ts
+++ b/app/routes/unsubscribe.$jwt/jwt.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/unsubscribe.$jwt/route.tsx
+++ b/app/routes/unsubscribe.$jwt/route.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user._index.tsx
+++ b/app/routes/user._index.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user.credentials._index.tsx
+++ b/app/routes/user.credentials._index.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user.credentials.edit.tsx
+++ b/app/routes/user.credentials.edit.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user.credentials/client_credentials.server.ts
+++ b/app/routes/user.credentials/client_credentials.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user.credentials/route.ts
+++ b/app/routes/user.credentials/route.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user.email._index.tsx
+++ b/app/routes/user.email._index.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user.email.edit.tsx
+++ b/app/routes/user.email.edit.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user.email/email_circulars.server.ts
+++ b/app/routes/user.email/email_circulars.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user.email/email_notices.server.ts
+++ b/app/routes/user.email/email_notices.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user.email/route.ts
+++ b/app/routes/user.email/route.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user.endorsements/endorsements.server.ts
+++ b/app/routes/user.endorsements/endorsements.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user.endorsements/route.tsx
+++ b/app/routes/user.endorsements/route.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user.password/password.server.ts
+++ b/app/routes/user.password/password.server.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user.password/route.tsx
+++ b/app/routes/user.password/route.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/routes/user.tsx
+++ b/app/routes/user.tsx
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/sass/custom.scss
+++ b/app/sass/custom.scss
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/app/table-streams/circulars/index.ts
+++ b/app/table-streams/circulars/index.ts
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/sandbox-search.js
+++ b/sandbox-search.js
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/plugins/email-incoming.mjs
+++ b/src/plugins/email-incoming.mjs
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/plugins/emailOutgoing.mjs
+++ b/src/plugins/emailOutgoing.mjs
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/plugins/lambdaCognitoPermissions.mjs
+++ b/src/plugins/lambdaCognitoPermissions.mjs
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/plugins/lambdaMayNotWriteToStaticBucket.mjs
+++ b/src/plugins/lambdaMayNotWriteToStaticBucket.mjs
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/plugins/missionCloudPlatform.mjs
+++ b/src/plugins/missionCloudPlatform.mjs
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/plugins/sandboxOidcIdp.mjs
+++ b/src/plugins/sandboxOidcIdp.mjs
@@ -1,7 +1,7 @@
 /*!
- * Copyright © 2022 United States Government as represented by the Administrator
- * of the National Aeronautics and Space Administration. No copyright is claimed
- * in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
This is the copyright statement that GSFC's legal counsel wants us to use now. They asked us to remove the bit about "No copyright is claimed in the United States..." because the code is written by a mix of contractors and civil servants, and not just Government employees.