### PR TITLE
Track Remix v2 fetcher API change

### DIFF
--- a/app/routes/user.email._index/route.tsx
+++ b/app/routes/user.email._index/route.tsx
@@ -72,7 +72,7 @@ function CircularsSubscriptionForm({ value }: { value: boolean }) {
   const fetcher = useFetcher<typeof action>()
 
   let valuePending
-  switch (fetcher.submission?.formData?.get('intent')?.toString()) {
+  switch (fetcher.formData?.get('intent')?.toString()) {
     case 'subscribe':
       valuePending = true
       break


### PR DESCRIPTION
`fetcher.submission.formData` is now `fetcher.formData`. See https://remix.run/docs/en/main/pages/v2#usefetcher