### PR TITLE
Deploy static assets to a subdir of the static bucket

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -25,6 +25,7 @@ circulars
 @static
 fingerprint external
 folder build/static
+prefix app
 
 @tables
 client_credentials
@@ -121,7 +122,7 @@ volumeSize 10
 plugin-remix
 sandboxOidcIdp  # Sandbox identity provider
 lambdaCognitoPermissions  # Grant the Lambda function access to Cognito to run the credential vending machine.
-lambdaMayNotWriteToStaticBucket  # the Lambda function should not be able to modify the static bucket
+lambdaMayNotWriteToStaticBucket  # the Lambda function should not be able to modify the deployment folder in the static bucket
 missionCloudPlatform  # Custom permissions for deployment on Mission Cloud Platform
 emailOutgoing  # Grant the Lambda function permission to send email; add email templates.
 email-incoming  # Enable Lambda handlers for incoming emails

--- a/remix.config.mjs
+++ b/remix.config.mjs
@@ -39,7 +39,9 @@ export default {
   postcss: true,
   ignoredRouteFiles: ['**/.*'],
   assetsBuildDirectory: 'build/static',
-  publicPath: '/_static/',
+  // FIXME: Architect currently does not respect the 'prefix' setting in sandbox mode.
+  // See https://github.com/architect/architect/issues/1450
+  publicPath: isProduction ? '/_static/app/' : '/_static/',
   server: './server.ts',
   serverBuildPath: 'build/server/index.js',
   serverMinify: isProduction,

--- a/src/plugins/lambdaMayNotWriteToStaticBucket.mjs
+++ b/src/plugins/lambdaMayNotWriteToStaticBucket.mjs
@@ -6,15 +6,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// The Lambda function should not be able to modify the static bucket.
+// The Lambda function should not be able to modify the deployment folder in the static bucket.
 export const deploy = {
   start({ cloudformation }) {
-    cloudformation.Resources.Role.Properties.Policies =
-      cloudformation.Resources.Role.Properties.Policies.map((policy) => {
-        if (policy.PolicyName == 'ArcStaticBucketPolicy')
-          policy.PolicyDocument.Statement[0].Action = ['s3:GetObject']
-        return policy
-      })
+    cloudformation.Resources.Role.Properties.Policies.push({
+      PolicyName: 'ArcStaticBucketDenyWriteAppDirectoryPolicy',
+      PolicyDocument: {
+        Statement: [
+          {
+            Effect: 'Deny',
+            Action: ['s3:PutObject', 's3:PutObjectAcl', 's3:DeleteObject'],
+            Resource: [
+              {
+                'Fn::Sub': [
+                  `arn:aws:s3:::\${bukkit}/app/*`,
+                  {
+                    bukkit: {
+                      Ref: 'StaticBucket',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
     return cloudformation
   },
 }


### PR DESCRIPTION
Upload built assets to the app/ directory of the static bucket.

The Lambdas themselves can now write to the bucket with the exception of the app/ directory.

See #1316.