### PR TITLE
Use upstream git sources for nasawds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "jest-transform-stub": "^2.0.0",
         "lint-staged": "^15.2.0",
-        "nasawds": "github:lpsinger/nasawds#fix-usa-nav-dark-hamburger-link-color",
+        "nasawds": "github:bruffridge/nasawds",
         "npm-run-all": "^4.1.5",
         "oidc-provider": "^8.4.3",
         "postcss-csso": "^6.0.1",
@@ -20855,8 +20855,7 @@
     },
     "node_modules/nasawds": {
       "version": "4.0.1",
-      "resolved": "git+ssh://git@github.com/lpsinger/nasawds.git#74414da84a1ae605fcbbfd6d4dead695432ff062",
-      "integrity": "sha512-9ORjHcY9GsMUzjUshbz46lM/TVCdA95iCwbTJz9Hb5HXRI87viXPmwcMCM33LUcb95RusIDkLkAv/QRkn+iDDg==",
+      "resolved": "git+ssh://git@github.com/bruffridge/nasawds.git#8fa4c5a44b8da936d3d5e54cc2903290a311a321",
       "dev": true,
       "license": "CC0-1.0"
     },

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jest-transform-stub": "^2.0.0",
     "lint-staged": "^15.2.0",
-    "nasawds": "github:lpsinger/nasawds#fix-usa-nav-dark-hamburger-link-color",
+    "nasawds": "github:bruffridge/nasawds",
     "npm-run-all": "^4.1.5",
     "oidc-provider": "^8.4.3",
     "postcss-csso": "^6.0.1",


### PR DESCRIPTION
bruffridge/nasawds#10 has been fixed upstream, but is not yet in a release.