### PR TITLE
Update government shutdown FAQ

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -226,9 +226,9 @@ function Document({ children }: { children?: React.ReactNode }) {
         <DevBanner />
         <Header />
         <NewsBanner>
-          Notes on GCN service during a U.S. federal government shutdown. See{' '}
-          <Link to="/docs/faq#does-gcn-keep-working-during-a-us-federal-government-shutdown">
-            Frequently Asked Questions
+          New GCN Circulars features for September 2023! See{' '}
+          <Link to="/news#new-features-for-september-2023">
+            news and announcements
           </Link>
         </NewsBanner>
         <main id="main-content">{children}</main>

--- a/app/routes/docs.faq.md
+++ b/app/routes/docs.faq.md
@@ -88,9 +88,7 @@ If you had a GCN Circulars account prior to April 17, 2023, your account was mig
 
 ### Does GCN keep working during a U.S. federal government shutdown?
 
-**Yes.** All GCN services (GCN Circulars, GCN Notices, Kafka cluster, the web site) remain fully operational during a U.S. federal government shutdown. During a government shutdown, essential GCN personnel remain on call to monitor GCN operations and intervene in the event of incidents, outages, or emergencies.
-
-However, there are some minor impacts to GCN users during a government shutdown:
+**Yes.** During a U.S. federal government shutdown, all GCN services (GCN Circulars, GCN Notices, Kafka cluster, the web site) remain fully operational. However, there may be the following minor impacts to GCN users:
 
 - Responses to questions and requests through the [GCN help desk](/contact) may be delayed.
 - Issues and pull requests on https://github.com/nasa-gcn repositories may not be promptly reviewed.


### PR DESCRIPTION
- Reset the news banner for now. We'll change it as part of orderly shutdown activities if there _is_ a shutdown.
- Remove the sentene about people being on call, at the suggestion of Liz Hays.