### PR TITLE
Remove rel="external" from AstroData links

### DIFF
--- a/app/routes/circulars.$circularId/AstroData.components.tsx
+++ b/app/routes/circulars.$circularId/AstroData.components.tsx
@@ -20,11 +20,7 @@ export function GcnCircular({
 
 export function Arxiv({ children, value }: JSX.IntrinsicElements['data']) {
   return (
-    <a
-      className="usa-link"
-      rel="external"
-      href={`https://arxiv.org/abs/${value}`}
-    >
+    <a className="usa-link" href={`https://arxiv.org/abs/${value}`}>
       {children}
     </a>
   )
@@ -32,7 +28,7 @@ export function Arxiv({ children, value }: JSX.IntrinsicElements['data']) {
 
 export function Doi({ children, value }: JSX.IntrinsicElements['data']) {
   return (
-    <a className="usa-link" rel="external" href={`https://doi.org/${value}`}>
+    <a className="usa-link" href={`https://doi.org/${value}`}>
       {children}
     </a>
   )
@@ -40,11 +36,7 @@ export function Doi({ children, value }: JSX.IntrinsicElements['data']) {
 
 export function Tns({ children, value }: JSX.IntrinsicElements['data']) {
   return (
-    <a
-      className="usa-link"
-      rel="external"
-      href={`https://www.wis-tns.org/object/${value}`}
-    >
+    <a className="usa-link" href={`https://www.wis-tns.org/object/${value}`}>
       {children}
     </a>
   )


### PR DESCRIPTION
GCN Circulars frequently rely on monospaced ASCII tables, and the external link icon disrupts layout.

# Example

<img width="1207" alt="Screenshot 2023-10-11 at 15 47 18" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/9fb29a41-2dbb-41a8-a946-f07935da9597">
