### PR TITLE
Add all GCN Circulars to site map

### DIFF
--- a/app/lib/sitemap.server.ts
+++ b/app/lib/sitemap.server.ts
@@ -1,0 +1,79 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import invariant from 'tiny-invariant'
+
+/**
+ * The maximum number of URLs in a sitemap.
+ *
+ * See https://www.sitemaps.org/protocol.html#index
+ */
+export const maxEntriesPerSitemap = 50_000
+
+/**
+ * Create an XML response.
+ *
+ * Prepend the standard XML declaration to the content and set the MIME type in
+ * the HTTP response headers.
+ */
+export function xml(content: string, init?: ResponseInit) {
+  const headers = new Headers(init?.headers)
+  headers.set('Content-Type', 'application/xml; charset=utf-8')
+  return new Response(`<?xml version="1.0" encoding="UTF-8"?>${content}`, {
+    ...init,
+    headers,
+  })
+}
+
+function sitemapEntry(url: string) {
+  return `<url><loc>${url}</loc><priority>0.7</priority></url>`
+}
+
+/**
+ * Create a site map.
+ *
+ * See https://www.sitemaps.org/protocol.html#index
+ */
+export function sitemap(urls: string[], init?: ResponseInit) {
+  invariant(urls.length <= maxEntriesPerSitemap)
+  return xml(
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls
+      .map(sitemapEntry)
+      .join('')}</urlset>`,
+    init
+  )
+}
+
+type SitemapIndexProps = {
+  url: string
+  lastModified?: number
+}
+
+function sitemapIndexEntry({ url, lastModified }: SitemapIndexProps) {
+  return `<sitemap><loc>${url}</loc>${
+    lastModified === undefined
+      ? ''
+      : `<lastmod>${new Date(lastModified).toISOString()}</lastmod>`
+  }</sitemap>`
+}
+
+/**
+ * Create a site map index, a directory of individual site maps.
+ *
+ * A sitemap index allows you to have multiple sitemaps, in case your site has
+ * more pages than the maximum number of URLs per sitemap.
+ *
+ * See https://www.sitemaps.org/protocol.html#index
+ */
+export function sitemapIndex(props: SitemapIndexProps[], init?: ResponseInit) {
+  return xml(
+    `<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${props
+      .map(sitemapIndexEntry)
+      .join('')}</sitemapindex>`,
+    init
+  )
+}

--- a/app/routes/_seo.robots[.]txt.ts
+++ b/app/routes/_seo.robots[.]txt.ts
@@ -11,7 +11,7 @@ import { origin } from '~/lib/env.server'
 
 export function loader() {
   return generateRobotsTxt([
-    { type: 'sitemap', value: `${origin}/sitemap.xml` },
+    { type: 'sitemap', value: `${origin}/sitemap_index.xml` },
     { type: 'disallow', value: '/user' },
   ])
 }

--- a/app/routes/_seo.sitemap_index[.]xml.ts
+++ b/app/routes/_seo.sitemap_index[.]xml.ts
@@ -1,0 +1,33 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ListObjectsV2Command } from '@aws-sdk/client-s3'
+
+import { staticBucket as Bucket, origin } from '~/lib/env.server'
+import { sitemapIndex } from '~/lib/sitemap.server'
+import { Prefix } from '~/scheduled/circulars/actions/sitemap'
+import { s3 } from '~/scheduled/circulars/storage'
+
+async function getCircularsSitemapEntries() {
+  const response = await s3.send(new ListObjectsV2Command({ Bucket, Prefix }))
+  return (
+    response.Contents?.map(({ Key }) => ({
+      url: `${origin}/_static/${Prefix}/${Key}`,
+    })) ?? []
+  )
+}
+
+export async function loader() {
+  return sitemapIndex(
+    [{ url: `${origin}/sitemap.xml` }, ...(await getCircularsSitemapEntries())],
+    {
+      headers: {
+        'Cache-Control': `public, max-age=${60 * 5}`,
+      },
+    }
+  )
+}

--- a/app/scheduled/circulars/actions/sitemap.ts
+++ b/app/scheduled/circulars/actions/sitemap.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { PutObjectCommand } from '@aws-sdk/client-s3'
+
+import type { CircularAction } from '../actions'
+import { Prefix as parentPrefix, s3 } from '../storage'
+import { staticBucket as Bucket, origin } from '~/lib/env.server'
+import { maxEntriesPerSitemap, sitemap } from '~/lib/sitemap.server'
+import type { Circular } from '~/routes/circulars/circulars.lib'
+
+type SitemapContext = {
+  items: Circular[]
+  page: number
+}
+
+export const Prefix = `${parentPrefix}/sitemap`
+
+async function flush(context: SitemapContext) {
+  const Key = `${Prefix}/${context.page}.xml`
+  const response = sitemap(
+    context.items.map(({ circularId }) => `${origin}/circulars/${circularId}`)
+  )
+  const Body = await response.text()
+  await s3.send(new PutObjectCommand({ Body, Bucket, Key }))
+  context.items.length = 0
+  context.page += 1
+}
+
+export const sitemapAction: CircularAction<SitemapContext> = {
+  initialize() {
+    return { items: [], page: 0 }
+  },
+  async action(newItems, context) {
+    do {
+      const count = maxEntriesPerSitemap - context.items.length
+      context.items.push(...newItems.slice(0, count))
+      newItems.splice(0, count)
+      if (context.items.length >= maxEntriesPerSitemap) await flush(context)
+    } while (newItems.length)
+  },
+  async finalize(context) {
+    if (context.items.length) await flush(context)
+  },
+}

--- a/app/scheduled/circulars/actions/stats.ts
+++ b/app/scheduled/circulars/actions/stats.ts
@@ -8,10 +8,10 @@
 import { PutObjectCommand } from '@aws-sdk/client-s3'
 
 import type { CircularAction } from '../actions'
-import { keyPrefix, s3 } from '../storage'
+import { Prefix, s3 } from '../storage'
 import { staticBucket as Bucket } from '~/lib/env.server'
 
-const Key = `${keyPrefix}/stats.json`
+const Key = `${Prefix}/stats.json`
 
 export const statsAction: CircularAction<Record<string, number>> = {
   initialize() {

--- a/app/scheduled/circulars/actions/tar.ts
+++ b/app/scheduled/circulars/actions/tar.ts
@@ -13,7 +13,7 @@ import type { Pack } from 'tar-stream'
 import { pack as tarPack } from 'tar-stream'
 
 import type { CircularAction } from '../actions'
-import { keyPrefix, s3 } from '../storage'
+import { Prefix, s3 } from '../storage'
 import { staticBucket as Bucket, region } from '~/lib/env.server'
 import type { Circular } from '~/routes/circulars/circulars.lib'
 import {
@@ -24,7 +24,7 @@ import {
 const archiveSuffix = '.tar.gz'
 
 function getBucketKey(suffix: string) {
-  return `${keyPrefix}/archive.${suffix}${archiveSuffix}`
+  return `${Prefix}/archive.${suffix}${archiveSuffix}`
 }
 
 function getBucketUrl(region: string, bucket: string, key: string) {

--- a/app/scheduled/circulars/index.ts
+++ b/app/scheduled/circulars/index.ts
@@ -6,9 +6,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { forAllCirculars } from './actions'
+import { sitemapAction } from './actions/sitemap'
 import { statsAction } from './actions/stats'
 import { jsonUploadAction, txtUploadAction } from './actions/tar'
 
 export async function handler() {
-  await forAllCirculars(jsonUploadAction, txtUploadAction, statsAction)
+  await forAllCirculars(
+    jsonUploadAction,
+    txtUploadAction,
+    statsAction,
+    sitemapAction
+  )
 }

--- a/app/scheduled/circulars/storage.ts
+++ b/app/scheduled/circulars/storage.ts
@@ -8,4 +8,4 @@
 import { S3Client } from '@aws-sdk/client-s3'
 
 export const s3 = new S3Client({})
-export const keyPrefix = 'generated/circulars'
+export const Prefix = 'generated/circulars'


### PR DESCRIPTION
- Every night, generate site maps for GCN Circulars in batches of 50,000 and save them to the S3 bucket.
- Add a site map index which lists the GCN Circulars site map files and the auto-generated site map route.