### PR TITLE
Replace .eslintignore file with @nasa-gcn/eslint-config-gitignore extension

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-.gitignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@aws-sdk/util-dynamodb": "^3.319.0",
         "@babel/preset-typescript": "^7.22.5",
         "@nasa-gcn/architect-plugin-search": "^1.0.0",
+        "@nasa-gcn/eslint-config-gitignore": "^0.0.1",
         "@remix-run/dev": "^1.19.3",
         "@remix-run/eslint-config": "^1.19.3",
         "@testing-library/jest-dom": "^6.0.0",
@@ -5543,6 +5544,18 @@
       "integrity": "sha512-JJZTaR0Emow69EVWS4CXHFmYtiJZDA++GGorUHhP8eUgj8K/Nnw9PCAKXyYj70bGougM5g/90ByXz7bwUVNHXA==",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@nasa-gcn/eslint-config-gitignore": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@nasa-gcn/eslint-config-gitignore/-/eslint-config-gitignore-0.0.1.tgz",
+      "integrity": "sha512-+T+dWsH/iB00jOaTFZnt01w4vCfmShvnkgwr9OrBMrGblcboHmLudYu/IA3df5SSi4XOmLFfrKTFbLCoAZ053g==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -28239,6 +28252,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@nasa-gcn/dynamodb-autoincrement/-/dynamodb-autoincrement-1.0.0.tgz",
       "integrity": "sha512-JJZTaR0Emow69EVWS4CXHFmYtiJZDA++GGorUHhP8eUgj8K/Nnw9PCAKXyYj70bGougM5g/90ByXz7bwUVNHXA=="
+    },
+    "@nasa-gcn/eslint-config-gitignore": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@nasa-gcn/eslint-config-gitignore/-/eslint-config-gitignore-0.0.1.tgz",
+      "integrity": "sha512-+T+dWsH/iB00jOaTFZnt01w4vCfmShvnkgwr9OrBMrGblcboHmLudYu/IA3df5SSi4XOmLFfrKTFbLCoAZ053g==",
+      "dev": true,
+      "requires": {}
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@aws-sdk/util-dynamodb": "^3.319.0",
     "@babel/preset-typescript": "^7.22.5",
     "@nasa-gcn/architect-plugin-search": "^1.0.0",
+    "@nasa-gcn/eslint-config-gitignore": "^0.0.1",
     "@remix-run/dev": "^1.19.3",
     "@remix-run/eslint-config": "^1.19.3",
     "@testing-library/jest-dom": "^6.0.0",
@@ -146,6 +147,7 @@
     "extends": [
       "@remix-run/eslint-config",
       "@remix-run/eslint-config/node",
+      "@nasa-gcn/eslint-config-gitignore",
       "prettier"
     ],
     "rules": {


### PR DESCRIPTION
One fewer file to clutter up the root of the repository.