### PR TITLE
Remove workaround for asset imports from node_modules

### DIFF
--- a/app/components/Spinner.tsx
+++ b/app/components/Spinner.tsx
@@ -7,7 +7,7 @@
  */
 import classnames from 'classnames'
 
-import loaderImage from '~/../node_modules/nasawds/src/img/loader.gif'
+import loaderImage from 'nasawds/src/img/loader.gif'
 
 // Adapted from https://github.com/trussworks/react-uswds/blob/main/src/components/Icon/Icon.tsx
 export default function Spinner({

--- a/app/components/nested-checkboxes/nested-checkboxes.module.scss
+++ b/app/components/nested-checkboxes/nested-checkboxes.module.scss
@@ -1,10 +1,10 @@
 .node {
   & {
-    list-style: url('~/../node_modules/nasawds/src/img/usa-icons/chevron_right.svg');
+    list-style: url('nasawds/src/img/usa-icons/chevron_right.svg');
   }
 
   &[aria-expanded='true'] {
-    list-style: url('~/../node_modules/nasawds/src/img/usa-icons/expand_more.svg');
+    list-style: url('nasawds/src/img/usa-icons/expand_more.svg');
   }
 
   & [data-testid='checkbox'] {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -67,13 +67,13 @@ import highlightStyle from 'highlight.js/styles/github.css'
 //     ])
 //   )
 // )
-import favicon_16 from '~/../node_modules/nasawds/src/img/favicons/favicon-16.png'
-import favicon_40 from '~/../node_modules/nasawds/src/img/favicons/favicon-40.png'
-import favicon_57 from '~/../node_modules/nasawds/src/img/favicons/favicon-57.png'
-import favicon_72 from '~/../node_modules/nasawds/src/img/favicons/favicon-72.png'
-import favicon_114 from '~/../node_modules/nasawds/src/img/favicons/favicon-114.png'
-import favicon_144 from '~/../node_modules/nasawds/src/img/favicons/favicon-144.png'
-import favicon_192 from '~/../node_modules/nasawds/src/img/favicons/favicon-192.png'
+import favicon_16 from 'nasawds/src/img/favicons/favicon-16.png'
+import favicon_40 from 'nasawds/src/img/favicons/favicon-40.png'
+import favicon_57 from 'nasawds/src/img/favicons/favicon-57.png'
+import favicon_72 from 'nasawds/src/img/favicons/favicon-72.png'
+import favicon_114 from 'nasawds/src/img/favicons/favicon-114.png'
+import favicon_144 from 'nasawds/src/img/favicons/favicon-144.png'
+import favicon_192 from 'nasawds/src/img/favicons/favicon-192.png'
 import themeStyle from '~/theme.css'
 
 const favicons = {

--- a/app/routes/circulars._index.tsx
+++ b/app/routes/circulars._index.tsx
@@ -37,7 +37,7 @@ import { Anchor } from '~/components/Anchor'
 import Hint from '~/components/Hint'
 import { usePagination } from '~/lib/pagination'
 
-import searchImg from '~/../node_modules/nasawds/src/img/usa-icons-bg/search--white.svg'
+import searchImg from 'nasawds/src/img/usa-icons-bg/search--white.svg'
 
 export async function loader({ request: { url } }: DataFunctionArgs) {
   const { searchParams } = new URL(url)

--- a/app/routes/user.endorsements/route.tsx
+++ b/app/routes/user.endorsements/route.tsx
@@ -39,7 +39,7 @@ import SegmentedCards from '~/components/SegmentedCards'
 import { getFormDataString } from '~/lib/utils'
 import type { BreadcrumbHandle } from '~/root/Title'
 
-import loaderImage from '~/../node_modules/nasawds/src/img/loader.gif'
+import loaderImage from 'nasawds/src/img/loader.gif'
 
 export const handle: BreadcrumbHandle & SEOHandle = {
   breadcrumb: 'Peer Endorsements',

--- a/app/theme.scss
+++ b/app/theme.scss
@@ -8,8 +8,8 @@
 
 @use 'styles' with (
   $theme-show-notifications: false,
-  $theme-image-path: '~/../node_modules/nasawds/src/img',
-  $theme-font-path: '~/../node_modules/nasawds/src/fonts'
+  $theme-image-path: 'nasawds/src/img',
+  $theme-font-path: 'nasawds/src/fonts'
 );
 
 @use 'uswds-core' as *;
@@ -110,7 +110,7 @@ h6 {
   }
 
   & > a:hover::after {
-    content: url('~/../node_modules/nasawds/src/img/usa-icons/link.svg');
+    content: url('nasawds/src/img/usa-icons/link.svg');
     position: absolute;
     padding-left: 1ex;
   }


### PR DESCRIPTION
This workaround is no longer needed because https://github.com/remix-run/remix/pull/6813 has been fixed upstream.