### PR TITLE
Remove duplicate usa-header styles

### DIFF
--- a/app/routes/_gcn/header/Header.tsx
+++ b/app/routes/_gcn/header/Header.tsx
@@ -89,10 +89,7 @@ export function Header() {
       {expanded && (
         <div className="usa-overlay is-visible" onClick={hideMobileNav} />
       )}
-      <USWDSHeader
-        basic
-        className={`usa-header usa-header--dark ${styles.header}`}
-      >
+      <USWDSHeader basic className={`usa-header--dark ${styles.header}`}>
         <div className="usa-nav-container">
           <div className="usa-navbar">
             <Title>

--- a/app/routes/labs/header/Header.tsx
+++ b/app/routes/labs/header/Header.tsx
@@ -34,10 +34,7 @@ export function Header() {
       {expanded && (
         <div className="usa-overlay is-visible" onClick={hideMobileNav} />
       )}
-      <USWDSHeader
-        basic
-        className={`usa-header usa-header--dark ${styles.header}`}
-      >
+      <USWDSHeader basic className={`usa-header--dark ${styles.header}`}>
         <div className="usa-nav-container">
           <div className="usa-navbar">
             <Title>


### PR DESCRIPTION
The USWDSHeader component _always_ has the `usa-header` style. We need not specifiy it explicitly.