### PR TITLE
Remove non-default route file ignores

### DIFF
--- a/remix.config.mjs
+++ b/remix.config.mjs
@@ -33,7 +33,7 @@ export default {
     remarkPlugins: [remarkGfm],
   },
   postcss: true,
-  ignoredRouteFiles: ['**/.*', '**/*.lib.*', '**/*.server.*'],
+  ignoredRouteFiles: ['**/.*'],
   assetsBuildDirectory: 'build/static',
   publicPath: '/_static/',
   server: './server.ts',


### PR DESCRIPTION
These are no longer necessary after switching to the v2 route convention.