### PR TITLE
Set Python tab size to 4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "[python]": {
+    "editor.tabSize": 4
+  },
   "editor.tabSize": 2,
   "javascript.format.semicolons": "remove",
   "typescript.preferences.quoteStyle": "single",


### PR DESCRIPTION
A tab size of 2 is pretty normal for JavaScript, but Python codes typicaly use 4. We are using Black to format Python code, and Black uses 4-space tabs.