### PR TITLE
Preserve leading whitespace in GCN Circulars

### DIFF
--- a/app/routes/circulars.$circularId/PlainTextBody.module.scss
+++ b/app/routes/circulars.$circularId/PlainTextBody.module.scss
@@ -1,0 +1,9 @@
+.PlainTextBody {
+  &,
+  & pre,
+  & code {
+    font-size: 0.95rem;
+    white-space: pre-wrap;
+    background: none;
+  }
+}

--- a/app/routes/circulars.$circularId/PlainTextBody.tsx
+++ b/app/routes/circulars.$circularId/PlainTextBody.tsx
@@ -16,6 +16,8 @@ import { u } from 'unist-builder'
 
 import rehypeAutolinkLiteral from './rehypeAutolinkLiteral'
 
+import styles from './PlainTextBody.module.css'
+
 /** A Unified.js parser plugin that just returns a canned tree. */
 const remarkFromMdast: Plugin<[Root], string, Root> = function (tree) {
   this.Parser = () => tree
@@ -60,10 +62,10 @@ function AstroData({
   }
 }
 
-export function Body({ children }: { children: string }) {
-  const tree = u('root', [u('paragraph', [u('text', children)])])
+export function PlainTextBody({ children }: { children: string }) {
+  const tree = u('root', [u('code', children)])
 
-  return unified()
+  const { result } = unified()
     .use(remarkFromMdast, tree)
     .use(remarkRehype)
     .use(rehypeAstro)
@@ -73,5 +75,7 @@ export function Body({ children }: { children: string }) {
       createElement,
       components: { a: LinkWrapper, data: AstroData },
     })
-    .processSync().result
+    .processSync()
+
+  return <div className={styles.PlainTextBody}>{result}</div>
 }

--- a/app/routes/circulars.$circularId/route.tsx
+++ b/app/routes/circulars.$circularId/route.tsx
@@ -12,7 +12,7 @@ import { Button, ButtonGroup, Grid, Icon } from '@trussworks/react-uswds'
 
 import { formatDateISO } from '../circulars/circulars.lib'
 import { get } from '../circulars/circulars.server'
-import { Body } from './body'
+import { PlainTextBody } from './PlainTextBody'
 import TimeAgo from '~/components/TimeAgo'
 import { origin } from '~/lib/env.server'
 import { getCanonicalUrlHeaders, pickHeaders } from '~/lib/headers.server'
@@ -137,9 +137,7 @@ export default function () {
           <Grid col="fill">{submittedHowMap[submittedHow]}</Grid>
         </Grid>
       )}
-      <div className="text-pre-wrap font-mono-sm">
-        <Body>{body}</Body>
-      </div>
+      <PlainTextBody>{body}</PlainTextBody>
     </>
   )
 }


### PR DESCRIPTION
Some GCN Circulars (particularly MASTER ones) contain ASCII art tables with leading whitespace. Make sure that leading whitespace is preserved.

# Before

![Screenshot 2023-09-19 at 21 48 42](https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/e2436074-c7a9-4d2c-a7f1-e78b5360d93a)

# After

![Screenshot 2023-09-19 at 21 47 50](https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/846a69e9-48b5-4647-b916-d8bfe4e44f81)
