### PR TITLE
Remove prettierignore symlink

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-.gitignore


### PR DESCRIPTION
Prettier uses .gitignore by default. See https://prettier.io/docs/en/cli#--ignore-path