### PR TITLE
Fix visual artifact due to doubled breadcrumb

### DIFF
--- a/app/routes/docs_._schema-browser.schema.($version).$/BreadcrumbNav.tsx
+++ b/app/routes/docs_._schema-browser.schema.($version).$/BreadcrumbNav.tsx
@@ -39,10 +39,8 @@ export default function BreadcrumbNav({
           )
         })}
       </>
-      <Breadcrumb>
-        <Breadcrumb current>
-          <h2 className="margin-y-0 display-inline">{lastBreadcrumb}</h2>
-        </Breadcrumb>
+      <Breadcrumb current>
+        <h2 className="margin-y-0 display-inline">{lastBreadcrumb}</h2>
       </Breadcrumb>
     </BreadcrumbBar>
   )


### PR DESCRIPTION
# Before
<img width="274" alt="Screenshot 2023-10-06 at 12 28 59" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/63778400-bec6-4546-987a-1e2306e83595">

# After
<img width="266" alt="Screenshot 2023-10-06 at 12 29 55" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/5f680add-2088-49ad-9b74-33396b0224f5">
