### PR TITLE
Change name of text download button from "Raw text" to "Text"

### DIFF
--- a/app/routes/circulars._index.tsx
+++ b/app/routes/circulars._index.tsx
@@ -218,7 +218,7 @@ function DownloadModal() {
                 className="text-no-underline text-white"
                 href="/circulars/archive.txt.tar"
               >
-                Raw text
+                Text
               </a>
             </ModalToggleButton>
 


### PR DESCRIPTION
This is more consistent with the buttons on the individual Circular pages.