### PR TITLE
Refactor latest stable schema redirect

### DIFF
--- a/app/lib/schema-data.ts
+++ b/app/lib/schema-data.ts
@@ -155,19 +155,16 @@ export async function getGithubDir(
   ).data as GitContentDataResponse[]
 }
 
+async function getDefaultBranch() {
+  return (await octokit.rest.repos.get(repoData)).data.default_branch
+}
+
 export async function getLatestRelease() {
-  let latestRelease
   try {
-    latestRelease = (await octokit.rest.repos.getLatestRelease(repoData)).data
+    return (await octokit.rest.repos.getLatestRelease(repoData)).data.tag_name
   } catch (error) {
-    if (error instanceof RequestError) {
-      if (error.status != 404) {
-        throw error
-      }
-      latestRelease = { tag_name: 'main' }
-    } else {
-      throw error
-    }
+    if (error instanceof RequestError && error.status === 404)
+      return await getDefaultBranch()
+    throw error
   }
-  return latestRelease
 }

--- a/app/routes/docs.schema.stable.$.ts
+++ b/app/routes/docs.schema.stable.$.ts
@@ -4,6 +4,5 @@ import { redirect } from '@remix-run/node'
 import { getLatestRelease } from '~/lib/schema-data'
 
 export async function loader({ params: { '*': path } }: DataFunctionArgs) {
-  const latestRelease = await getLatestRelease()
-  return redirect(`/docs/schema/${latestRelease.tag_name}/${path}`)
+  return redirect(`/docs/schema/${await getLatestRelease()}/${path}`)
 }

--- a/app/routes/schema.stable.$.ts
+++ b/app/routes/schema.stable.$.ts
@@ -5,21 +5,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Octokit } from '@octokit/rest'
 import { type DataFunctionArgs, redirect } from '@remix-run/node'
 
-const githubData = {
-  owner: 'nasa-gcn',
-  repo: 'gcn-schema',
-}
-const octokit = new Octokit()
+import { getLatestRelease } from '~/lib/schema-data'
 
 export async function loader({ params: { '*': path } }: DataFunctionArgs) {
-  const latestRelease = (await octokit.rest.repos.getLatestRelease(githubData))
-    .data
-  if (!latestRelease) throw new Response(null, { status: 404 })
-
   return redirect(
-    `https://raw.githubusercontent.com/nasa-gcn/gcn-schema/${latestRelease.tag_name}/${path}`
+    `https://raw.githubusercontent.com/nasa-gcn/gcn-schema/${await getLatestRelease()}/${path}`
   )
 }


### PR DESCRIPTION
* Combine duplicate implementations
* Get default branch name, rather than assuming that it is 'main'
* Simplify error handling
* Rename /docs/schema/latest redirect to /docs/schema/stable for consistency with /schema