### PR TITLE
Refactor root meta function as meta tags

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -19,11 +19,7 @@
  *
  */
 import { cssBundleHref } from '@remix-run/css-bundle'
-import type {
-  DataFunctionArgs,
-  LinksFunction,
-  MetaFunction,
-} from '@remix-run/node'
+import type { DataFunctionArgs, LinksFunction } from '@remix-run/node'
 import {
   Link,
   Links,
@@ -96,17 +92,6 @@ TopBarProgress.config({
 
 export const handle: BreadcrumbHandle = {
   breadcrumb: 'GCN',
-}
-
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
-  const result = [
-    { charset: 'utf-8' },
-    { name: 'viewport', content: 'width=device-width,initial-scale=1' },
-  ]
-  // Exclude non-production deployments from indexing by search engines
-  if (data && new URL(data.origin).hostname !== 'gcn.nasa.gov')
-    result.push({ name: 'robots', content: 'noindex' })
-  return result
 }
 
 export const links: LinksFunction = () => [
@@ -210,9 +195,14 @@ function Progress() {
 }
 
 function Document({ children }: { children?: React.ReactNode }) {
+  const noIndex = useHostname() !== 'gcn.nasa.gov'
+
   return (
     <html lang="en-US">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        {noIndex && <meta name="robots" content="noindex" />}
         <Meta />
         <Links />
         <Title />


### PR DESCRIPTION
This refactoring will make it simpler to add SEO metadata to routes because it will avoid having to merge meta function outputs.

According to https://remix.run/docs/en/main/route/meta#global-meta:

> Nearly every app will have global meta like the viewport and
> charSet. We recommend using normal <meta> tags inside the root
> route instead of the meta export, so you simply don't have to
> deal with merging.