### PR TITLE
Date selector cleanup

### DIFF
--- a/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
@@ -197,13 +197,12 @@ export function DateSelector({
                 }}
               />
             )}
-
-            <CardFooter>
-              <Button type="submit" form={form}>
-                <Icon.CalendarToday /> Submit
-              </Button>
-            </CardFooter>
           </CardBody>
+          <CardFooter>
+            <Button type="submit" form={form}>
+              <Icon.CalendarToday /> Submit
+            </Button>
+          </CardFooter>
         </DetailsDropdownContent>
       )}
     </>

--- a/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
@@ -201,7 +201,7 @@ export function DateSelector({
           {showDateRange && (
             <CardFooter>
               <Button type="submit" form={form}>
-                <Icon.CalendarToday /> Submit
+                Submit
               </Button>
             </CardFooter>
           )}

--- a/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
@@ -5,6 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+import { useSubmit } from '@remix-run/react'
 import {
   Button,
   ButtonGroup,
@@ -15,7 +16,7 @@ import {
   Icon,
   Radio,
 } from '@trussworks/react-uswds'
-import { type ChangeEvent, useState } from 'react'
+import { type ChangeEvent, useRef, useState } from 'react'
 
 import DetailsDropdownContent from '~/components/DetailsDropdownContent'
 
@@ -75,29 +76,48 @@ export function DateSelector({
   defaultStartDate?: string
   defaultEndDate?: string
 }) {
-  const [startDate, setStartDate] = useState(defaultStartDate)
-  const [endDate, setEndDate] = useState(defaultEndDate)
   const [showContent, setShowContent] = useState(false)
   const defaultShowDateRange = Boolean(
     (defaultStartDate && !dateSelectorLabels[defaultStartDate]) ||
       defaultEndDate
   )
   const [showDateRange, setShowDateRange] = useState(defaultShowDateRange)
+  const startDateInputRef = useRef<HTMLInputElement>(null)
+  const endDateInputRef = useRef<HTMLInputElement>(null)
+  const submit = useSubmit()
+
+  function setStartDate(value: string) {
+    if (startDateInputRef.current) startDateInputRef.current.value = value
+  }
+
+  function setEndDate(value: string) {
+    if (endDateInputRef.current) endDateInputRef.current.value = value
+  }
 
   function radioOnChange({ target: { value } }: ChangeEvent<HTMLInputElement>) {
     setShowDateRange(false)
     setStartDate(value)
     setEndDate('')
+    const form = startDateInputRef.current?.form
+    if (form) submit(form)
   }
 
   return (
     <>
-      {Boolean(startDate) && (
-        <input type="hidden" name="startDate" form={form} value={startDate} />
-      )}
-      {Boolean(endDate) && (
-        <input type="hidden" name="endDate" form={form} value={endDate} />
-      )}
+      <input
+        type="hidden"
+        name="startDate"
+        form={form}
+        ref={startDateInputRef}
+        defaultValue={defaultStartDate}
+      />
+      <input
+        type="hidden"
+        name="endDate"
+        form={form}
+        ref={endDateInputRef}
+        defaultValue={defaultEndDate}
+      />
       <DateSelectorButton
         startDate={defaultStartDate}
         endDate={defaultEndDate}
@@ -160,7 +180,7 @@ export function DateSelector({
                   dateFormat: 'YYYY-MM-DD',
                   defaultValue: defaultStartDate,
                   onChange: (value) => {
-                    setStartDate(value)
+                    setStartDate(value ?? '')
                   },
                 }}
                 endDateHint="YYYY-MM-DD"
@@ -172,7 +192,7 @@ export function DateSelector({
                   dateFormat: 'YYYY-MM-DD',
                   defaultValue: defaultEndDate,
                   onChange: (value) => {
-                    setEndDate(value)
+                    setEndDate(value ?? '')
                   },
                 }}
               />

--- a/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
@@ -79,7 +79,11 @@ export function DateSelector({
   const [startDate, setStartDate] = useState(defaultStartDate)
   const [endDate, setEndDate] = useState(defaultEndDate)
   const [showContent, setShowContent] = useState(false)
-  const [showDateRange, setShowDateRange] = useState(false)
+  const defaultShowDateRange = Boolean(
+    (defaultStartDate && !dateSelectorLabels[defaultStartDate]) ||
+      defaultEndDate
+  )
+  const [showDateRange, setShowDateRange] = useState(defaultShowDateRange)
 
   const submit = useSubmit()
 
@@ -108,7 +112,6 @@ export function DateSelector({
         endDate={defaultEndDate}
         onClick={() => {
           setShowContent((shown) => !shown)
-          setShowDateRange(false)
         }}
         expanded={showContent}
       />
@@ -122,9 +125,9 @@ export function DateSelector({
                   name="radio-date"
                   value=""
                   label="All Time"
-                  defaultChecked={true}
-                  onChange={(e) => {
-                    setStartDate(e.target.value)
+                  defaultChecked={!defaultStartDate && !defaultEndDate}
+                  onChange={() => {
+                    setFuzzyTime('')
                   }}
                 />
               </Grid>
@@ -135,7 +138,7 @@ export function DateSelector({
                     name="radio-date"
                     value={value}
                     label={label}
-                    checked={value === startDate}
+                    defaultChecked={value === defaultStartDate}
                     onChange={() => {
                       setFuzzyTime(value)
                     }}
@@ -148,7 +151,7 @@ export function DateSelector({
                   name="radio-date"
                   value="custom"
                   label="Custom Range..."
-                  checked={showDateRange}
+                  defaultChecked={defaultShowDateRange}
                   onChange={(e) => {
                     setShowDateRange(e.target.checked)
                   }}
@@ -157,23 +160,25 @@ export function DateSelector({
             </Grid>
             {showDateRange && (
               <DateRangePicker
-                startDateHint="dd/mm/yyyy"
+                startDateHint="YYYY-MM-DD"
                 startDateLabel="Start Date"
                 className="margin-bottom-2"
                 startDatePickerProps={{
                   id: 'event-date-start',
                   name: 'event-date-start',
-                  defaultValue: 'startDate',
+                  dateFormat: 'YYYY-MM-DD',
+                  defaultValue: defaultStartDate,
                   onChange: (value) => {
                     setStartDate(value)
                   },
                 }}
-                endDateHint="dd/mm/yyyy"
+                endDateHint="YYYY-MM-DD"
                 endDateLabel="End Date"
                 endDatePickerProps={{
                   id: 'event-date-end',
                   name: 'event-date-end',
-                  defaultValue: 'endDate',
+                  dateFormat: 'YYYY-MM-DD',
+                  defaultValue: defaultEndDate,
                   onChange: (value) => {
                     setEndDate(value)
                   },

--- a/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
@@ -68,16 +68,16 @@ function DateSelectorButton({
 }
 
 export function DateSelector({
-  startDate,
-  endDate,
+  defaultStartDate,
+  defaultEndDate,
 }: {
-  startDate?: string
-  endDate?: string
+  defaultStartDate?: string
+  defaultEndDate?: string
 }) {
   const [searchParams] = useSearchParams()
 
-  const [inputDateGte, setInputDateGte] = useState(startDate)
-  const [inputDateLte, setInputDateLte] = useState(endDate)
+  const [startDate, setStartDate] = useState(defaultStartDate)
+  const [endDate, setEndDate] = useState(defaultEndDate)
   const [showContent, setShowContent] = useState(false)
   const [showDateRange, setShowDateRange] = useState(false)
 
@@ -85,15 +85,15 @@ export function DateSelector({
 
   function setFuzzyTime(startDate?: string) {
     setShowDateRange(false)
-    setInputDateGte(startDate)
-    setInputDateLte('')
+    setStartDate(startDate)
+    setEndDate('')
   }
 
   function setDateRange() {
     setShowContent(false)
-    if (inputDateGte) searchParams.set('startDate', inputDateGte)
+    if (startDate) searchParams.set('startDate', startDate)
     else searchParams.delete('startDate')
-    if (inputDateLte) searchParams.set('endDate', inputDateLte)
+    if (endDate) searchParams.set('endDate', endDate)
     else searchParams.delete('endDate')
     submit(searchParams, {
       method: 'get',
@@ -104,8 +104,8 @@ export function DateSelector({
   return (
     <>
       <DateSelectorButton
-        startDate={startDate}
-        endDate={endDate}
+        startDate={defaultStartDate}
+        endDate={defaultEndDate}
         onClick={() => {
           setShowContent((shown) => !shown)
           setShowDateRange(false)
@@ -124,7 +124,7 @@ export function DateSelector({
                   label="All Time"
                   defaultChecked={true}
                   onChange={(e) => {
-                    setInputDateGte(e.target.value)
+                    setStartDate(e.target.value)
                   }}
                 />
               </Grid>
@@ -135,7 +135,7 @@ export function DateSelector({
                     name="radio-date"
                     value={value}
                     label={label}
-                    checked={value === inputDateGte}
+                    checked={value === startDate}
                     onChange={() => {
                       setFuzzyTime(value)
                     }}
@@ -165,7 +165,7 @@ export function DateSelector({
                   name: 'event-date-start',
                   defaultValue: 'startDate',
                   onChange: (value) => {
-                    setInputDateGte(value)
+                    setStartDate(value)
                   },
                 }}
                 endDateHint="dd/mm/yyyy"
@@ -175,7 +175,7 @@ export function DateSelector({
                   name: 'event-date-end',
                   defaultValue: 'endDate',
                   onChange: (value) => {
-                    setInputDateLte(value)
+                    setEndDate(value)
                   },
                 }}
               />

--- a/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
@@ -16,7 +16,7 @@ import {
   Icon,
   Radio,
 } from '@trussworks/react-uswds'
-import { useState } from 'react'
+import { type ChangeEvent, useState } from 'react'
 
 import DetailsDropdownContent from '~/components/DetailsDropdownContent'
 
@@ -87,9 +87,9 @@ export function DateSelector({
 
   const submit = useSubmit()
 
-  function setFuzzyTime(startDate?: string) {
+  function radioOnChange({ target: { value } }: ChangeEvent<HTMLInputElement>) {
     setShowDateRange(false)
-    setStartDate(startDate)
+    setStartDate(value)
     setEndDate('')
   }
 
@@ -126,9 +126,7 @@ export function DateSelector({
                   value=""
                   label="All Time"
                   defaultChecked={!defaultStartDate && !defaultEndDate}
-                  onChange={() => {
-                    setFuzzyTime('')
-                  }}
+                  onChange={radioOnChange}
                 />
               </Grid>
               {Object.entries(dateSelectorLabels).map(([value, label]) => (
@@ -139,9 +137,7 @@ export function DateSelector({
                     value={value}
                     label={label}
                     defaultChecked={value === defaultStartDate}
-                    onChange={() => {
-                      setFuzzyTime(value)
-                    }}
+                    onChange={radioOnChange}
                   />
                 </Grid>
               ))}
@@ -152,8 +148,8 @@ export function DateSelector({
                   value="custom"
                   label="Custom Range..."
                   defaultChecked={defaultShowDateRange}
-                  onChange={(e) => {
-                    setShowDateRange(e.target.checked)
+                  onChange={({ target: { checked } }) => {
+                    setShowDateRange(checked)
                   }}
                 />
               </Grid>

--- a/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
@@ -16,6 +16,7 @@ import {
   Icon,
   Radio,
 } from '@trussworks/react-uswds'
+import classNames from 'classnames'
 import { type ChangeEvent, useRef, useState } from 'react'
 
 import DetailsDropdownContent from '~/components/DetailsDropdownContent'
@@ -98,6 +99,7 @@ export function DateSelector({
     setShowDateRange(false)
     setStartDate(value)
     setEndDate('')
+    setShowContent(false)
     const form = startDateInputRef.current?.form
     if (form) submit(form)
   }
@@ -126,87 +128,96 @@ export function DateSelector({
         }}
         expanded={showContent}
       />
-      {showContent && (
-        <DetailsDropdownContent className="maxw-card-xlg">
-          <CardBody>
-            <Grid row>
-              <Grid col={4} key="radio-alltime">
+      <DetailsDropdownContent
+        className={classNames('maxw-card-xlg', {
+          'display-none': !showContent,
+        })}
+      >
+        <CardBody>
+          <Grid row>
+            <Grid col={4} key="radio-alltime">
+              <Radio
+                form=""
+                id="radio-alltime"
+                name="radio-date"
+                value=""
+                label="All Time"
+                defaultChecked={!defaultStartDate && !defaultEndDate}
+                onChange={radioOnChange}
+              />
+            </Grid>
+            {Object.entries(dateSelectorLabels).map(([value, label]) => (
+              <Grid col={4} key={`radio-${value}`}>
                 <Radio
                   form=""
-                  id="radio-alltime"
+                  id={`radio-${value}`}
                   name="radio-date"
-                  value=""
-                  label="All Time"
-                  defaultChecked={!defaultStartDate && !defaultEndDate}
+                  value={value}
+                  label={label}
+                  defaultChecked={value === defaultStartDate}
                   onChange={radioOnChange}
                 />
               </Grid>
-              {Object.entries(dateSelectorLabels).map(([value, label]) => (
-                <Grid col={4} key={`radio-${value}`}>
-                  <Radio
-                    form=""
-                    id={`radio-${value}`}
-                    name="radio-date"
-                    value={value}
-                    label={label}
-                    defaultChecked={value === defaultStartDate}
-                    onChange={radioOnChange}
-                  />
-                </Grid>
-              ))}
-              <Grid col={4}>
-                <Radio
-                  form=""
-                  id="radio-custom"
-                  name="radio-date"
-                  value="custom"
-                  label="Custom Range..."
-                  defaultChecked={defaultShowDateRange}
-                  onChange={({ target: { checked } }) => {
-                    setShowDateRange(checked)
-                  }}
-                />
-              </Grid>
-            </Grid>
-            {showDateRange && (
-              <DateRangePicker
-                startDateHint="YYYY-MM-DD"
-                startDateLabel="Start Date"
-                className="margin-bottom-2"
-                startDatePickerProps={{
-                  form: '',
-                  id: 'event-date-start',
-                  name: 'event-date-start',
-                  dateFormat: 'YYYY-MM-DD',
-                  defaultValue: defaultStartDate,
-                  onChange: (value) => {
-                    setStartDate(value ?? '')
-                  },
-                }}
-                endDateHint="YYYY-MM-DD"
-                endDateLabel="End Date"
-                endDatePickerProps={{
-                  form: '',
-                  id: 'event-date-end',
-                  name: 'event-date-end',
-                  dateFormat: 'YYYY-MM-DD',
-                  defaultValue: defaultEndDate,
-                  onChange: (value) => {
-                    setEndDate(value ?? '')
-                  },
+            ))}
+            <Grid col={4}>
+              <Radio
+                form=""
+                id="radio-custom"
+                name="radio-date"
+                value="custom"
+                label="Custom Range..."
+                defaultChecked={defaultShowDateRange}
+                onChange={({ target: { checked } }) => {
+                  setShowDateRange(checked)
                 }}
               />
-            )}
-          </CardBody>
+            </Grid>
+          </Grid>
           {showDateRange && (
-            <CardFooter>
-              <Button type="submit" form={form}>
-                Submit
-              </Button>
-            </CardFooter>
+            <DateRangePicker
+              startDateHint="YYYY-MM-DD"
+              startDateLabel="Start Date"
+              className="margin-bottom-2"
+              startDatePickerProps={{
+                form: '',
+                id: 'event-date-start',
+                name: 'event-date-start',
+                dateFormat: 'YYYY-MM-DD',
+                defaultValue: defaultStartDate,
+                onChange: (value) => {
+                  setStartDate(value ?? '')
+                },
+              }}
+              endDateHint="YYYY-MM-DD"
+              endDateLabel="End Date"
+              endDatePickerProps={{
+                form: '',
+                id: 'event-date-end',
+                name: 'event-date-end',
+                dateFormat: 'YYYY-MM-DD',
+                defaultValue: defaultEndDate,
+                onChange: (value) => {
+                  setEndDate(value ?? '')
+                },
+              }}
+            />
           )}
-        </DetailsDropdownContent>
-      )}
+        </CardBody>
+        {showDateRange && (
+          <CardFooter>
+            <Button
+              type="button"
+              onClick={() => {
+                setShowContent(false)
+                const form = startDateInputRef.current?.form
+                if (form) submit(form)
+              }}
+            >
+              Submit
+            </Button>
+          </CardFooter>
+        )}
+      </DetailsDropdownContent>
     </>
   )
 }

--- a/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
@@ -198,11 +198,13 @@ export function DateSelector({
               />
             )}
           </CardBody>
-          <CardFooter>
-            <Button type="submit" form={form}>
-              <Icon.CalendarToday /> Submit
-            </Button>
-          </CardFooter>
+          {showDateRange && (
+            <CardFooter>
+              <Button type="submit" form={form}>
+                <Icon.CalendarToday /> Submit
+              </Button>
+            </CardFooter>
+          )}
         </DetailsDropdownContent>
       )}
     </>

--- a/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
@@ -5,7 +5,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { useSearchParams, useSubmit } from '@remix-run/react'
 import {
   Button,
   ButtonGroup,
@@ -68,14 +67,14 @@ function DateSelectorButton({
 }
 
 export function DateSelector({
+  form,
   defaultStartDate,
   defaultEndDate,
 }: {
+  form?: string
   defaultStartDate?: string
   defaultEndDate?: string
 }) {
-  const [searchParams] = useSearchParams()
-
   const [startDate, setStartDate] = useState(defaultStartDate)
   const [endDate, setEndDate] = useState(defaultEndDate)
   const [showContent, setShowContent] = useState(false)
@@ -85,28 +84,20 @@ export function DateSelector({
   )
   const [showDateRange, setShowDateRange] = useState(defaultShowDateRange)
 
-  const submit = useSubmit()
-
   function radioOnChange({ target: { value } }: ChangeEvent<HTMLInputElement>) {
     setShowDateRange(false)
     setStartDate(value)
     setEndDate('')
   }
 
-  function setDateRange() {
-    setShowContent(false)
-    if (startDate) searchParams.set('startDate', startDate)
-    else searchParams.delete('startDate')
-    if (endDate) searchParams.set('endDate', endDate)
-    else searchParams.delete('endDate')
-    submit(searchParams, {
-      method: 'get',
-      action: '/circulars',
-    })
-  }
-
   return (
     <>
+      {Boolean(startDate) && (
+        <input type="hidden" name="startDate" form={form} value={startDate} />
+      )}
+      {Boolean(endDate) && (
+        <input type="hidden" name="endDate" form={form} value={endDate} />
+      )}
       <DateSelectorButton
         startDate={defaultStartDate}
         endDate={defaultEndDate}
@@ -188,13 +179,7 @@ export function DateSelector({
             )}
 
             <CardFooter>
-              <Button
-                type="button"
-                form="searchForm"
-                onClick={() => {
-                  setDateRange()
-                }}
-              >
+              <Button type="submit" form={form}>
                 <Icon.CalendarToday /> Submit
               </Button>
             </CardFooter>

--- a/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/_gcn.circulars._archive._index/DateSelectorMenu.tsx
@@ -121,6 +121,7 @@ export function DateSelector({
             <Grid row>
               <Grid col={4} key="radio-alltime">
                 <Radio
+                  form=""
                   id="radio-alltime"
                   name="radio-date"
                   value=""
@@ -132,6 +133,7 @@ export function DateSelector({
               {Object.entries(dateSelectorLabels).map(([value, label]) => (
                 <Grid col={4} key={`radio-${value}`}>
                   <Radio
+                    form=""
                     id={`radio-${value}`}
                     name="radio-date"
                     value={value}
@@ -143,6 +145,7 @@ export function DateSelector({
               ))}
               <Grid col={4}>
                 <Radio
+                  form=""
                   id="radio-custom"
                   name="radio-date"
                   value="custom"
@@ -160,6 +163,7 @@ export function DateSelector({
                 startDateLabel="Start Date"
                 className="margin-bottom-2"
                 startDatePickerProps={{
+                  form: '',
                   id: 'event-date-start',
                   name: 'event-date-start',
                   dateFormat: 'YYYY-MM-DD',
@@ -171,6 +175,7 @@ export function DateSelector({
                 endDateHint="YYYY-MM-DD"
                 endDateLabel="End Date"
                 endDatePickerProps={{
+                  form: '',
                   id: 'event-date-end',
                   name: 'event-date-end',
                   dateFormat: 'YYYY-MM-DD',

--- a/app/routes/_gcn.circulars._archive._index/route.tsx
+++ b/app/routes/_gcn.circulars._archive._index/route.tsx
@@ -23,7 +23,7 @@ import {
   TextInput,
 } from '@trussworks/react-uswds'
 import clamp from 'lodash/clamp'
-import { useState } from 'react'
+import { useId, useState } from 'react'
 
 import { getUser } from '../_gcn._auth/user.server'
 import {
@@ -114,6 +114,7 @@ export default function () {
   const [inputQuery, setInputQuery] = useState(query)
   const clean = inputQuery === query
 
+  const formId = useId()
   const submit = useSubmit()
 
   return (
@@ -123,7 +124,7 @@ export default function () {
         <Form
           className="display-inline-block usa-search usa-search--small"
           role="search"
-          id="searchForm"
+          id={formId}
         >
           <Label srOnly={true} htmlFor="query">
             Search
@@ -150,7 +151,11 @@ export default function () {
           </Button>
         </Form>
         {featureCircularsFilterByDate && (
-          <DateSelector defaultStartDate={startDate} defaultEndDate={endDate} />
+          <DateSelector
+            form={formId}
+            defaultStartDate={startDate}
+            defaultEndDate={endDate}
+          />
         )}
         <Link to={`/circulars/new${searchString}`}>
           <Button

--- a/app/routes/_gcn.circulars._archive._index/route.tsx
+++ b/app/routes/_gcn.circulars._archive._index/route.tsx
@@ -150,7 +150,7 @@ export default function () {
           </Button>
         </Form>
         {featureCircularsFilterByDate && (
-          <DateSelector startDate={startDate} endDate={endDate} />
+          <DateSelector defaultStartDate={startDate} defaultEndDate={endDate} />
         )}
         <Link to={`/circulars/new${searchString}`}>
           <Button

--- a/app/routes/_gcn.circulars._archive._index/route.tsx
+++ b/app/routes/_gcn.circulars._archive._index/route.tsx
@@ -39,7 +39,6 @@ import CircularsIndex from './CircularsIndex'
 import { DateSelector } from './DateSelectorMenu'
 import Hint from '~/components/Hint'
 import { getFormDataString } from '~/lib/utils'
-import { useFeature } from '~/root'
 
 import searchImg from 'nasawds/src/img/usa-icons-bg/search--white.svg'
 
@@ -92,7 +91,6 @@ export async function action({ request }: ActionFunctionArgs) {
 export default function () {
   const newItem = useActionData<typeof action>()
   const { items, page, totalPages, totalItems } = useLoaderData<typeof loader>()
-  const featureCircularsFilterByDate = useFeature('CIRCULARS_FILTER_BY_DATE')
 
   // Concatenate items from the action and loader functions
   const allItems = [...(newItem ? [newItem] : []), ...(items || [])]
@@ -150,13 +148,11 @@ export default function () {
             />
           </Button>
         </Form>
-        {featureCircularsFilterByDate && (
-          <DateSelector
-            form={formId}
-            defaultStartDate={startDate}
-            defaultEndDate={endDate}
-          />
-        )}
+        <DateSelector
+          form={formId}
+          defaultStartDate={startDate}
+          defaultEndDate={endDate}
+        />
         <Link to={`/circulars/new${searchString}`}>
           <Button
             type="button"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@remix-run/css-bundle": "^2.5.1",
         "@remix-run/node": "^2.5.1",
         "@remix-run/react": "^2.5.1",
-        "@trussworks/react-uswds": "^6.2.0",
+        "@trussworks/react-uswds": "github:lpsinger/react-uswds#dateFormat",
         "aws-lambda-ses-forwarder": "github:lpsinger/aws-lambda-ses-forwarder#aws-sdk-v3",
         "classnames": "^2.5.1",
         "color-convert": "^2.0.1",
@@ -9203,8 +9203,8 @@
     },
     "node_modules/@trussworks/react-uswds": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@trussworks/react-uswds/-/react-uswds-6.2.0.tgz",
-      "integrity": "sha512-B7Yi9hy+dF4A3XiXUB3BofvcNekhcb/NTldaAIM4Lt+jEd7wIFbTJc03v1inIJHUMLcke0nYFx4gOmixpivPZg==",
+      "resolved": "git+ssh://git@github.com/lpsinger/react-uswds.git#817c705612f2c4eda57a2ad20375aa260bfe20d8",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">= 16.20.0"
       },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@remix-run/css-bundle": "^2.5.1",
     "@remix-run/node": "^2.5.1",
     "@remix-run/react": "^2.5.1",
-    "@trussworks/react-uswds": "^6.2.0",
+    "@trussworks/react-uswds": "github:lpsinger/react-uswds#dateFormat",
     "aws-lambda-ses-forwarder": "github:lpsinger/aws-lambda-ses-forwarder#aws-sdk-v3",
     "classnames": "^2.5.1",
     "color-convert": "^2.0.1",


### PR DESCRIPTION
Fix several front-end bugs in the date selector:
- When you expand the date selector, the correct default values are selected if have chosen all time or a custom date range.
- We now submit the form using ordinary form submission rather than manually adjusting the query string. This allows for easier composition with additional inputs elements in the same form.
- We now submit the form automatically when you select a fuzzy date radio button.
- Switch to display with the YYYY-MM-DD format, which more closely resembles dates displayed in the GCN Circular archive. Note that this depends upon https://github.com/trussworks/react-uswds/pull/2726.

Finally, remove the feature flag.