### PR TITLE
Fix Python hydration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -180,98 +180,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@architect/architect/node_modules/@architect/sandbox": {
-      "version": "5.8.2",
-      "resolved": "git+ssh://git@github.com/lpsinger/sandbox.git#7fc5aa7b31c5848524021660c1ed436a5ecdd01a",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@architect/asap": "~6.0.3",
-        "@architect/create": "~4.2.3",
-        "@architect/hydrate": "~3.3.0",
-        "@architect/inventory": "~3.6.1",
-        "@architect/utils": "~3.1.9",
-        "@aws-sdk/client-apigatewaymanagementapi": "^3.316.0",
-        "@aws-sdk/client-dynamodb": "^3.316.0",
-        "@aws-sdk/client-s3": "^3.316.0",
-        "@aws-sdk/client-sns": "^3.316.0",
-        "@aws-sdk/client-sqs": "^3.316.0",
-        "@aws-sdk/client-ssm": "^3.316.0",
-        "@aws-sdk/lib-dynamodb": "^3.316.0",
-        "@aws-sdk/node-http-handler": "^3.360.0",
-        "@begin/hashid": "~1.0.0",
-        "aws-sdk": "^2.1363.0",
-        "chalk": "4.1.2",
-        "chokidar": "~3.5.3",
-        "depstatus": "~1.1.1",
-        "dynalite": "~3.2.2",
-        "finalhandler": "~1.2.0",
-        "glob": "~10.3.3",
-        "http-proxy": "~1.18.1",
-        "lambda-runtimes": "~1.1.4",
-        "minimist": "~1.2.8",
-        "router": "~1.3.8",
-        "run-parallel": "~1.2.0",
-        "run-series": "~1.1.9",
-        "send": "~0.18.0",
-        "server-destroy": "~1.0.1",
-        "tmp": "~0.2.1",
-        "tree-kill": "~1.2.2",
-        "update-notifier-cjs": "~5.1.6",
-        "ws": "~8.13.0"
-      },
-      "bin": {
-        "sandbox": "src/cli/cli.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@architect/architect/node_modules/@architect/sandbox/node_modules/@architect/hydrate": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@architect/hydrate/-/hydrate-3.3.1.tgz",
-      "integrity": "sha512-1glad5yjXZhJdp5T730k4iTXo6pOSjt+NUfFi6u2V8AAcm6CC+w/VXL5thJ1gbjUGQtUT7+KPuBTnnylKcVWuQ==",
-      "dev": true,
-      "dependencies": {
-        "@architect/inventory": "~3.6.0",
-        "@architect/utils": "~3.1.9",
-        "acorn-loose": "~8.3.0",
-        "chalk": "4.1.2",
-        "cpr": "~3.0.1",
-        "esquery": "~1.5.0",
-        "glob": "~10.3.3",
-        "minimist": "~1.2.8",
-        "run-series": "~1.1.9",
-        "symlink-or-copy": "~1.3.1"
-      },
-      "bin": {
-        "arc-hydrate": "src/cli.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@architect/architect/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@architect/asap": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@architect/asap/-/asap-6.0.3.tgz",
@@ -431,15 +339,15 @@
       }
     },
     "node_modules/@architect/inventory": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@architect/inventory/-/inventory-3.6.2.tgz",
-      "integrity": "sha512-YUeTu4tAuSIav8qQke5lXavx+gIGgRSn53B3ruO/nYUmvWGat3zlmxw0XSdg+2Z9U+V/1uYo0tq7ReYnlwqGRg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@architect/inventory/-/inventory-3.6.3.tgz",
+      "integrity": "sha512-1CsN4NEUOENNPgGqsZ0f5vLXjTPzNNyihRE0h+aFjChduS3Y9AOMYxWWM0S+gsvRhV2LTqxvufJIgPza1Vyc0w==",
       "dev": true,
       "dependencies": {
-        "@architect/asap": "~6.0.0",
-        "@architect/parser": "~6.0.2",
-        "@architect/utils": "~3.1.7",
-        "lambda-runtimes": "~1.1.4"
+        "@architect/asap": "~6.0.3",
+        "@architect/parser": "~6.0.3",
+        "@architect/utils": "~3.1.9",
+        "lambda-runtimes": "~1.1.6"
       },
       "engines": {
         "node": ">=14"
@@ -501,6 +409,72 @@
       },
       "engines": {
         "node": ">=14.17.0"
+      }
+    },
+    "node_modules/@architect/sandbox": {
+      "version": "5.9.3",
+      "resolved": "git+ssh://git@github.com/lpsinger/sandbox.git#d814be46940d784a2e08a846a03e26b1c8b312c7",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@architect/asap": "~6.0.3",
+        "@architect/create": "~4.2.4",
+        "@architect/hydrate": "~3.5.0",
+        "@architect/inventory": "~3.6.3",
+        "@architect/utils": "~3.1.9",
+        "@aws-sdk/client-apigatewaymanagementapi": "^3.316.0",
+        "@aws-sdk/client-dynamodb": "^3.316.0",
+        "@aws-sdk/client-s3": "^3.316.0",
+        "@aws-sdk/client-sns": "^3.316.0",
+        "@aws-sdk/client-sqs": "^3.316.0",
+        "@aws-sdk/client-ssm": "^3.316.0",
+        "@aws-sdk/lib-dynamodb": "^3.316.0",
+        "@aws-sdk/node-http-handler": "^3.360.0",
+        "@begin/hashid": "~1.0.0",
+        "aws-sdk": "^2.1363.0",
+        "chalk": "4.1.2",
+        "chokidar": "~3.5.3",
+        "depstatus": "~1.1.1",
+        "dynalite": "~3.2.2",
+        "finalhandler": "~1.2.0",
+        "glob": "~10.3.10",
+        "http-proxy": "~1.18.1",
+        "lambda-runtimes": "~1.1.6",
+        "minimist": "~1.2.8",
+        "router": "~1.3.8",
+        "run-parallel": "~1.2.0",
+        "run-series": "~1.1.9",
+        "send": "~0.18.0",
+        "server-destroy": "~1.0.1",
+        "tmp": "~0.2.1",
+        "tree-kill": "~1.2.2",
+        "update-notifier-cjs": "~5.1.6",
+        "ws": "~8.14.2"
+      },
+      "bin": {
+        "sandbox": "src/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@architect/sandbox/node_modules/@architect/create": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@architect/create/-/create-4.2.4.tgz",
+      "integrity": "sha512-jwi/Im0FaMUpLtpkxpOWew7uBsJJGHLvUCq5QGgYh2HSzmPzYoA9/5jPcVMV3VnvfiqDpv/Il1j+r1jo6C4tNw==",
+      "dev": true,
+      "dependencies": {
+        "@architect/inventory": "~3.6.3",
+        "@architect/utils": "~3.1.9",
+        "chalk": "4.1.2",
+        "lambda-runtimes": "~1.1.6",
+        "minimist": "~1.2.8"
+      },
+      "bin": {
+        "arc-create": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@architect/utils": {
@@ -17266,9 +17240,9 @@
       }
     },
     "node_modules/lambda-runtimes": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/lambda-runtimes/-/lambda-runtimes-1.1.5.tgz",
-      "integrity": "sha512-EXW6OcDdTVoSjuoV27vq0XynZ2W12CQ//rVyqCiI7PekR7XixvI5l8dfzGtR4h054bS2PocCQQFnZqFtA+11SA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lambda-runtimes/-/lambda-runtimes-1.1.6.tgz",
+      "integrity": "sha512-nMYTto/eIzj/5XnPosp2f/3DjyGh+lSz5orxnHx6mBGgCDJCbxTgG/qKGxA8haODiOyg3v4+xONsFRSXAkQTfg==",
       "dev": true,
       "engines": {
         "node": ">=14"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,3 @@
+astropy
+fastapi
+mangum

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-astropy
 black
-fastapi
-mangum
-pipdeptree
 pytest
+-r python/requirements.txt


### PR DESCRIPTION
Don't use Architect's automatic Python tree-shaking support because it cannot detect imports of modules defined inside the Lambda. It invariably tries to find a matching package installed with pip.

Fixes #1678.