### PR TITLE
Fix for broken Swift/BAT GUANO schema links.

### DIFF
--- a/app/routes/_gcn.missions.swift/route.mdx
+++ b/app/routes/_gcn.missions.swift/route.mdx
@@ -285,11 +285,11 @@ These are bursts that did not result in any of the automatic GCN Notices describ
 
 These notices are published on the GCN Kafka topic `gcn.notices.swift.bat.guano`.
 
-The [GCN schema](/schema/stable/gcn/notices/swift/bat/guano.schema.json) and
-example [JSON message](/schema/stable/gcn/notices/swift/bat/guano.example.json) files
-are available to use. See our [Schema Browser](/docs/schema/stable/gcn/notices/swift/bat/guano.example.json) for more information on the properties defined in the schema.
+The [GCN schema](/schema/stable/gcn/notices/swift/bat/Guano.schema.json) and
+example [JSON message](/schema/stable/gcn/notices/swift/bat/Guano.example.json) files
+are available to use. See our [Schema Browser](/docs/schema/stable/gcn/notices/swift/bat/Guano.schema.json) for more information on the properties defined in the schema.
 
-[Detailed Description and Examples](https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/swift/bat/guano)
+[Detailed Description and Examples](https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/swift/bat)
 
 <div className="overflow-table">
 


### PR DESCRIPTION
Links to the GUANO schema were incorrect. This pull attempts to fix that, fixing three issues:

* Links to the schema on GitHub were corrected so guano -> Guano (note uppercase G)
* Link to Schema Browser was to the incorrect filename "guano.example.json", which is fixed to "Guano.schema.json".
* [Detailed Description and Examples](https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/swift/bat) linked to a non-existent "guano". This now links to the "bat".

~~Quick note: Schema Browser does not work in my dev environment, so I cannot verify the fix.~~ Schema Browser link verified to work.