### PR TITLE
Fix broken skipnav link in labs pages

### DIFF
--- a/app/routes/labs/route.tsx
+++ b/app/routes/labs/route.tsx
@@ -26,7 +26,7 @@ export default function () {
     <>
       <Header />
       <h1>ACROSS</h1>
-      <main>
+      <main id="main-content">
         <Outlet />
       </main>
       <Footer />


### PR DESCRIPTION
This accessibility link was broken on labs pages:
https://github.com/nasa-gcn/gcn.nasa.gov/blob/2bad72b8e461d766c28a0b21b318a549dc8f330d/app/root.tsx#L196-L198