### PR TITLE
Add redirect to Circulars archive tarballs in static bucket

### DIFF
--- a/app/lib/env.server.ts
+++ b/app/lib/env.server.ts
@@ -50,10 +50,23 @@ function getSessionSecret() {
   return getEnvOrDieInProduction('SESSION_SECRET') || 'fallback-secret-for-dev'
 }
 
+function getStaticBucket() {
+  return getEnvOrDie('ARC_STATIC_BUCKET')
+}
+
+function getRegion() {
+  const result = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION
+  if (!result)
+    throw new Error('Either AWS_REGION or AWS_DEFAULT_REGION must be defined')
+  return result
+}
+
 export const origin = /* @__PURE__ */ getOrigin()
 export const hostname = /* @__PURE__ */ getHostname()
 export const features = /* @__PURE__ */ getFeatures()
 export const sessionSecret = /* @__PURE__ */ getSessionSecret()
+export const staticBucket = /* @__PURE__ */ getStaticBucket()
+export const region = /* @__PURE__ */ getRegion()
 
 /**
  * Return true if the given feature flag is enabled.

--- a/app/routes/circulars._index.tsx
+++ b/app/routes/circulars._index.tsx
@@ -211,7 +211,6 @@ function DownloadModal() {
           <p id="modal-1-description">
             This is a download of the entire GCN Circulars database.
           </p>
-          <p>It may take a moment.</p>
           <p>Select a file format to begin download.</p>
         </div>
         <ModalFooter>

--- a/app/routes/circulars.archive.$suffix[.]tar.ts
+++ b/app/routes/circulars.archive.$suffix[.]tar.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { type LoaderArgs, redirect } from '@remix-run/node'
+import invariant from 'tiny-invariant'
+
+import { region, staticBucket } from '~/lib/env.server'
+import { getBucketKey } from '~/scheduled/circulars/uploadTar'
+
+function getBucketUrl(region: string, bucket: string, key: string) {
+  return `https://s3.${region}.amazonaws.com/${bucket}/key`
+}
+
+export async function loader({ params: { suffix } }: LoaderArgs) {
+  invariant(suffix)
+  return redirect(getBucketUrl(region, staticBucket, getBucketKey(suffix)))
+}


### PR DESCRIPTION
API Gateways have a limit on response size of 10 MB, so we cannot rely on the API Gateway to server the Circulars archive.