### PR TITLE
Change deploy workflow to build and deploy in arm64 docker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,21 +24,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Node.js
-        uses: actions/setup-node@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
         with:
-          node-version: '18'
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: NPM Install
-        run: npm ci
-      - name: Build
-        run: npm run build
+          platforms: linux/arm64
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           aws-region: us-east-1
-      - name: Deploy
-        run: npm run deploy
+      - name: Build and deploy inside Docker
+        uses: addnab/docker-run-action@v3
+        with:
+          image: nikolaik/python-nodejs:python3.11-nodejs18
+          options: |
+            --platform linux/arm64
+            --volume ${{ github.workspace }}/../:/build
+          run: |
+            cd /build/gcn.nasa.gov
+            npm ci
+            npm run build
+            npm run deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           aws-region: us-east-1
-      - name: NPM install
+      - name: NPM Install
         uses: addnab/docker-run-action@v3
         with:
           image: nikolaik/python-nodejs:python3.11-nodejs18

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,15 +33,33 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           aws-region: us-east-1
-      - name: Build and deploy inside Docker
+      - name: NPM install
         uses: addnab/docker-run-action@v3
         with:
           image: nikolaik/python-nodejs:python3.11-nodejs18
           options: |
             --platform linux/arm64
-            --volume ${{ github.workspace }}/../:/build
+            --volume ${{ github.workspace }}:/build
           run: |
-            cd /build/gcn.nasa.gov
+            cd /build
             npm ci
+      - name: Build
+        uses: addnab/docker-run-action@v3
+        with:
+          image: nikolaik/python-nodejs:python3.11-nodejs18
+          options: |
+            --platform linux/arm64
+            --volume ${{ github.workspace }}:/build
+          run: |
+            cd /build
             npm run build
+      - name: Deploy
+        uses: addnab/docker-run-action@v3
+        with:
+          image: nikolaik/python-nodejs:python3.11-nodejs18
+          options: |
+            --platform linux/arm64
+            --volume ${{ github.workspace }}:/build
+          run: |
+            cd /build
             npm run deploy


### PR DESCRIPTION
Pull request makes a first pass at changing the `deploy.yml` file, changing it so that `npm ci`, `npm run build` and `npm run deploy` are executed inside a Docker container running arm64 linux under QEMU. This fixes (maybe) the issue where the current deployment can only use binary packages from pip, making it break if no binary is available for the `manylinux_aarch64` architecture. 