### PR TITLE
Fix route ID of parent laoder for version refs

### DIFF
--- a/app/routes/_gcn.docs_._schema-browser.schema.($version).$/route.tsx
+++ b/app/routes/_gcn.docs_._schema-browser.schema.($version).$/route.tsx
@@ -164,9 +164,8 @@ export default function () {
   const { version, '*': path } = useParams()
   const { data, jsonContent, examples } = useLoaderData<typeof loader>()
   const versions = useRouteLoaderData<typeof parentLoader>(
-    'routes/docs_._schema-browser'
+    'routes/_gcn.docs_._schema-browser'
   )
-
   invariant(version)
   invariant(path)
   invariant(versions)


### PR DESCRIPTION
Fixes an issue where the versions would fail the invariant check, which would break the schema browser pages