### PR TITLE
Schema browser maintenance

### DIFF
--- a/app/lib/schema-data.server.ts
+++ b/app/lib/schema-data.server.ts
@@ -120,17 +120,25 @@ export type GitContentDataResponse = {
   children?: GitContentDataResponse[]
 }
 
+function normalizeExampleName(name: string, schemaName: string) {
+  name = name.slice(schemaName.length, -exampleSuffix.length)
+  if (name.startsWith('.')) name = name.slice(1)
+  name ||= 'Example'
+  return name
+}
+
 export const loadSchemaExamples = memoizee(
   async function (schemaPath: string, ref: string): Promise<ExampleFile[]> {
     const dirPath = dirname(schemaPath)
-    const prefix = `${basename(schemaPath, schemaSuffix)}.`
+    const schemaName = basename(schemaPath, schemaSuffix)
+    const prefix = `${schemaName}.`
     const exampleFiles = (await getGithubDir(dirPath, ref)).filter(
       (x) => x.name.startsWith(prefix) && x.name.endsWith(exampleSuffix)
     )
 
     return await Promise.all(
       exampleFiles.map(async ({ name }) => ({
-        name: name.replace(exampleSuffix, ''),
+        name: normalizeExampleName(name, schemaName),
         content: await loadContentFromGithub(join(dirPath, name), ref),
       }))
     )

--- a/app/lib/schema-data.server.ts
+++ b/app/lib/schema-data.server.ts
@@ -12,6 +12,7 @@ import { basename, dirname, extname, join } from 'path'
 import { relative } from 'path/posix'
 
 import { getEnvOrDieInProduction } from './env.server'
+import { exampleSuffix } from './schema-data'
 import type {
   ReferencedSchema,
   Schema,
@@ -126,7 +127,7 @@ export const loadSchemaExamples = memoizee(
     const exampleFiles = (await getGithubDir(dirPath, ref)).filter(
       (x) =>
         x.name.startsWith(`${schemaName.split('.')[0]}.`) &&
-        x.name.endsWith('.example.json')
+        x.name.endsWith(exampleSuffix)
     )
 
     const result: ExampleFile[] = []
@@ -134,7 +135,7 @@ export const loadSchemaExamples = memoizee(
       const exPath = join(dirPath, exampleFile.name)
       const example = await loadContentFromGithub(exPath, ref)
       result.push({
-        name: exampleFile.name.replace('.example.json', ''),
+        name: exampleFile.name.replace(exampleSuffix, ''),
         content: example,
       })
     }

--- a/app/lib/schema-data.ts
+++ b/app/lib/schema-data.ts
@@ -1,0 +1,10 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const schemaSuffix = '.schema.json'
+export const exampleSuffix = '.example.json'

--- a/app/routes/docs_._schema-browser.schema.($version).$/route.tsx
+++ b/app/routes/docs_._schema-browser.schema.($version).$/route.tsx
@@ -37,6 +37,7 @@ import DetailsDropdownContent from '~/components/DetailsDropdownContent'
 import { Highlight } from '~/components/Highlight'
 import { Tab, Tabs } from '~/components/tabs/Tabs'
 import { publicStaticShortTermCacheControlHeaders } from '~/lib/headers.server'
+import { exampleSuffix, schemaSuffix } from '~/lib/schema-data'
 import type {
   ExampleFile,
   GitContentDataResponse,
@@ -51,7 +52,7 @@ import type { BreadcrumbHandle } from '~/root/Title'
 
 export const handle: BreadcrumbHandle = {
   breadcrumb({ params: { version, '*': path } }) {
-    return `${version} - ${path?.replace('.schema.json', '')}`
+    return `${version} - ${path?.replace(schemaSuffix, '')}`
   },
 }
 
@@ -78,7 +79,7 @@ export async function loader({
   } else {
     data = await getGithubDir(path, version)
   }
-  data = data.filter((x) => !x.name.endsWith('.example.json'))
+  data = data.filter((x) => !x.name.endsWith(exampleSuffix))
   return json(
     { data, jsonContent, examples },
     { headers: publicStaticShortTermCacheControlHeaders }
@@ -178,7 +179,7 @@ export default function () {
           className="flex-align-self-center padding-y-1"
         >
           <Breadcrumbs
-            path={path.replace('.schema.json', '')}
+            path={path.replace(schemaSuffix, '')}
             className="font-ui-lg"
           />
         </Grid>


### PR DESCRIPTION
- Factor out schema suffixes as reusable constants
- Parallelize fetching of examples
- Provide default example name if none present in filename