### PR TITLE
Fix indeterminate checkbox state in JSON notice type format tab

### DIFF
--- a/app/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes.tsx
+++ b/app/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes.tsx
@@ -234,6 +234,7 @@ export function NoticeTypeCheckboxes({
   return (
     <>
       <NestedCheckboxes
+        key={selectedFormat}
         nodes={Object.entries(
           selectedFormat == 'json' ? JsonNoticeTypes : NoticeTypes
         ).map(([mission, noticeTypes]) => ({

--- a/app/components/nested-checkboxes/NestedCheckboxes.tsx
+++ b/app/components/nested-checkboxes/NestedCheckboxes.tsx
@@ -112,7 +112,7 @@ function NestedCheckboxNode({
       />
       <ul hidden={!expanded} className={styles.leaf}>
         {nodes.map((node, index) => (
-          <li role="treeitem" key={index} aria-selected={false}>
+          <li role="treeitem" key={node.id} aria-selected={false}>
             <Checkbox
               {...node}
               inputRef={(instance) => {
@@ -142,9 +142,9 @@ export function NestedCheckboxes({
 }: NestedCheckboxesProps) {
   return (
     <ul role="tree" aria-multiselectable>
-      {nodes.map((node, index) => (
+      {nodes.map((node) => (
         <NestedCheckboxNode
-          key={index}
+          key={node.id}
           {...node}
           childoncheckhandler={childoncheckhandler}
         />


### PR DESCRIPTION
The problem was that the `childValues` state was being shared between checkbox groups on different tabs that happened to have the same name.

Fix this by giving the React elements distinct keys so that they have distinct states.

Fixes #1538.