### PR TITLE
Replace DataFunctionArgs with {Action,Loader}FunctionArgs

### DIFF
--- a/app/components/NewCredentialForm.tsx
+++ b/app/components/NewCredentialForm.tsx
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { LoaderFunctionArgs } from '@remix-run/node'
 import { redirect } from '@remix-run/node'
 import { Form, Link, useLoaderData } from '@remix-run/react'
 import {
@@ -24,7 +24,7 @@ import { getFormDataString } from '~/lib/utils'
 import { useRecaptchaSiteKey } from '~/root'
 import { ClientCredentialVendingMachine } from '~/routes/_gcn.user.credentials/client_credentials.server'
 
-export async function loader(args: DataFunctionArgs) {
+export async function loader(args: LoaderFunctionArgs) {
   return await handleCredentialLoader(args)
 }
 
@@ -67,7 +67,7 @@ export async function handleCredentialActions(
       throw new Response('unknown intent', { status: 400 })
   }
 }
-export async function handleCredentialLoader({ request }: DataFunctionArgs) {
+export async function handleCredentialLoader({ request }: LoaderFunctionArgs) {
   const machine = await ClientCredentialVendingMachine.create(request)
   const client_credentials = await machine.getClientCredentials()
   const groups = await machine.getGroupDescriptions()

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -19,7 +19,7 @@
  *
  */
 import { cssBundleHref } from '@remix-run/css-bundle'
-import type { DataFunctionArgs, LinksFunction } from '@remix-run/node'
+import type { LinksFunction, LoaderFunctionArgs } from '@remix-run/node'
 import {
   Links,
   LiveReload,
@@ -92,7 +92,7 @@ export const links: LinksFunction = () => [
   })),
 ]
 
-export async function loader({ request }: DataFunctionArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const user = await getUser(request)
   const email = user?.email
   const name = user?.name

--- a/app/routes/_gcn.circulars.$circularId/route.tsx
+++ b/app/routes/_gcn.circulars.$circularId/route.tsx
@@ -5,8 +5,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { DataFunctionArgs, HeadersFunction } from '@remix-run/node'
-import { json } from '@remix-run/node'
+import {
+  type HeadersFunction,
+  type LoaderFunctionArgs,
+  json,
+} from '@remix-run/node'
 import { Link, useLoaderData } from '@remix-run/react'
 import { Button, ButtonGroup, Icon } from '@trussworks/react-uswds'
 
@@ -27,7 +30,7 @@ export const handle: BreadcrumbHandle<typeof loader> = {
   },
 }
 
-export async function loader({ params: { circularId } }: DataFunctionArgs) {
+export async function loader({ params: { circularId } }: LoaderFunctionArgs) {
   if (!circularId)
     throw new Response('circularId must be defined', { status: 400 })
   const result = await get(parseFloat(circularId))

--- a/app/routes/_gcn.circulars.$circularId[.]json.ts
+++ b/app/routes/_gcn.circulars.$circularId[.]json.ts
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { LoaderFunctionArgs } from '@remix-run/node'
 import invariant from 'tiny-invariant'
 
 import { formatCircularJson } from './_gcn.circulars/circulars.lib'
@@ -13,7 +13,7 @@ import { get } from './_gcn.circulars/circulars.server'
 import { origin } from '~/lib/env.server'
 import { getCanonicalUrlHeaders } from '~/lib/headers.server'
 
-export async function loader({ params: { circularId } }: DataFunctionArgs) {
+export async function loader({ params: { circularId } }: LoaderFunctionArgs) {
   invariant(circularId)
   const result = await get(parseFloat(circularId))
   return new Response(formatCircularJson(result), {

--- a/app/routes/_gcn.circulars.$circularId[.]txt.ts
+++ b/app/routes/_gcn.circulars.$circularId[.]txt.ts
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { LoaderFunctionArgs } from '@remix-run/node'
 import invariant from 'tiny-invariant'
 
 import { formatCircularText } from './_gcn.circulars/circulars.lib'
@@ -13,7 +13,7 @@ import { get } from './_gcn.circulars/circulars.server'
 import { origin } from '~/lib/env.server'
 import { getCanonicalUrlHeaders } from '~/lib/headers.server'
 
-export async function loader({ params: { circularId } }: DataFunctionArgs) {
+export async function loader({ params: { circularId } }: LoaderFunctionArgs) {
   invariant(circularId)
   const result = await get(parseFloat(circularId))
   return new Response(formatCircularText(result), {

--- a/app/routes/_gcn.circulars._archive._index/route.tsx
+++ b/app/routes/_gcn.circulars._archive._index/route.tsx
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import {
   Form,
   Link,
@@ -47,7 +47,7 @@ import { useFeature } from '~/root'
 
 import searchImg from 'nasawds/src/img/usa-icons-bg/search--white.svg'
 
-export async function loader({ request: { url } }: DataFunctionArgs) {
+export async function loader({ request: { url } }: LoaderFunctionArgs) {
   const { searchParams } = new URL(url)
   const query = searchParams.get('query') || undefined
   if (query) {
@@ -68,7 +68,7 @@ export async function loader({ request: { url } }: DataFunctionArgs) {
   return { page, ...results }
 }
 
-export async function action({ request }: DataFunctionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const data = await request.formData()
   const body = getFormDataString(data, 'body')
   const subject = getFormDataString(data, 'subject')

--- a/app/routes/_gcn.circulars.new.tsx
+++ b/app/routes/_gcn.circulars.new.tsx
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { DataFunctionArgs, HeadersFunction } from '@remix-run/node'
+import type { HeadersFunction, LoaderFunctionArgs } from '@remix-run/node'
 import { json } from '@remix-run/node'
 import {
   Form,
@@ -52,7 +52,7 @@ export const handle: BreadcrumbHandle = {
   breadcrumb: 'New',
 }
 
-export async function loader({ request }: DataFunctionArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const user = await getUser(request)
   let isAuthenticated, isAuthorized, formattedAuthor
   if (user) {

--- a/app/routes/_gcn.contact.tsx
+++ b/app/routes/_gcn.contact.tsx
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { DataFunctionArgs, HeadersFunction } from '@remix-run/node'
+import type { ActionFunctionArgs, HeadersFunction } from '@remix-run/node'
 import { json } from '@remix-run/node'
 import { Form, Link, useActionData } from '@remix-run/react'
 import {
@@ -44,7 +44,7 @@ export async function loader() {
 export const headers: HeadersFunction = ({ loaderHeaders }) =>
   pickHeaders(loaderHeaders, ['Link'])
 
-export async function action({ request }: DataFunctionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const data = await request.formData()
 
   const recaptchaResponse = getFormDataString(data, 'g-recaptcha-response')

--- a/app/routes/_gcn.docs_._schema-browser.schema.($version).$/route.tsx
+++ b/app/routes/_gcn.docs_._schema-browser.schema.($version).$/route.tsx
@@ -5,8 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { DataFunctionArgs } from '@remix-run/node'
-import { json, redirect } from '@remix-run/node'
+import { type LoaderFunctionArgs, json, redirect } from '@remix-run/node'
 import { Link, useLoaderData, useRouteLoaderData } from '@remix-run/react'
 import {
   Card,
@@ -58,7 +57,7 @@ export const handle: BreadcrumbHandle = {
 
 export async function loader({
   params: { version, '*': path },
-}: DataFunctionArgs) {
+}: LoaderFunctionArgs) {
   if (version === 'stable') version = undefined
   if (!version || !path) {
     version ||= await getLatestRelease()

--- a/app/routes/_gcn.quickstart._index.tsx
+++ b/app/routes/_gcn.quickstart._index.tsx
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { LoaderFunctionArgs } from '@remix-run/node'
 import { Link, useLoaderData } from '@remix-run/react'
 import { FormGroup } from '@trussworks/react-uswds'
 
@@ -17,7 +17,7 @@ export const handle: BreadcrumbHandle = {
   breadcrumb: 'Sign in / Sign up',
 }
 
-export async function loader({ request }: DataFunctionArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const user = await getUser(request)
   return { email: user?.email, idp: user?.idp }
 }

--- a/app/routes/_gcn.quickstart.code.tsx
+++ b/app/routes/_gcn.quickstart.code.tsx
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { SEOHandle } from '@nasa-gcn/remix-seo'
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { LoaderFunctionArgs } from '@remix-run/node'
 import { Form, Link, useLoaderData } from '@remix-run/react'
 import { Button, ButtonGroup, FormGroup } from '@trussworks/react-uswds'
 
@@ -21,7 +21,7 @@ export const handle: BreadcrumbHandle & SEOHandle = {
   getSitemapEntries: () => null,
 }
 
-export async function loader({ request }: DataFunctionArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const { clientId, noticeFormat, ...rest } = Object.fromEntries(
     new URL(request.url).searchParams
   )

--- a/app/routes/_gcn.quickstart.credentials.tsx
+++ b/app/routes/_gcn.quickstart.credentials.tsx
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { SEOHandle } from '@nasa-gcn/remix-seo'
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { ActionFunctionArgs } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 
 import CredentialCard from '~/components/CredentialCard'
@@ -25,7 +25,7 @@ export const handle: BreadcrumbHandle & SEOHandle = {
 
 export const loader = handleCredentialLoader
 
-export async function action({ request }: DataFunctionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   return handleCredentialActions(request, 'quickstart')
 }
 

--- a/app/routes/_gcn.schema.$.ts
+++ b/app/routes/_gcn.schema.$.ts
@@ -5,13 +5,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { type DataFunctionArgs, redirect } from '@remix-run/node'
+import { type LoaderFunctionArgs, redirect } from '@remix-run/node'
 
 import { publicStaticShortTermCacheControlHeaders } from '~/lib/headers.server'
 
 /* Make all JSON files at https://github.com/nasa-gcn/gcn-schema available from
  * https://gcn.nasa.gov/schema */
-export async function loader({ params: { '*': path } }: DataFunctionArgs) {
+export async function loader({ params: { '*': path } }: LoaderFunctionArgs) {
   return redirect(
     `https://raw.githubusercontent.com/nasa-gcn/gcn-schema/${path ?? ''}`,
     { headers: publicStaticShortTermCacheControlHeaders }

--- a/app/routes/_gcn.schema.stable.$.ts
+++ b/app/routes/_gcn.schema.stable.$.ts
@@ -5,12 +5,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { type DataFunctionArgs, redirect } from '@remix-run/node'
+import { type LoaderFunctionArgs, redirect } from '@remix-run/node'
 
 import { publicStaticShortTermCacheControlHeaders } from '~/lib/headers.server'
 import { getLatestRelease } from '~/lib/schema-data.server'
 
-export async function loader({ params: { '*': path } }: DataFunctionArgs) {
+export async function loader({ params: { '*': path } }: LoaderFunctionArgs) {
   return redirect(
     `https://raw.githubusercontent.com/nasa-gcn/gcn-schema/${await getLatestRelease()}/${path}`,
     { headers: publicStaticShortTermCacheControlHeaders }

--- a/app/routes/_gcn.unsubscribe.$jwt/route.tsx
+++ b/app/routes/_gcn.unsubscribe.$jwt/route.tsx
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { SEOHandle } from '@nasa-gcn/remix-seo'
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import {
   Form,
   Link,
@@ -42,13 +42,13 @@ function joinListWithOxfordComma(list: string[], conjunction: string = 'and') {
   return butLast ? `${butLast} ${conjunction} ${last}` : last
 }
 
-export async function loader({ params }: DataFunctionArgs) {
+export async function loader({ params }: LoaderFunctionArgs) {
   const availableTopics = Object.keys(unsubscribeActions)
   const decoded = await decodeFromURLParams(params)
   return { availableTopics, ...decoded }
 }
 
-export async function action({ params, request }: DataFunctionArgs) {
+export async function action({ params, request }: ActionFunctionArgs) {
   const [{ email }, formData] = await Promise.all([
     decodeFromURLParams(params),
     request.formData(),

--- a/app/routes/_gcn.user._index.tsx
+++ b/app/routes/_gcn.user._index.tsx
@@ -7,7 +7,7 @@
  */
 import { UpdateUserAttributesCommand } from '@aws-sdk/client-cognito-identity-provider'
 import type { SEOHandle } from '@nasa-gcn/remix-seo'
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { useFetcher, useLoaderData } from '@remix-run/react'
 import {
   Button,
@@ -32,7 +32,7 @@ export const handle: BreadcrumbHandle & SEOHandle = {
   getSitemapEntries: () => null,
 }
 
-export async function loader({ request }: DataFunctionArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const user = await getUser(request)
   if (!user) throw new Response(null, { status: 403 })
 
@@ -40,7 +40,7 @@ export async function loader({ request }: DataFunctionArgs) {
   return { email, idp, name, affiliation }
 }
 
-export async function action({ request }: DataFunctionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const user = await getUser(request)
   if (!user) throw new Response(null, { status: 403 })
 

--- a/app/routes/_gcn.user.credentials._index.tsx
+++ b/app/routes/_gcn.user.credentials._index.tsx
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { SEOHandle } from '@nasa-gcn/remix-seo'
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { Link, useLoaderData } from '@remix-run/react'
 
 import { ClientCredentialVendingMachine } from './_gcn.user.credentials/client_credentials.server'
@@ -17,13 +17,13 @@ import { getFormDataString } from '~/lib/utils'
 
 export const handle: SEOHandle = { getSitemapEntries: () => null }
 
-export async function loader({ request }: DataFunctionArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const machine = await ClientCredentialVendingMachine.create(request)
   const client_credentials = await machine.getClientCredentials()
   return { client_credentials }
 }
 
-export async function action({ request }: DataFunctionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const [data, machine] = await Promise.all([
     request.formData(),
     ClientCredentialVendingMachine.create(request),

--- a/app/routes/_gcn.user.credentials.edit.tsx
+++ b/app/routes/_gcn.user.credentials.edit.tsx
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { SEOHandle } from '@nasa-gcn/remix-seo'
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { ActionFunctionArgs } from '@remix-run/node'
 
 import {
   NewCredentialForm,
@@ -22,7 +22,7 @@ export const handle: BreadcrumbHandle & SEOHandle = {
 
 export const loader = handleCredentialLoader
 
-export async function action({ request }: DataFunctionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   return handleCredentialActions(request, 'user')
 }
 

--- a/app/routes/_gcn.user.email._index/route.tsx
+++ b/app/routes/_gcn.user.email._index/route.tsx
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { SEOHandle } from '@nasa-gcn/remix-seo'
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { Link, useFetcher, useLoaderData } from '@remix-run/react'
 import { Button, ButtonGroup, Grid, Icon } from '@trussworks/react-uswds'
 
@@ -30,7 +30,7 @@ import { getUser } from '~/routes/_gcn._auth/user.server'
 
 export const handle: SEOHandle = { getSitemapEntries: () => null }
 
-export async function action({ request }: DataFunctionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const user = await getUser(request)
   if (!user) throw new Response(null, { status: 403 })
   const data = await request.formData()
@@ -59,7 +59,7 @@ export async function action({ request }: DataFunctionArgs) {
   return null
 }
 
-export async function loader({ request }: DataFunctionArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const user = await getUser(request)
   if (!user) throw new Response(null, { status: 403 })
   const data = await getEmailNotifications(user.sub)

--- a/app/routes/_gcn.user.email.edit.tsx
+++ b/app/routes/_gcn.user.email.edit.tsx
@@ -6,8 +6,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { SEOHandle } from '@nasa-gcn/remix-seo'
-import type { DataFunctionArgs } from '@remix-run/node'
-import { redirect } from '@remix-run/node'
+import {
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  redirect,
+} from '@remix-run/node'
 import { Form, Link, useLoaderData } from '@remix-run/react'
 import {
   Button,
@@ -41,7 +44,7 @@ export const handle: BreadcrumbHandle & SEOHandle = {
   getSitemapEntries: () => null,
 }
 
-export async function action({ request }: DataFunctionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const user = await getUser(request)
   if (!user) throw new Response(null, { status: 403 })
   const data = await request.formData()
@@ -84,7 +87,7 @@ export async function action({ request }: DataFunctionArgs) {
   }
 }
 
-export async function loader({ request }: DataFunctionArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const { uuid } = Object.fromEntries(new URL(request.url).searchParams)
   let intent = 'create'
   const user = await getUser(request)

--- a/app/routes/_gcn.user.endorsements/route.tsx
+++ b/app/routes/_gcn.user.endorsements/route.tsx
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { SEOHandle } from '@nasa-gcn/remix-seo'
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { Link, useFetcher, useLoaderData } from '@remix-run/react'
 import {
   Button,
@@ -46,7 +46,7 @@ export const handle: BreadcrumbHandle & SEOHandle = {
   getSitemapEntries: () => null,
 }
 
-export async function loader({ request }: DataFunctionArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const endorsementServer = await EndorsementsServer.create(request)
   const [requestedEndorsements, awaitingEndorsements] = await Promise.all([
     endorsementServer.getEndorsements('requestor'),
@@ -60,7 +60,7 @@ export async function loader({ request }: DataFunctionArgs) {
   }
 }
 
-export async function action({ request }: DataFunctionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const [data, endorsementServer] = await Promise.all([
     request.formData(),
     EndorsementsServer.create(request),

--- a/app/routes/_gcn.user.password/route.tsx
+++ b/app/routes/_gcn.user.password/route.tsx
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { SEOHandle } from '@nasa-gcn/remix-seo'
-import type { DataFunctionArgs } from '@remix-run/node'
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { useFetcher } from '@remix-run/react'
 import {
   Alert,
@@ -32,13 +32,13 @@ export const handle: BreadcrumbHandle & SEOHandle = {
   getSitemapEntries: () => null,
 }
 
-export async function loader({ request }: DataFunctionArgs) {
+export async function loader({ request }: LoaderFunctionArgs) {
   const user = await getUser(request)
   if (!user) throw new Response(null, { status: 403 })
   return null
 }
 
-export async function action({ request }: DataFunctionArgs) {
+export async function action({ request }: ActionFunctionArgs) {
   const data = await request.formData()
   const oldPassword = getFormDataString(data, 'current-password')
   const newPassword = getFormDataString(data, 'new-password')


### PR DESCRIPTION
DataFunctionArgs was deprecated in Remix 2.4.0.

See https://github.com/remix-run/remix/blob/main/CHANGELOG.md#v240