### PR TITLE
Move hover link indicators to the right

### DIFF
--- a/app/theme.scss
+++ b/app/theme.scss
@@ -98,18 +98,21 @@ body {
  * Hover link indicator for headings (like in GitHub's display of Markdown)
  */
 
-@for $i from 1 through 6 {
-  h#{$i} > a {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  & > a {
     color: inherit;
     text-decoration: none;
   }
 
-  h#{$i} > a:hover::before {
+  & > a:hover::after {
     content: url('~/../node_modules/nasawds/src/img/usa-icons/link.svg');
-    position: relative;
-    float: left;
-    width: 0;
-    right: 30px;
+    position: absolute;
+    padding-left: 1ex;
   }
 }
 


### PR DESCRIPTION
When they were on the left, they were getting clipped off of the screen.

# Before

![Screenshot 2023-08-23 at 14 16 36](https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/fcc31768-6736-4c58-8fca-3845594546cb)

# After

![Screenshot 2023-08-23 at 14 15 39](https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/47566c8b-eae3-4e8c-8b60-0e1b1b52ebed)
