### PR TITLE
Add Atom feed for most recent GCN Circulars

### DIFF
--- a/app/routes/_seo.sitemap_index[.]xml.ts
+++ b/app/routes/_seo.sitemap_index[.]xml.ts
@@ -23,7 +23,11 @@ async function getCircularsSitemapEntries() {
 
 export async function loader() {
   return sitemapIndex(
-    [{ url: `${origin}/sitemap.xml` }, ...(await getCircularsSitemapEntries())],
+    [
+      { url: `${origin}/sitemap.xml` },
+      { url: `${origin}/circulars.atom` },
+      ...(await getCircularsSitemapEntries()),
+    ],
     {
       headers: {
         'Cache-Control': `public, max-age=${60 * 5}`,

--- a/app/routes/circulars[.]atom.ts
+++ b/app/routes/circulars[.]atom.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { CircularMetadata } from './circulars/circulars.lib'
+import { search } from './circulars/circulars.server'
+import { origin } from '~/lib/env.server'
+import { xml } from '~/lib/sitemap.server'
+
+function feedEntry({ circularId }: CircularMetadata) {
+  return `<entry><link href="${origin}/circulars/${circularId}"></link></entry>`
+}
+
+export async function loader() {
+  const { items } = await search({})
+  return xml(
+    `<feed xmlns="https://www.w3.org/2005/Atom">${items
+      .map(feedEntry)
+      .join('')}</feed>`,
+    {
+      headers: { 'Cache-Control': `public, max-age=${60 * 5}` },
+    }
+  )
+}


### PR DESCRIPTION
According to https://developers.google.com/search/blog/2014/10/best-practices-for-xml-sitemaps-rssatom#important-fields:

> Generating both XML sitemaps and Atom/RSS feeds is a great way to optimize crawling of a site for Google and other search engines.