### PR TITLE
Increase session cookie max age to 30 days

### DIFF
--- a/app/routes/_auth/auth.server.ts
+++ b/app/routes/_auth/auth.server.ts
@@ -40,7 +40,7 @@ export const storage = createArcTableSessionStorage({
     secure: process.env.NODE_ENV === 'production',
     secrets: [sessionSecret],
     path: '/',
-    maxAge: 3600,
+    maxAge: 30 * 24 * 3600,
     httpOnly: true,
   },
   table: 'sessions',


### PR DESCRIPTION
This is the currently configured lifetime of our refresh tokens.