### PR TITLE
Clean up GCN Circulars archive Lambda

### DIFF
--- a/__tests__/circulars.ts
+++ b/__tests__/circulars.ts
@@ -11,7 +11,7 @@ import {
   bodyIsValid,
   emailIsAutoReply,
   formatAuthor,
-  formatCircular,
+  formatCircularText,
   parseEventFromSubject,
   subjectIsValid,
 } from '../app/routes/circulars/circulars.lib'
@@ -43,7 +43,7 @@ describe('formatAuthor', () => {
 describe('formatCircular', () => {
   test('formats a toy circular', () => {
     expect(
-      formatCircular({
+      formatCircularText({
         circularId: 123,
         subject: 'GRB 170817A: The most amazing GRB ever',
         body: "You're never going to believe this...",

--- a/app/routes/circulars.$circularId[.]json.ts
+++ b/app/routes/circulars.$circularId[.]json.ts
@@ -6,20 +6,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { DataFunctionArgs } from '@remix-run/node'
-import { json } from '@remix-run/node'
+import invariant from 'tiny-invariant'
 
+import { formatCircularJson } from './circulars/circulars.lib'
 import { get } from './circulars/circulars.server'
 import { origin } from '~/lib/env.server'
 import { getCanonicalUrlHeaders } from '~/lib/headers.server'
 
 export async function loader({ params: { circularId } }: DataFunctionArgs) {
-  if (!circularId)
-    throw new Response('circularId must be defined', { status: 400 })
+  invariant(circularId)
   const result = await get(parseFloat(circularId))
-  delete result.sub
-  return json(result, {
-    headers: getCanonicalUrlHeaders(
-      new URL(`/circulars/${circularId}`, origin)
-    ),
+  return new Response(formatCircularJson(result), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      ...getCanonicalUrlHeaders(new URL(`/circulars/${circularId}`, origin)),
+    },
   })
 }

--- a/app/routes/circulars.$circularId[.]txt.ts
+++ b/app/routes/circulars.$circularId[.]txt.ts
@@ -6,18 +6,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { DataFunctionArgs } from '@remix-run/node'
+import invariant from 'tiny-invariant'
 
-import { formatCircular } from './circulars/circulars.lib'
+import { formatCircularText } from './circulars/circulars.lib'
 import { get } from './circulars/circulars.server'
 import { origin } from '~/lib/env.server'
 import { getCanonicalUrlHeaders } from '~/lib/headers.server'
 
 export async function loader({ params: { circularId } }: DataFunctionArgs) {
-  if (!circularId)
-    throw new Response('circularId must be defined', { status: 400 })
+  invariant(circularId)
   const result = await get(parseFloat(circularId))
-  delete result.sub
-  return new Response(formatCircular(result), {
+  return new Response(formatCircularText(result), {
     headers: getCanonicalUrlHeaders(
       new URL(`/circulars/${circularId}`, origin)
     ),

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -47,7 +47,7 @@ const subjectMatchers: SubjectMatcher[] = [
 ]
 
 /** Format a Circular as plain text. */
-export function formatCircular({
+export function formatCircularText({
   circularId,
   subject,
   createdOn,
@@ -73,6 +73,11 @@ export function formatCircular({
 
   ${body}
   `
+}
+
+/** Format a Circular as JSON. */
+export function formatCircularJson({ sub, ...props }: Circular) {
+  return JSON.stringify(props, null, 2)
 }
 
 /** Convert a date to an ISO 8601 string with seconds precision. */

--- a/app/scheduled/circulars/circularAction.ts
+++ b/app/scheduled/circulars/circularAction.ts
@@ -8,7 +8,7 @@
 import type { Circular } from '~/routes/circulars/circulars.lib'
 
 export interface CircularAction<T = any> {
-  initialize: () => Promise<T>
-  action: (circulars: Circular[], context: T) => Promise<void>
-  finalize: (context: T) => Promise<void>
+  initialize: () => T | Promise<T>
+  action: (circulars: Circular[], context: T) => void | Promise<void>
+  finalize: (context: T) => void | Promise<void>
 }

--- a/app/scheduled/circulars/uploadTar.ts
+++ b/app/scheduled/circulars/uploadTar.ts
@@ -5,120 +5,52 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
-import { createReadableStreamFromReadable } from '@remix-run/node'
-import { Readable } from 'stream'
+import { S3Client } from '@aws-sdk/client-s3'
+import { Upload } from '@aws-sdk/lib-storage'
+import { PassThrough } from 'node:stream'
 import type { Pack } from 'tar-stream'
 import { pack as tarPack } from 'tar-stream'
 
 import type { CircularAction } from './circularAction'
 import { getEnvOrDie } from '~/lib/env.server'
 import type { Circular } from '~/routes/circulars/circulars.lib'
-import { formatCircular } from '~/routes/circulars/circulars.lib'
-
-interface TarContext {
-  pack: Pack
-  tarStream: Readable | ReadableStream<Uint8Array>
-  fileType: string
-}
-
-const formatters: Record<string, (circular: Circular) => string> = {
-  json({ sub, ...circular }) {
-    return JSON.stringify(circular, null, 2)
-  },
-  txt: formatCircular,
-}
+import {
+  formatCircularJson,
+  formatCircularText,
+} from '~/routes/circulars/circulars.lib'
 
 const s3 = new S3Client({})
 const Bucket = getEnvOrDie('ARC_STATIC_BUCKET')
 
-async function uploadStream(tarContext: TarContext) {
-  await s3.send(
-    new PutObjectCommand({
-      Bucket,
-      Key: `circulars.archive.${tarContext.fileType}.tar`,
-      Body: tarContext.tarStream,
-    })
-  )
-}
+function createUploadAction(
+  suffix: string,
+  formatter: (circular: Circular) => string
+): CircularAction<{ pack: Pack; promise: Promise<any> }> {
+  const baseFilename = `circulars-archive.${suffix}`
 
-export async function makeTarFile({
-  pack,
-  circulars,
-  fileType,
-}: {
-  pack: Pack
-  circulars: Circular[]
-  fileType: 'txt' | 'json'
-}) {
-  const formatter = formatters[fileType]
-  for (const circular of circulars) {
-    const name = `archive.${fileType}/${circular.circularId}.${fileType}`
-    pack.entry({ name }, formatter(circular)).end()
+  return {
+    initialize() {
+      const pack = tarPack()
+      const Body = new PassThrough()
+      pack.pipe(Body)
+      const promise = new Upload({
+        client: s3,
+        params: { Body, Bucket, Key: `${baseFilename}.tar` },
+      }).done()
+      return { pack, promise }
+    },
+    action(circulars, { pack }) {
+      for (const circular of circulars) {
+        const name = `${baseFilename}/${circular.circularId}.${suffix}`
+        pack.entry({ name }, formatter(circular)).end()
+      }
+    },
+    async finalize({ pack, promise }) {
+      pack.finalize()
+      await promise
+    },
   }
 }
 
-export async function setupTar() {
-  const tarStream = new Readable({
-    read() {},
-  })
-
-  const pack = tarPack()
-
-  pack.on('error', (err: Error) => {
-    tarStream.emit('error', err)
-  })
-
-  pack.on('data', (chunk: Uint8Array) => {
-    tarStream.push(chunk)
-  })
-
-  pack.on('end', () => {
-    tarStream.push(null)
-  })
-
-  return { pack, tarStream } as TarContext
-}
-
-export async function finalizeTar(context: TarContext) {
-  context.pack.finalize()
-  const readableTar = createReadableStreamFromReadable(
-    Readable.from(context.tarStream as Readable)
-  )
-  await uploadStream({
-    pack: context.pack,
-    tarStream: readableTar,
-    fileType: context.fileType,
-  })
-}
-
-export async function uploadTxtTar(circulars: Circular[], context: TarContext) {
-  return await makeTarFile({
-    pack: context.pack,
-    circulars,
-    fileType: 'txt',
-  })
-}
-
-export async function uploadJsonTar(
-  circulars: Circular[],
-  context: TarContext
-) {
-  return await makeTarFile({
-    pack: context.pack,
-    circulars,
-    fileType: 'json',
-  })
-}
-
-export const jsonUploadAction: CircularAction<TarContext> = {
-  action: uploadJsonTar,
-  initialize: setupTar,
-  finalize: finalizeTar,
-}
-
-export const txtUploadAction: CircularAction<TarContext> = {
-  action: uploadTxtTar,
-  initialize: setupTar,
-  finalize: finalizeTar,
-}
+export const jsonUploadAction = createUploadAction('json', formatCircularJson)
+export const txtUploadAction = createUploadAction('txt', formatCircularText)

--- a/app/table-streams/circulars/index.ts
+++ b/app/table-streams/circulars/index.ts
@@ -20,7 +20,7 @@ import { sendEmailBulk } from '~/lib/email.server'
 import { createTriggerHandler } from '~/lib/lambdaTrigger.server'
 import { search as getSearchClient } from '~/lib/search.server'
 import type { Circular } from '~/routes/circulars/circulars.lib'
-import { formatCircular } from '~/routes/circulars/circulars.lib'
+import { formatCircularText } from '~/routes/circulars/circulars.lib'
 
 const index = 'circulars'
 const fromName = 'GCN Circulars'
@@ -99,7 +99,7 @@ async function send(circular: Circular) {
     fromName,
     to,
     subject: circular.subject,
-    body: formatCircular(circular),
+    body: formatCircularText(circular),
     topic: 'circulars',
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@aws-sdk/client-s3": "^3.319.0",
         "@aws-sdk/client-sesv2": "^3.319.0",
         "@aws-sdk/lib-dynamodb": "^3.319.0",
+        "@aws-sdk/lib-storage": "^3.319.0",
         "@aws-sdk/util-dynamodb": "^3.319.0",
         "@babel/preset-typescript": "^7.22.11",
         "@nasa-gcn/architect-plugin-search": "^1.0.0",
@@ -3315,6 +3316,46 @@
         "@aws-sdk/client-dynamodb": "^3.0.0",
         "@aws-sdk/smithy-client": "^3.0.0",
         "@aws-sdk/types": "^3.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage": {
+      "version": "3.405.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.405.0.tgz",
+      "integrity": "sha512-K0m4Q5KaRjL/KTlWNFmU1y2Xyh6lpOtEXu42ZijETNecp19J9dCBhxQpNur7svV3X76Ad/Qdr6vHTVhKXmipdA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^2.0.1",
+        "@smithy/middleware-endpoint": "^2.0.5",
+        "@smithy/smithy-client": "^2.0.5",
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-s3": "^3.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage/node_modules/buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "dev": true,
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/@aws-sdk/md5-js": {
@@ -24552,6 +24593,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/stream-browserify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/stream-shift": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
@@ -29800,6 +29865,39 @@
       "requires": {
         "@aws-sdk/util-dynamodb": "3.360.0",
         "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/lib-storage": {
+      "version": "3.405.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.405.0.tgz",
+      "integrity": "sha512-K0m4Q5KaRjL/KTlWNFmU1y2Xyh6lpOtEXu42ZijETNecp19J9dCBhxQpNur7svV3X76Ad/Qdr6vHTVhKXmipdA==",
+      "dev": true,
+      "requires": {
+        "@smithy/abort-controller": "^2.0.1",
+        "@smithy/middleware-endpoint": "^2.0.5",
+        "@smithy/smithy-client": "^2.0.5",
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "events": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+          "dev": true
+        }
       }
     },
     "@aws-sdk/md5-js": {
@@ -45512,6 +45610,29 @@
       "dev": true,
       "requires": {
         "internal-slot": "^1.0.4"
+      }
+    },
+    "stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "stream-shift": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@aws-sdk/client-s3": "^3.319.0",
     "@aws-sdk/client-sesv2": "^3.319.0",
     "@aws-sdk/lib-dynamodb": "^3.319.0",
+    "@aws-sdk/lib-storage": "^3.319.0",
     "@aws-sdk/util-dynamodb": "^3.319.0",
     "@babel/preset-typescript": "^7.22.11",
     "@nasa-gcn/architect-plugin-search": "^1.0.0",


### PR DESCRIPTION
- Refactor the action into a closure to simplify the code
- Refactor the endpoint for retrieving an individual GCN Circular as JSON so that the formatting is consistent with the tarball
- Stream the tarball to S3 to decrease memory usage
- Allow, but do not require, action callbacks to be promises