### PR TITLE
Display Circular text in monospace font

### DIFF
--- a/app/routes/circulars.$circularId/route.tsx
+++ b/app/routes/circulars.$circularId/route.tsx
@@ -137,7 +137,7 @@ export default function () {
           <Grid col="fill">{submittedHowMap[submittedHow]}</Grid>
         </Grid>
       )}
-      <div className="text-pre-wrap margin-top-2">
+      <div className="text-pre-wrap font-mono-sm">
         <Body>{body}</Body>
       </div>
     </>


### PR DESCRIPTION
Circulars frequently contain ASCII art tables which only display correctly with a monospace font.

When we start supporting Markdown, we'll want to display Circulars that are in plain text in a monospaced font but Circulars that are entered as Markdown in a variable-width sans-serif font (i.e., the default body text of the web site).