### PR TITLE
Circulars - move date selector component outside of route.tsx to its own file

### DIFF
--- a/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
@@ -1,0 +1,162 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { useSearchParams, useSubmit } from '@remix-run/react'
+import {
+  Button,
+  CardBody,
+  CardFooter,
+  DateRangePicker,
+  Grid,
+  Icon,
+  Radio,
+} from '@trussworks/react-uswds'
+import { useState } from 'react'
+
+import DateSelectorButton from './DateSelectorButton'
+import DetailsDropdownContent from '~/components/DetailsDropdownContent'
+
+export default function ({
+  startDate,
+  endDate,
+}: {
+  startDate?: string
+  endDate?: string
+}) {
+  const [searchParams] = useSearchParams()
+
+  const [inputDateGte, setInputDateGte] = useState(startDate)
+  const [inputDateLte, setInputDateLte] = useState(endDate)
+  const [showContent, setShowContent] = useState(false)
+  const [showDateRange, setShowDateRange] = useState(false)
+
+  const submit = useSubmit()
+
+  function setFuzzyTime(startDate?: string) {
+    setShowDateRange(false)
+    setInputDateGte(startDate)
+    setInputDateLte('')
+  }
+
+  function setDateRange() {
+    setShowContent(false)
+    if (inputDateGte) searchParams.set('startDate', inputDateGte)
+    else searchParams.delete('startDate')
+    if (inputDateLte) searchParams.set('endDate', inputDateLte)
+    else searchParams.delete('endDate')
+    submit(searchParams, {
+      method: 'get',
+      action: '/circulars',
+    })
+  }
+
+  const dateSelectorLabels: Record<string, string> = {
+    hour: 'Last Hour',
+    today: 'Today',
+    day: 'Last Day',
+    week: 'Last Week',
+    month: 'Last Month',
+    year: 'Last Year',
+    ytd: 'Year to Date',
+  }
+  return (
+    <>
+      <DateSelectorButton
+        startDate={startDate}
+        endDate={endDate}
+        onClick={() => {
+          setShowContent((shown) => !shown)
+          setShowDateRange(false)
+        }}
+        expanded={showContent}
+      />
+      {showContent && (
+        <DetailsDropdownContent className="maxw-card-xlg">
+          <CardBody>
+            <Grid row>
+              <Grid col={4} key={`radio-alltime`}>
+                <Radio
+                  id={`radio-alltime`}
+                  name="radio-date"
+                  value=""
+                  label="All Time"
+                  defaultChecked={true}
+                  onChange={(e) => {
+                    setInputDateGte(e.target.value)
+                  }}
+                />
+              </Grid>
+              {Object.entries(dateSelectorLabels).map(([value, label]) => (
+                <Grid col={4} key={`radio-${value}`}>
+                  <Radio
+                    id={`radio-${value}`}
+                    name="radio-date"
+                    value={value}
+                    label={label}
+                    checked={value === inputDateGte}
+                    onChange={() => {
+                      setFuzzyTime(value)
+                    }}
+                  />
+                </Grid>
+              ))}
+              <Grid col={4}>
+                <Radio
+                  id="radio-custom"
+                  name="radio-date"
+                  value="custom"
+                  label="Custom Range..."
+                  checked={showDateRange}
+                  onChange={(e) => {
+                    setShowDateRange(e.target.checked)
+                  }}
+                />
+              </Grid>
+            </Grid>
+            {showDateRange && (
+              <DateRangePicker
+                startDateHint="dd/mm/yyyy"
+                startDateLabel="Start Date"
+                className="margin-bottom-2"
+                startDatePickerProps={{
+                  id: 'event-date-start',
+                  name: 'event-date-start',
+                  defaultValue: 'startDate',
+                  onChange: (value) => {
+                    setInputDateGte(value)
+                  },
+                }}
+                endDateHint="dd/mm/yyyy"
+                endDateLabel="End Date"
+                endDatePickerProps={{
+                  id: 'event-date-end',
+                  name: 'event-date-end',
+                  defaultValue: 'endDate',
+                  onChange: (value) => {
+                    setInputDateLte(value)
+                  },
+                }}
+              />
+            )}
+
+            <CardFooter>
+              <Button
+                type="button"
+                form="searchForm"
+                onClick={() => {
+                  setDateRange()
+                }}
+              >
+                <Icon.CalendarToday /> Submit
+              </Button>
+            </CardFooter>
+          </CardBody>
+        </DetailsDropdownContent>
+      )}
+    </>
+  )
+}

--- a/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
@@ -20,7 +20,7 @@ import { useState } from 'react'
 import DateSelectorButton from './DateSelectorButton'
 import DetailsDropdownContent from '~/components/DetailsDropdownContent'
 
-export default function ({
+export function DateSelector ({
   startDate,
   endDate,
 }: {

--- a/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
@@ -20,7 +20,7 @@ import { useState } from 'react'
 import DateSelectorButton from './DateSelectorButton'
 import DetailsDropdownContent from '~/components/DetailsDropdownContent'
 
-export function DateSelector ({
+export function DateSelector({
   startDate,
   endDate,
 }: {

--- a/app/routes/_gcn.circulars._archive._index/route.tsx
+++ b/app/routes/_gcn.circulars._archive._index/route.tsx
@@ -34,7 +34,7 @@ import {
 import CircularPagination from './CircularPagination'
 import CircularsHeader from './CircularsHeader'
 import CircularsIndex from './CircularsIndex'
-import DateSelectorMenu from './DateSelectorMenu'
+import { DateSelector } from './DateSelectorMenu'
 import Hint from '~/components/Hint'
 import { getFormDataString } from '~/lib/utils'
 import { useFeature } from '~/root'
@@ -135,7 +135,7 @@ export default function () {
           </Button>
         </Form>
         {featureCircularsFilterByDate && (
-          <DateSelectorMenu startDate={startDate} endDate={endDate} />
+          <DateSelector startDate={startDate} endDate={endDate} />
         )}
         <Link to={`/circulars/new${searchString}`}>
           <Button

--- a/app/routes/_gcn.circulars._archive._index/route.tsx
+++ b/app/routes/_gcn.circulars._archive._index/route.tsx
@@ -17,13 +17,8 @@ import {
 import {
   Button,
   ButtonGroup,
-  CardBody,
-  CardFooter,
-  DateRangePicker,
-  Grid,
   Icon,
   Label,
-  Radio,
   Select,
   TextInput,
 } from '@trussworks/react-uswds'
@@ -39,8 +34,7 @@ import {
 import CircularPagination from './CircularPagination'
 import CircularsHeader from './CircularsHeader'
 import CircularsIndex from './CircularsIndex'
-import DateSelectorButton from './DateSelectorButton'
-import DetailsDropdownContent from '~/components/DetailsDropdownContent'
+import DateSelectorMenu from './DateSelectorMenu'
 import Hint from '~/components/Hint'
 import { getFormDataString } from '~/lib/utils'
 import { useFeature } from '~/root'
@@ -103,41 +97,9 @@ export default function () {
   if (searchString) searchString = `?${searchString}`
 
   const [inputQuery, setInputQuery] = useState(query)
-  const [inputDateGte, setInputDateGte] = useState(startDate)
-  const [inputDateLte, setInputDateLte] = useState(endDate)
-  const [showContent, setShowContent] = useState(false)
-  const [showDateRange, setShowDateRange] = useState(false)
   const clean = inputQuery === query
 
   const submit = useSubmit()
-
-  function setFuzzyTime(startDate?: string) {
-    setShowDateRange(false)
-    setInputDateGte(startDate)
-    setInputDateLte('')
-  }
-
-  function setDateRange() {
-    setShowContent(false)
-    if (inputDateGte) searchParams.set('startDate', inputDateGte)
-    else searchParams.delete('startDate')
-    if (inputDateLte) searchParams.set('endDate', inputDateLte)
-    else searchParams.delete('endDate')
-    submit(searchParams, {
-      method: 'get',
-      action: '/circulars',
-    })
-  }
-
-  const dateSelectorLabels: Record<string, string> = {
-    hour: 'Last Hour',
-    today: 'Today',
-    day: 'Last Day',
-    week: 'Last Week',
-    month: 'Last Month',
-    year: 'Last Year',
-    ytd: 'Year to Date',
-  }
 
   return (
     <>
@@ -173,102 +135,7 @@ export default function () {
           </Button>
         </Form>
         {featureCircularsFilterByDate && (
-          <>
-            <DateSelectorButton
-              startDate={startDate}
-              endDate={endDate}
-              onClick={() => {
-                setShowContent((shown) => !shown)
-                setShowDateRange(false)
-              }}
-              expanded={showContent}
-            />
-            {showContent && (
-              <DetailsDropdownContent className="maxw-card-xlg">
-                <CardBody>
-                  <Grid row>
-                    <Grid col={4} key={`radio-alltime`}>
-                      <Radio
-                        id={`radio-alltime`}
-                        name="radio-date"
-                        value=""
-                        label="All Time"
-                        defaultChecked={true}
-                        onChange={(e) => {
-                          setInputDateGte(e.target.value)
-                        }}
-                      />
-                    </Grid>
-                    {Object.entries(dateSelectorLabels).map(
-                      ([value, label]) => (
-                        <Grid col={4} key={`radio-${value}`}>
-                          <Radio
-                            id={`radio-${value}`}
-                            name="radio-date"
-                            value={value}
-                            label={label}
-                            checked={value === inputDateGte}
-                            onChange={() => {
-                              setFuzzyTime(value)
-                            }}
-                          />
-                        </Grid>
-                      )
-                    )}
-                    <Grid col={4}>
-                      <Radio
-                        id="radio-custom"
-                        name="radio-date"
-                        value="custom"
-                        label="Custom Range..."
-                        checked={showDateRange}
-                        onChange={(e) => {
-                          setShowDateRange(e.target.checked)
-                        }}
-                      />
-                    </Grid>
-                  </Grid>
-                  {showDateRange && (
-                    <DateRangePicker
-                      startDateHint="dd/mm/yyyy"
-                      startDateLabel="Start Date"
-                      className="margin-bottom-2"
-                      startDatePickerProps={{
-                        id: 'event-date-start',
-                        name: 'event-date-start',
-                        defaultValue: 'startDate',
-                        onChange: (value) => {
-                          setInputDateGte(value)
-                        },
-                      }}
-                      endDateHint="dd/mm/yyyy"
-                      endDateLabel="End Date"
-                      endDatePickerProps={{
-                        id: 'event-date-end',
-                        name: 'event-date-end',
-                        defaultValue: 'endDate',
-                        onChange: (value) => {
-                          setInputDateLte(value)
-                        },
-                      }}
-                    />
-                  )}
-
-                  <CardFooter>
-                    <Button
-                      type="button"
-                      form="searchForm"
-                      onClick={() => {
-                        setDateRange()
-                      }}
-                    >
-                      <Icon.CalendarToday /> Submit
-                    </Button>
-                  </CardFooter>
-                </CardBody>
-              </DetailsDropdownContent>
-            )}
-          </>
+          <DateSelectorMenu startDate={startDate} endDate={endDate} />
         )}
         <Link to={`/circulars/new${searchString}`}>
           <Button


### PR DESCRIPTION
Similar to what was done with the DateSelectorButton component or the CircularsIndex, this PR separates the date selector menu into a separate file outside of route.tsx. This should make it somewhat easier to parse the route file by moving a bit over 150 lines to this separate file. 

Only the start and end date parameters are passed as arguments to the component; I wasn't sure if searchParams itself should be passed.