### PR TITLE
Remove overly general word break CSS rule for anchors

### DIFF
--- a/app/theme.scss
+++ b/app/theme.scss
@@ -375,9 +375,6 @@ input.react-tags__combobox-input:focus {
 /*
   General Responsiveness in missions page
 */
-a {
-  word-break: break-word;
-}
 
 .overflow-table {
   overflow-x: scroll;


### PR DESCRIPTION
This was causing weird spacing on anchors that have the usa-button class. Removing this doesn't seem to have any negative effects on layout.

# Before

<img width="686" alt="Screenshot 2023-10-03 at 15 09 33" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/510cb9b5-d414-45e6-b797-4554b4f99e72">

# After

<img width="686" alt="Screenshot 2023-10-03 at 15 09 00" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/b561bb88-0854-4bcd-badd-9b204b660544">
