### PR TITLE
Enable fuzzy full text searches for GCN Circulars

### DIFF
--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -127,6 +127,7 @@ export async function search({
                 multi_match: {
                   query,
                   fields: ['submitter', 'subject', 'body'],
+                  fuzziness: 'AUTO',
                 },
               }
             : undefined,


### PR DESCRIPTION
# Before

<img width="1207" alt="Screenshot 2023-10-11 at 15 40 04" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/f6f33c2f-6590-44dc-88ac-f3495d3eaa15">

# After

<img width="1207" alt="Screenshot 2023-10-11 at 15 39 48" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/5d4ebd79-0c8c-40b0-8dcc-1d33ac68be17">
