### PR TITLE
Allow cognito-idp:AdminGetUser AWS IAM action

### DIFF
--- a/src/plugins/lambdaCognitoPermissions.js
+++ b/src/plugins/lambdaCognitoPermissions.js
@@ -25,6 +25,7 @@ export const deploy = {
             Effect: 'Allow',
             Action: [
               'cognito-idp:AdminAddUserToGroup',
+              'cognito-idp:AdminGetUser',
               'cognito-idp:AdminListGroupsForUser',
               'cognito-idp:CreateUserPoolClient',
               'cognito-idp:DeleteUserPoolClient',


### PR DESCRIPTION
The Circulars API endpoint uses it.