### PR TITLE
Ignore python/vendor directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pytest.ini_options]
+addopts = "--ignore=python/vendor"


### PR DESCRIPTION
This permits test discovery to work while running a sandbox server.