### PR TITLE
Update to react-uswds 6.1.0, uswds 3.7.1

### DIFF
--- a/app/routes/_gcn.circulars.new.tsx
+++ b/app/routes/_gcn.circulars.new.tsx
@@ -164,16 +164,18 @@ export default function () {
       <h1>New GCN Circular</h1>
       <Form method="POST" action={`/circulars${formSearchString}`}>
         <InputGroup className="border-0 maxw-full">
-          <InputPrefix>From</InputPrefix>
-          <span className="padding-1">{formattedAuthor}</span>
-          <Link
-            to="/user"
-            title="Adjust how your name and affiliation appear in new GCN Circulars"
-          >
-            <Button unstyled type="button">
-              <Icon.Edit role="presentation" /> Edit
-            </Button>
-          </Link>
+          <InputPrefix className="wide-input-prefix">From</InputPrefix>
+          <span>
+            {formattedAuthor}{' '}
+            <Link
+              to="/user"
+              title="Adjust how your name and affiliation appear in new GCN Circulars"
+            >
+              <Button unstyled type="button">
+                <Icon.Edit role="presentation" /> Edit
+              </Button>
+            </Link>
+          </span>
         </InputGroup>
         <InputGroup
           className={classnames('maxw-full', {
@@ -181,7 +183,7 @@ export default function () {
             'usa-input--success': subjectValid,
           })}
         >
-          <InputPrefix>Subject</InputPrefix>
+          <InputPrefix className="wide-input-prefix">Subject</InputPrefix>
           <TextInput
             autoFocus
             aria-describedby="subjectDescription"

--- a/app/theme.scss
+++ b/app/theme.scss
@@ -45,7 +45,7 @@ h1:first-child {
  */
 
 .usa-identifier {
-  position: sticky; /* instead of absolute */
+  position: static; /* instead of absolute */
   top: 100vh;
 }
 
@@ -381,10 +381,9 @@ input.react-tags__combobox-input:focus {
 }
 
 /*
- * Workaround for https://github.com/uswds/uswds/pull/5418
+ * Workaround for https://github.com/uswds/uswds/issues/5558
  */
-.usa-nav__submenu {
-  @include at-media($theme-header-min-width) {
-    padding: units(1);
-  }
+
+.usa-input-prefix.wide-input-prefix + * {
+  padding-left: units(10);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@remix-run/css-bundle": "^2.4.0",
         "@remix-run/node": "^2.4.0",
         "@remix-run/react": "^2.4.0",
-        "@trussworks/react-uswds": "^5.1.1",
+        "@trussworks/react-uswds": "^6.1.0",
         "aws-lambda-ses-forwarder": "github:lpsinger/aws-lambda-ses-forwarder#aws-sdk-v3",
         "classnames": "^2.3.2",
         "color-convert": "^2.0.1",
@@ -9074,14 +9074,14 @@
       }
     },
     "node_modules/@trussworks/react-uswds": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@trussworks/react-uswds/-/react-uswds-5.1.1.tgz",
-      "integrity": "sha512-SAlgEIFGCIKyV5aQjIi8dBUwLGdqNkbDHDvXPPWyySlhJkut5MNmZQ73BpFTxke6WqJreljkApPubMWUPiynlw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@trussworks/react-uswds/-/react-uswds-6.1.0.tgz",
+      "integrity": "sha512-UyS+quISxEAXY7nrYonSkQYLJv4xR8jPYOaGFm4YzgOo3TaopJ30Laf4hIlfjtazDIZrNbaRTfBu/fArQv6PPQ==",
       "engines": {
         "node": ">= 16.20.0"
       },
       "peerDependencies": {
-        "@uswds/uswds": "3.1.0",
+        "@uswds/uswds": "^3.6.0",
         "react": "^16.x || ^17.x || ^18.x",
         "react-dom": "^16.x || ^17.x || ^18.x"
       }
@@ -9697,13 +9697,12 @@
       "dev": true
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.1.0.tgz",
-      "integrity": "sha512-6XTeaQD/ipc3x4713mud4Rrr+lRc4nJ1Qw5Oy35dbVEXuKr7DjN4EBoAkbze9OoV0UdmAIvoxolBF/UcpFVKOg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.7.1.tgz",
+      "integrity": "sha512-32u2S50bf5dwIujebqL+f1Jgx2rmRrpxcaccSZzdo3Qv9HaDUdcmeavlrxHqN30edHc7p8kRPjvjevOmOJKB7w==",
       "peer": true,
       "dependencies": {
-        "classlist-polyfill": "1.0.3",
-        "domready": "1.0.8",
+        "classlist-polyfill": "1.2.0",
         "object-assign": "4.1.1",
         "receptor": "1.0.0",
         "resolve-id-refs": "0.1.0"
@@ -11301,9 +11300,9 @@
       "dev": true
     },
     "node_modules/classlist-polyfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.0.3.tgz",
-      "integrity": "sha512-bDLDUsSg5LYFWsc2hphtG6ulyaCFSupdEBU3wxNECKWHnyPVvY8EB9Wbt9DzWkstWclFZhDaZK/VnEK/DmqE/Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ==",
       "peer": true
     },
     "node_modules/classnames": {
@@ -12384,12 +12383,6 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
-    },
-    "node_modules/domready": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
-      "integrity": "sha512-uIzsOJUNk+AdGE9a6VDeessoMCzF8RrZvJCX/W8QtyfgdR6Uofn/MvRonih3OtCO79b2VDzDOymuiABrQ4z3XA==",
-      "peer": true
     },
     "node_modules/domutils": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@remix-run/css-bundle": "^2.4.0",
     "@remix-run/node": "^2.4.0",
     "@remix-run/react": "^2.4.0",
-    "@trussworks/react-uswds": "^5.1.1",
+    "@trussworks/react-uswds": "^6.1.0",
     "aws-lambda-ses-forwarder": "github:lpsinger/aws-lambda-ses-forwarder#aws-sdk-v3",
     "classnames": "^2.3.2",
     "color-convert": "^2.0.1",


### PR DESCRIPTION
- Remove workaround for uswds/uswds#5418
- Add workaround for uswds/uswds#5558
- Fix footer snapped to bottom of page - not sure why I had to change this from `position: sticky` to `position: static` with the USWDS update, but I did