### PR TITLE
Disallow 'SUBJECT:' in GCN Circulars subject

### DIFF
--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -180,6 +180,7 @@ export const emailAutoReplyChecklist = [
   'fwd: ',
   ' r: ',
   ' ris: ',
+  'subject:',
 ]
 
 export function formatAuthor({


### PR DESCRIPTION
This is a common copy-paste error.