### PR TITLE
Update ADS weekly

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -15,7 +15,7 @@ support
 
 @scheduled
 ads
-  rate 1 day
+  cron 0 8 * * MON *
   src build/scheduled/ads
 
 @tables-streams

--- a/app/routes/circulars.$circularId.tsx
+++ b/app/routes/circulars.$circularId.tsx
@@ -101,7 +101,7 @@ export default function () {
             type="button"
             disabled
             outline
-            title="The ADS entry for this Circular is not yet available. ADS entries are updated daily. Please check back later."
+            title="The ADS entry for this Circular is not yet available. ADS entries are updated every week on Monday at 08:00 UTC. Please check back later."
           >
             Cite (ADS)
           </Button>

--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -17,7 +17,7 @@ Upon successful submission and distribution, a GCN Circulars is assigned a numbe
 
 The [SAO/NASA Astrophysics Data System (ADS)](https://ui.adsabs.harvard.edu) ingests and indexes all GCN Circulars. You can use ADS to get bibliographic records for GCN Circulars to cite them in a publication.
 
-When you are viewing a GCN Circular in the archive, you can click the "Cite (ADS)" button to go to the ADS entry for that Circular. Note that ADS entries are updated once a day, so the button may be disabled for GCN Circulars that were posted less than 24 hours ago.
+When you are viewing a GCN Circular in the archive, you can click the "Cite (ADS)" button to go to the ADS entry for that Circular. Note that ADS entries are updated every Monday at 08:00 UTC, so the button may be disabled for the most recent GCN Circulars.
 
 ## GCN Viewer
 


### PR DESCRIPTION
According to ADS, they harvest new GCN Circulars once a week on Friday. They take a while to ingest, so we harvest bibcodes on Monday.