### PR TITLE
Remove News from navbar

### DIFF
--- a/app/routes/_gcn/header/Header.tsx
+++ b/app/routes/_gcn/header/Header.tsx
@@ -135,14 +135,6 @@ export function Header() {
               >
                 Documentation
               </NavLink>,
-              <NavLink
-                className="usa-nav__link"
-                to="/news"
-                key="/news"
-                onClick={hideMobileNav}
-              >
-                News
-              </NavLink>,
               email ? (
                 <>
                   <NavDropDownButton


### PR DESCRIPTION
It takes up too much space.

# Before

<img width="1140" alt="Screenshot 2024-01-29 at 14 01 51" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/bae6e7f2-bf3f-4650-99f1-d582c026a521">

# After

<img width="1140" alt="Screenshot 2024-01-29 at 14 07 29" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/afc7add7-9b23-481f-b468-ce79e5ed934d">
