### PR TITLE
Add space-track.org env variables to contributing config page.

### DIFF
--- a/app/routes/_gcn.docs.contributing.configuration/route.mdx
+++ b/app/routes/_gcn.docs.contributing.configuration/route.mdx
@@ -118,5 +118,12 @@ _All_ environment variables are _optional in local development_. _All_ environme
       </Description>
       <Default>No features</Default>
     </tr>
+    <tr>
+      <Key>`SPACE_TRACK_USER`, `SPACE_TRACK_PASS`</Key>
+      <Description>
+        [space-track.org](https://www.space-track.org/) username and password
+      </Description>
+      <Default>ACROSS API feasibility tools disabled.</Default>
+    </tr>
   </tbody>
 </Table>

--- a/app/routes/_gcn.docs.contributing.configuration/route.mdx
+++ b/app/routes/_gcn.docs.contributing.configuration/route.mdx
@@ -123,7 +123,7 @@ _All_ environment variables are _optional in local development_. _All_ environme
       <Description>
         [space-track.org](https://www.space-track.org/) username and password
       </Description>
-      <Default>ACROSS API feasibility tools disabled.</Default>
+      <Default>ACROSS API feasibility tools disabled</Default>
     </tr>
   </tbody>
 </Table>


### PR DESCRIPTION
Adds information about space-track.org environment variables to the GCN Contributing / Configuration page. 

Fixes #1872 