### PR TITLE
Explicitly set serverModuleFormat to cjs

### DIFF
--- a/remix.config.mjs
+++ b/remix.config.mjs
@@ -43,6 +43,7 @@ export default {
   server: './server.ts',
   serverBuildPath: 'build/server/index.js',
   serverMinify: isProduction,
+  serverModuleFormat: 'cjs',
   serverDependenciesToBundle: [
     ...esmOnlyModules,
     ...(isProduction ? [/^(?!@?aws-sdk(\/|$))/] : []),


### PR DESCRIPTION
This silences the following warning:

```
 warn  The default server module format is changing in v2
┃ The default format will change from `cjs` to `esm`.
┃ You can keep using `cjs` by explicitly specifying `serverModuleFormat: 'cjs'`.
┃ You can opt-in early to this change by explicitly specifying `serverModuleFormat: 'esm'`
┃ -> https://remix.run/docs/en/v1.16.0/pages/v2#servermoduleformat
┗
```