### PR TITLE
Ignore version.txt in build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 /build/static
 /build/**/metafile.*
 /build/**/index.*
+/build/**/version.txt
 /coverage
 *.tsbuildinfo
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev": "run-p \"dev:*\"",
     "prepare": "husky install",
     "deploy": "arc deploy --no-hydrate --prune --production",
-    "clean": "rimraf --glob build/static app/css \"build/**/index.*\" \"build/**/metafile.*\" \"app/**/*.css\" \"app/**/*.css.map\" sam.json sam.yaml .cache",
+    "clean": "rimraf --glob build/static app/css \"build/**/index.*\" \"build/**/metafile.*\" \"build/**/version.txt\" \"app/**/*.css\" \"app/**/*.css.map\" sam.json sam.yaml .cache",
     "test": "jest",
     "test-coverage": "jest --coverage",
     "typecheck": "tsc"


### PR DESCRIPTION
Remix 2.0.0 generates this file when we run `npm run dev`. Ignore it.