### PR TITLE
Link Circulars to ADS entries

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -13,6 +13,11 @@ circulars
 support
   src build/email-incoming/support
 
+@scheduled
+ads
+  rate 1 day
+  src build/scheduled/ads
+
 @tables-streams
 circulars
   src build/table-streams/circulars

--- a/app/routes/circulars.$circularId.tsx
+++ b/app/routes/circulars.$circularId.tsx
@@ -12,7 +12,7 @@ import type {
 } from '@remix-run/node'
 import { json } from '@remix-run/node'
 import { Link, useLoaderData } from '@remix-run/react'
-import { ButtonGroup, Grid, Icon } from '@trussworks/react-uswds'
+import { Button, ButtonGroup, Grid, Icon } from '@trussworks/react-uswds'
 
 import { formatDateISO } from './circulars/circulars.lib'
 import { get } from './circulars/circulars.server'
@@ -51,8 +51,15 @@ const submittedHowMap = {
 }
 
 export default function () {
-  const { circularId, subject, submitter, createdOn, body, submittedHow } =
-    useLoaderData<typeof loader>()
+  const {
+    circularId,
+    subject,
+    submitter,
+    createdOn,
+    body,
+    submittedHow,
+    bibcode,
+  } = useLoaderData<typeof loader>()
   const searchString = useSearchString()
   return (
     <>
@@ -82,6 +89,23 @@ export default function () {
             JSON
           </Link>
         </ButtonGroup>
+        {bibcode ? (
+          <Link
+            to={`https://ui.adsabs.harvard.edu/abs/${bibcode}`}
+            className="usa-button usa-button--outline"
+          >
+            Cite (ADS)
+          </Link>
+        ) : (
+          <Button
+            type="button"
+            disabled
+            outline
+            title="The ADS entry for this Circular is not yet available. ADS entries are updated daily. Please check back later."
+          >
+            Cite (ADS)
+          </Button>
+        )}
       </ButtonGroup>
       <h1>GCN Circular {circularId}</h1>
       <Grid row>

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -20,6 +20,7 @@ export interface Circular extends CircularMetadata {
   body: string
   submitter: string
   submittedHow?: SubmittedHow
+  bibcode?: string
 }
 
 type SubjectMatcher = [RegExp, (match: RegExpMatchArray) => string]

--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -17,6 +17,8 @@ Upon successful submission and distribution, a GCN Circulars is assigned a numbe
 
 The [SAO/NASA Astrophysics Data System (ADS)](https://ui.adsabs.harvard.edu) ingests and indexes all GCN Circulars. You can use ADS to get bibliographic records for GCN Circulars to cite them in a publication.
 
+When you are viewing a GCN Circular in the archive, you can click the "Cite (ADS)" button to go to the ADS entry for that Circular. Note that ADS entries are updated once a day, so the button may be disabled for GCN Circulars that were posted less than 24 hours ago.
+
 ## GCN Viewer
 
 The [GCN Viewer](https://heasarc.gsfc.nasa.gov/wsgi-scripts/tach/gcn_v2/tach.wsgi/) also automatically ingests and parses GCN Circulars, sorting them by astronomical event, and associates them with their [GCN Notices](/notices).

--- a/app/routes/docs.contributing.configuration/route.mdx
+++ b/app/routes/docs.contributing.configuration/route.mdx
@@ -103,6 +103,14 @@ _All_ environment variables are _optional in local development_. _All_ environme
       <Default>Zendesk API disabled</Default>
     </tr>
     <tr>
+      <Key>`ADS_TOKEN`</Key>
+      <Description>
+        [Astrophysics Data System (ADS)](https://ui.adsabs.harvard.edu) API
+        token
+      </Description>
+      <Default>ADS disabled</Default>
+    </tr>
+    <tr>
       <Key>`GCN_FEATURES`</Key>
       <Description>
         [Feature flags](feature-flags) (for example,

--- a/app/scheduled/ads/index.ts
+++ b/app/scheduled/ads/index.ts
@@ -1,0 +1,71 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { tables } from '@architect/functions'
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
+
+import { getEnvOrDie } from '~/lib/env.server'
+
+const adsToken = getEnvOrDie('ADS_TOKEN')
+
+async function* getAdsEntries() {
+  const url = new URL('https://api.adsabs.harvard.edu/v1/search/query')
+  url.searchParams.set('q', 'bibstem:GCN')
+  url.searchParams.set('fl', 'bibcode,volume')
+  url.searchParams.set('rows', '2000')
+  let start = 0
+  let length
+
+  let items: { bibcode: string; volume: string }[]
+  do {
+    const result = await fetch(url, {
+      headers: { Authorization: `Bearer ${adsToken}` },
+    })
+    if (!result.ok)
+      throw new Error(`${url.toString()} returned HTTP status ${result.status}`)
+
+    items = (await result.json()).response.docs
+    length = items.length
+    start += length
+    url.searchParams.set('start', start.toString())
+
+    yield items.map(({ bibcode, volume }) => ({
+      bibcode,
+      circularId: Number(volume.replace('a', '.5')),
+    }))
+  } while (length)
+}
+
+// FIXME: must use module.exports here for OpenTelemetry shim to work correctly.
+// See https://dev.to/heymarkkop/how-to-solve-cannot-redefine-property-handler-on-aws-lambda-3j67
+module.exports.handler = async () => {
+  const db = await tables()
+  for await (const entries of getAdsEntries()) {
+    await Promise.all(
+      entries.map(async ({ bibcode, circularId }) => {
+        try {
+          await db.circulars.update({
+            ConditionExpression: 'attribute_exists(circularId)',
+            ExpressionAttributeValues: {
+              ':bibcode': bibcode,
+            },
+            Key: { circularId },
+            UpdateExpression: 'set bibcode = :bibcode',
+          })
+        } catch (e) {
+          if (e instanceof ConditionalCheckFailedException) {
+            console.error(
+              `Attempted to update Circular ${circularId}, which does not exist in DynamoDB`
+            )
+          } else {
+            throw e
+          }
+        }
+      })
+    )
+  }
+}

--- a/build/scheduled/ads/config.arc
+++ b/build/scheduled/ads/config.arc
@@ -1,0 +1,2 @@
+@aws
+timeout 900

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -4,7 +4,7 @@ import { glob } from 'glob'
 const args = process.argv.slice(2)
 const dev = args.includes('--dev')
 const entryPoints = await glob(
-  './app/{email-incoming,table-streams}/*/index.ts'
+  './app/{email-incoming,scheduled,table-streams}/*/index.ts'
 )
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@architect/plugin-storage-private": "^1.0.1",
         "@architect/utils": "^3.1.9",
         "@aws-sdk/client-cognito-identity-provider": "^3.319.0",
+        "@aws-sdk/client-dynamodb": "^3.319.0",
         "@aws-sdk/client-s3": "^3.319.0",
         "@aws-sdk/client-sesv2": "^3.319.0",
         "@aws-sdk/lib-dynamodb": "^3.319.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@architect/plugin-storage-private": "^1.0.1",
     "@architect/utils": "^3.1.9",
     "@aws-sdk/client-cognito-identity-provider": "^3.319.0",
+    "@aws-sdk/client-dynamodb": "^3.319.0",
     "@aws-sdk/client-s3": "^3.319.0",
     "@aws-sdk/client-sesv2": "^3.319.0",
     "@aws-sdk/lib-dynamodb": "^3.319.0",


### PR DESCRIPTION
Harvest bibcodes from ADS once a day and link them to GCN Circulars.

Fixes #1231.