### PR TITLE
Throw, not return, 404 response for disabled feature flags

### DIFF
--- a/app/routes/_gcn.docs.contributing.feature-flags.md
+++ b/app/routes/_gcn.docs.contributing.feature-flags.md
@@ -23,7 +23,8 @@ To customize the server-side behavior of the code, use the `feature()` function.
 import { feature } from '~/lib/env.server'
 
 export function loader() {
-  return feature('PYROKINESIS') || new Response(null, { status: 404 })
+  if (feature('PYROKINESIS')) return null
+  else throw new Response(null, { status: 404 })
 }
 
 # Pyrokinesis

--- a/app/routes/labs.tsx
+++ b/app/routes/labs.tsx
@@ -15,7 +15,8 @@ export const handle: BreadcrumbHandle = {
 }
 
 export function loader() {
-  return feature('LABS') || new Response(null, { status: 404 })
+  if (feature('LABS')) return null
+  else throw new Response(null, { status: 404 })
 }
 
 export default function () {


### PR DESCRIPTION
When the loader belongs to a parent route, a returned 404 response does not result in a 404 error on the child route. A thrown 404 response does result in a 404 error.