### PR TITLE
Update Node.js version to 20.x

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -142,7 +142,7 @@ synonyms
   name synonymsById
 
 @aws
-runtime nodejs18.x
+runtime nodejs20.x
 region us-east-1
 architecture arm64
 memory 256

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,7 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@architect/hydrate": "github:lpsinger/hydrate#pip-fixes"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "sideEffects": false,
   "prettier": {


### PR DESCRIPTION
AWS Lambda support for Node.js 20.x landed in November 2023.

See https://aws.amazon.com/blogs/compute/node-js-20-x-runtime-now-available-in-aws-lambda/#:~:text=Lambda%20now%20supports%20Node.,deploy%20functions%20using%20the%20Node.