### PR TITLE
Fix zero rate estimate display for JSON notice types

### DIFF
--- a/app/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes.tsx
+++ b/app/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes.tsx
@@ -256,7 +256,9 @@ export function NoticeTypeCheckboxes({
                   <small className="text-base-light">
                     {humanizedRate(
                       triggerRate[
-                        `gcn.classic.${selectedFormat}.${noticeType}`
+                        selectedFormat === 'json'
+                          ? noticeType
+                          : `gcn.classic.${selectedFormat}.${noticeType}`
                       ] ?? 0,
                       'alert'
                     )}


### PR DESCRIPTION
We were using the wrong key to look up the rates.