### PR TITLE
Ignore dotfiles in app/routes directory

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -61,9 +61,9 @@ export default {
     remarkPlugins: [remarkGfm],
   },
   postcss: true,
-  ignoredRouteFiles: ['**/*'],
+  ignoredRouteFiles: ['**/*', '**/.*'],
   routes(defineRoutes) {
-    return flatRoutes('routes', defineRoutes)
+    return flatRoutes('routes', defineRoutes, { ignoredRouteFiles: ['**/.*'] })
   },
   assetsBuildDirectory: 'build/static',
   publicPath: '/_static/app/',


### PR DESCRIPTION
@jracusin found that the Remix build was failing if there were dot files in the app/routes directory (i.e., .DS_Store metadata files on macOS). This workaround fixes it.

See https://github.com/remix-run/remix/discussions/6256#discussioncomment-5864190.