### PR TITLE
Use codecov in informational mode

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,9 @@
+# Use Codecov in "informational" mode: post coverage results to pull requests,
+# but do not report a failing status if the coverage decreases.
+#
+# FIXME: remove this when we have a much higher coverage fraction.
+coverage:
+  status:
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
Post coverage to pull reqeusts, but do not report a failing status if the coverage decreases.

See https://github.com/nasa-gcn/gcn.nasa.gov/pull/1245#issuecomment-1691633416.