### PR TITLE
Rewrite README with descriptive info about the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # General Coordinates Network Web Site
 
+![GCN diagram](app/img/hero/center-cropped.jpg)
+
 [![Node.js CI status](https://github.com/nasa-gcn/gcn.nasa.gov/workflows/Node.js%20CI/badge.svg)](https://github.com/nasa-gcn/gcn.nasa.gov/actions)
 [![codecov](https://codecov.io/gh/nasa-gcn/gcn.nasa.gov/branch/main/graph/badge.svg?token=qBUHelfQxL)](https://codecov.io/gh/nasa-gcn/gcn.nasa.gov)
 
-This is the source code for the General Coordinates Network web site, [https://gcn.nasa.gov](https://gcn.nasa.gov). It is based upon Remix, a web framework built on React and written in TypeScript (a strongly typed superset of JavaScript). It combines the server side code (back end) and browser side code (front end) in a single codebase (sometimes called an "isomorphic application"). This project was bootstrapped using the create-remix template.
+This is the source code for the General Coordinates Network web site, [https://gcn.nasa.gov](https://gcn.nasa.gov). The General Coordinates Network (GCN) is a public collaboration platform run by NASA for the astronomy research community to share alerts and rapid communications about high-energy, multimessenger, and transient phenomena.
+
+GCN distributes alerts between space- and ground-based observatories, physics experiments, and thousands of astronomers around the world.
+
+For more information, see [What is GCN?](https://gcn.nasa.gov/docs/#what-is-gcn) or check out our [slide deck](https://nasa-gcn.github.io/gcn-presentation/).
 
 ## Getting started for local development
 


### PR DESCRIPTION
The old README text was pretty technical and didn't say what the project is about. Replace it with copy from the front page of our web site.