### PR TITLE
Update minimum required version of librdkafka

### DIFF
--- a/app/components/ClientSampleCode.tsx
+++ b/app/components/ClientSampleCode.tsx
@@ -258,7 +258,7 @@ export function ClientSampleCode({
           >
             install librdkafka
           </Link>{' '}
-          version 1.9.2 or newer. Then, save the C code below to a file called{' '}
+          version 2.2.0 or newer. Then, save the C code below to a file called{' '}
           <code>example.c</code>:
           <Highlight
             language={language}


### PR DESCRIPTION
Update the minimum version of librdkafka for the C sample code to match the minimum version of confluent-kafka-python in gcn-kafka-python.