### PR TITLE
Install remix-flat-routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,7 @@
         "rehype-highlight": "^7.0.0",
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^3.0.1",
+        "remix-flat-routes": "^0.6.1",
         "rimraf": "^5.0.0",
         "sass": "^1.64.2",
         "ts-jest": "^29.1.0",
@@ -5906,6 +5907,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remix-run/v1-route-convention": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/v1-route-convention/-/v1-route-convention-0.1.4.tgz",
+      "integrity": "sha512-fVTr9YlNLWfaiM/6Y56sOtcY8x1bBJQHY0sDWO5+Z/vjJ2Ni7fe2fwrzs1jUFciMPXqBQdFGePnkuiYLz3cuUA==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^7.4.3"
+      },
+      "peerDependencies": {
+        "@remix-run/dev": "^1.15.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@remix-run/v1-route-convention/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@remix-run/v1-route-convention/node_modules/minimatch": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@remix-run/web-blob": {
@@ -20663,6 +20700,43 @@
       "integrity": "sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==",
       "dependencies": {
         "@types/unist": "^2"
+      }
+    },
+    "node_modules/remix-flat-routes": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/remix-flat-routes/-/remix-flat-routes-0.6.1.tgz",
+      "integrity": "sha512-7QlTjezVCSD1JCONRaEjINVfrkvl29gb9CXzSe6mvUsVvNmVNZ+nJMNTQaUYdDyEtnH9UGUq7NhafK2CHg3RrQ==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/v1-route-convention": "^0.1.3",
+        "minimatch": "^5.1.0"
+      },
+      "bin": {
+        "migrate-flat-routes": "dist/cli.js"
+      },
+      "peerDependencies": {
+        "@remix-run/dev": "^1.15.0 || ^2"
+      }
+    },
+    "node_modules/remix-flat-routes/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/remix-flat-routes/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "rehype-highlight": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^3.0.1",
+    "remix-flat-routes": "^0.6.1",
     "rimraf": "^5.0.0",
     "sass": "^1.64.2",
     "ts-jest": "^29.1.0",

--- a/remix.config.js
+++ b/remix.config.js
@@ -4,6 +4,7 @@ import rehypeExternalLinks from 'rehype-external-links'
 import rehypeHighlight from 'rehype-highlight'
 import rehypeSlug from 'rehype-slug'
 import remarkGfm from 'remark-gfm'
+import { flatRoutes } from 'remix-flat-routes'
 
 const isProduction = process.env.NODE_ENV === 'production'
 
@@ -60,7 +61,10 @@ export default {
     remarkPlugins: [remarkGfm],
   },
   postcss: true,
-  ignoredRouteFiles: ['**/.*'],
+  ignoredRouteFiles: ['**/*'],
+  routes(defineRoutes) {
+    return flatRoutes('routes', defineRoutes)
+  },
   assetsBuildDirectory: 'build/static',
   publicPath: '/_static/app/',
   server: './server.ts',


### PR DESCRIPTION
This will allow us to create an organizational folder for gcn.nasa.gov/labs.

See https://github.com/kiliman/remix-flat-routes#nested-folders-with-flat-files-convention--new-in-v051