### PR TITLE
ACROSS API: Add SAA and EarthLimb constraint classes

### DIFF
--- a/python/across_api/base/constraints.py
+++ b/python/across_api/base/constraints.py
@@ -14,7 +14,7 @@ from shapely import Polygon, points  # type: ignore[import]
 from .ephem import EphemBase
 
 
-def getslice(time: Time, ephem: EphemBase) -> slice:
+def get_slice(time: Time, ephem: EphemBase) -> slice:
     """
     Return a slice for what the part of the ephemeris that we're using.
 
@@ -101,13 +101,13 @@ class SAAPolygonConstraint(Constraint):
         """
 
         # Find a slice what the part of the ephemeris that we're using
-        i = getslice(time, ephem)
+        i = get_slice(time, ephem)
 
-        inconstraint = self.polygon.contains(
+        in_constraint = self.polygon.contains(
             points(ephem.longitude[i], ephem.latitude[i])
         )
         # Return the result as True or False, or an array of True/False
-        return inconstraint[0] if time.isscalar else inconstraint
+        return in_constraint[0] if time.isscalar else in_constraint
 
 
 class EarthLimbConstraint(Constraint):
@@ -166,16 +166,18 @@ class EarthLimbConstraint(Constraint):
         assert skycoord is not None, "SkyCoord object must be passed"
 
         # Find a slice what the part of the ephemeris that we're using
-        i = getslice(time, ephem)
+        i = get_slice(time, ephem)
 
         # Calculate the angular distance between the center of the Earth and
         # the object. Note that creating the SkyCoord here from ra/dec stored
         # in the ephemeris `earth` is 3x faster than just doing the separation
         # directly with `earth`.
-        inconstraint = (
+        in_constraint = (
             SkyCoord(ephem.earth[i].ra, ephem.earth[i].dec).separation(skycoord)
             < ephem.earthsize[i] + self.min_angle
         )
 
         # Return the result as True or False, or an array of True/False
-        return inconstraint[0] if time.isscalar and skycoord.isscalar else inconstraint
+        return (
+            in_constraint[0] if time.isscalar and skycoord.isscalar else in_constraint
+        )

--- a/python/across_api/base/constraints.py
+++ b/python/across_api/base/constraints.py
@@ -2,8 +2,7 @@
 # Administrator of the National Aeronautics and Space Administration.
 # All Rights Reserved.
 
-from abc import ABC, abstractmethod
-from typing import Optional, Union
+from typing import Union
 
 import astropy.units as u  # type: ignore[import]
 import numpy as np
@@ -50,17 +49,7 @@ def get_slice(time: Time, ephem: EphemBase) -> slice:
         return slice(ephem.ephindex(time[0]), ephem.ephindex(time[-1]) + 1)
 
 
-class Constraint(ABC):
-    """Define the basic structure of a Constraint class."""
-
-    @abstractmethod
-    def __call__(
-        self, time: Time, ephem: EphemBase, skycoord: Optional[SkyCoord] = None
-    ) -> Union[bool, np.ndarray]:
-        pass
-
-
-class SAAPolygonConstraint(Constraint):
+class SAAPolygonConstraint:
     """
     Polygon based SAA constraint. The SAA is defined by a Shapely Polygon, and
     this constraint will calculate for a given set of times and a given
@@ -77,9 +66,7 @@ class SAAPolygonConstraint(Constraint):
     def __init__(self, polygon: list):
         self.polygon = Polygon(polygon)
 
-    def __call__(
-        self, time: Time, ephem: EphemBase, skycoord: Optional[SkyCoord] = None
-    ) -> Union[bool, np.ndarray]:
+    def __call__(self, time: Time, ephem: EphemBase) -> Union[bool, np.ndarray]:
         """
         Return a bool array indicating whether the spacecraft is in constraint
         for a given ephemeris.
@@ -110,7 +97,7 @@ class SAAPolygonConstraint(Constraint):
         return in_constraint[0] if time.isscalar else in_constraint
 
 
-class EarthLimbConstraint(Constraint):
+class EarthLimbConstraint:
     """
     For a given Earth limb avoidance angle, is a given coordinate inside this
     constraint?
@@ -136,7 +123,7 @@ class EarthLimbConstraint(Constraint):
         self,
         time: Time,
         ephem: EphemBase,
-        skycoord: Optional[SkyCoord] = None,
+        skycoord: SkyCoord,
     ) -> Union[bool, np.ndarray]:
         """
         Check for a given time, ephemeris and coordinate if positions given are
@@ -162,9 +149,6 @@ class EarthLimbConstraint(Constraint):
             otherwise.
 
         """
-        # This class requires a SkyCoord object to be passed
-        assert skycoord is not None, "SkyCoord object must be passed"
-
         # Find a slice what the part of the ephemeris that we're using
         i = get_slice(time, ephem)
 

--- a/python/across_api/base/constraints.py
+++ b/python/across_api/base/constraints.py
@@ -1,0 +1,181 @@
+# Copyright © 2023 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+
+from abc import ABC, abstractmethod
+from typing import Optional, Union
+
+import astropy.units as u  # type: ignore[import]
+import numpy as np
+from astropy.coordinates import Angle, SkyCoord  # type: ignore[import]
+from astropy.time import Time  # type: ignore[import]
+from shapely import Polygon, points  # type: ignore[import]
+
+from .ephem import EphemBase
+
+
+def getslice(time: Time, ephem: EphemBase) -> slice:
+    """
+    Return a slice for what the part of the ephemeris that we're using.
+
+    Arguments
+    ---------
+    time
+        The time to calculate the slice for
+    ephem
+        The spacecraft ephemeris
+
+    Returns
+    -------
+        The slice for the ephemeris
+    """
+    # If we're just passing a single time, we can just find the index for that
+    if time.isscalar:
+        # Check that the time is within the ephemeris range, this should never
+        # happen as the ephemeris is generated based on this range.
+        assert (
+            time >= ephem.begin and time <= ephem.end
+        ), "Time outside of ephemeris of range"
+        # Find the index for the time and return a slice for that index
+        index = ephem.ephindex(time)
+        return slice(index, index + 1)
+    else:
+        # Check that the time range is within the ephemeris range, as above.
+        assert (
+            time[0] >= ephem.begin and time[-1] <= ephem.end
+        ), "Time outside of ephemeris of range"
+
+        # Find the indices for the start and end of the time range and return a
+        # slice for that range
+        return slice(ephem.ephindex(time[0]), ephem.ephindex(time[-1]) + 1)
+
+
+class Constraint(ABC):
+    """Define the basic structure of a Constraint class."""
+
+    @abstractmethod
+    def __call__(
+        self, time: Time, ephem: EphemBase, skycoord: Optional[SkyCoord] = None
+    ) -> Union[bool, np.ndarray]:
+        pass
+
+
+class SAAPolygonConstraint(Constraint):
+    """
+    Polygon based SAA constraint. The SAA is defined by a Shapely Polygon, and
+    this constraint will calculate for a given set of times and a given
+    ephemeris whether the spacecraft is in that SAA polygon.
+
+    Attributes
+    ----------
+    polygon
+        Shapely Polygon object defining the SAA polygon.
+    """
+
+    polygon: Polygon
+
+    def __init__(self, polygon: list):
+        self.polygon = Polygon(polygon)
+
+    def __call__(
+        self, time: Time, ephem: EphemBase, skycoord: Optional[SkyCoord] = None
+    ) -> Union[bool, np.ndarray]:
+        """
+        Return a bool array indicating whether the spacecraft is in constraint
+        for a given ephemeris.
+
+        Arguments
+        ---------
+        time
+            The time(s) to calculate the constraint for.
+        ephem
+            The spacecraft ephemeris, must be precalculated. NOTE: The
+            ephemeris can be calculated for a longer time range than the `time`
+            argument, but it must contain the time(s) in the `time` argument.
+
+        Returns
+        -------
+            Array of booleans for every value in `time` returning True if the
+            spacecraft is in the SAA polygon at that time. If `time` is a
+            scalar then a single boolean is returned.
+        """
+
+        # Find a slice what the part of the ephemeris that we're using
+        i = getslice(time, ephem)
+
+        inconstraint = self.polygon.contains(
+            points(ephem.longitude[i], ephem.latitude[i])
+        )
+        # Return the result as True or False, or an array of True/False
+        return inconstraint[0] if time.isscalar else inconstraint
+
+
+class EarthLimbConstraint(Constraint):
+    """
+    For a given Earth limb avoidance angle, is a given coordinate inside this
+    constraint?
+
+    Parameters
+    ----------
+    min_angle
+        The minimum angle from the Earth limb that the spacecraft can point.
+
+    Methods
+    -------
+    __call__(coord, ephem, earthsize=None)
+        Checks if a given coordinate is inside the constraint.
+
+    """
+
+    min_angle: u.Quantity
+
+    def __init__(self, min_angle: u.Quantity):
+        self.min_angle = Angle(min_angle)
+
+    def __call__(
+        self,
+        time: Time,
+        ephem: EphemBase,
+        skycoord: Optional[SkyCoord] = None,
+    ) -> Union[bool, np.ndarray]:
+        """
+        Check for a given time, ephemeris and coordinate if positions given are
+        inside the Earth limb constraint. This is done by checking if the
+        separation between the Earth and the spacecraft is less than the
+        Earth's angular radius plus the minimum angle.
+
+        NOTE: Assumes a circular approximation for Earth.
+
+        Parameters
+        ----------
+        coord
+            The coordinate to check.
+        time
+            The time to check.
+        ephem
+            The ephemeris object.
+
+        Returns
+        -------
+        bool
+            `True` if the coordinate is inside the constraint, `False`
+            otherwise.
+
+        """
+        # This class requires a SkyCoord object to be passed
+        assert skycoord is not None, "SkyCoord object must be passed"
+
+        # Find a slice what the part of the ephemeris that we're using
+        i = getslice(time, ephem)
+
+        # Calculate the angular distance between the center of the Earth and
+        # the object. Note that creating the SkyCoord here from ra/dec stored
+        # in the ephemeris `earth` is 3x faster than just doing the separation
+        # directly with `earth`.
+        inconstraint = (
+            SkyCoord(ephem.earth[i].ra, ephem.earth[i].dec).separation(skycoord)
+            < ephem.earthsize[i] + self.min_angle
+        )
+
+        # Return the result as True or False, or an array of True/False
+        return inconstraint[0] if time.isscalar and skycoord.isscalar else inconstraint

--- a/python/across_api/burstcube/constraints.py
+++ b/python/across_api/burstcube/constraints.py
@@ -1,0 +1,36 @@
+# Copyright © 2023 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+
+from ..base.constraints import EarthLimbConstraint, SAAPolygonConstraint
+import astropy.units as u  # type: ignore
+
+"""Define constraints for the BurstCube Mission."""
+
+burstcube_saa_constraint = SAAPolygonConstraint(
+    polygon=[
+        (33.900000, -30.0),
+        (12.398, -19.876),
+        (-9.103, -9.733),
+        (-30.605, 0.4),
+        (-38.4, 2.0),
+        (-45.0, 2.0),
+        (-65.0, -1.0),
+        (-84.0, -6.155),
+        (-89.2, -8.880),
+        (-94.3, -14.220),
+        (-94.3, -18.404),
+        (-84.48631, -31.84889),
+        (-86.100000, -30.0),
+        (-72.34921, -43.98599),
+        (-54.5587, -52.5815),
+        (-28.1917, -53.6258),
+        (-0.2095279, -46.88834),
+        (28.8026, -34.0359),
+        (33.900000, -30.0),
+    ]
+)
+
+
+# EarthLimbConstraint
+burstcube_earth_constraint = EarthLimbConstraint(min_angle=0 * u.deg)

--- a/python/across_api/swift/constraints.py
+++ b/python/across_api/swift/constraints.py
@@ -1,0 +1,31 @@
+# Copyright © 2023 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+
+import astropy.units as u  # type: ignore
+
+from ..base.constraints import EarthLimbConstraint, SAAPolygonConstraint
+
+"""Define constraints for the BurstCube Mission."""
+
+# Swift Spacecraft SAA polygon as supplied by Swift team.
+swift_saa_constraint = SAAPolygonConstraint(
+    polygon=[
+        (39.0, -30.0),
+        (36.0, -26.0),
+        (28.0, -21.0),
+        (6.0, -12.0),
+        (-5.0, -6.0),
+        (-21.0, 2.0),
+        (-30.0, 3.0),
+        (-45.0, 2.0),
+        (-60.0, -2.0),
+        (-75.0, -7.0),
+        (-83.0, -10.0),
+        (-87.0, -16.0),
+        (-86.0, -23.0),
+        (-83.0, -30.0),
+    ]
+)
+
+swift_earth_constraint = EarthLimbConstraint(min_angle=33 * u.deg)

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -5,5 +5,6 @@ email-validator
 fastapi
 mangum
 requests
+shapely
 sgp4
 spacetrack

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -59,6 +59,7 @@ numpy==1.26.2
     # via
     #   astropy
     #   pyerfa
+    #   shapely
 packaging==23.2
     # via astropy
 pyasn1==0.5.1
@@ -86,6 +87,8 @@ rsa==4.9
 rush==2021.4.0
     # via spacetrack
 sgp4==2.23
+    # via -r requirements.in
+shapely==2.0.2
     # via -r requirements.in
 simplejson==3.19.2
     # via architect-functions

--- a/python/tests/constraints/conftest.py
+++ b/python/tests/constraints/conftest.py
@@ -1,0 +1,288 @@
+# Copyright © 2023 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+
+import astropy.units as u  # type: ignore
+import numpy as np
+import pytest
+from across_api.base.schema import TLEEntry  # type: ignore
+from across_api.burstcube.ephem import BurstCubeEphem  # type: ignore
+from across_api.burstcube.tle import BurstCubeTLE  # type: ignore
+from across_api.burstcube.constraints import (  # type: ignore
+    burstcube_saa_constraint,
+    burstcube_earth_constraint,
+)
+from across_api.swift.constraints import (  # type: ignore
+    swift_earth_constraint,
+    swift_saa_constraint,
+)
+from across_api.swift.ephem import SwiftEphem  # type: ignore
+from across_api.swift.tle import SwiftTLE  # type: ignore
+from astropy.coordinates import SkyCoord  # type: ignore
+from astropy.time import Time  # type: ignore
+
+
+def make_windows(insaa, timestamp):
+    """Function to make start and end windows from a boolean array of SAA
+    constraints and array of timestamps"""
+    # Find the start and end of the SAA windows
+    buff = np.concatenate(([False], insaa.tolist(), [False]))
+    begin = np.flatnonzero(~buff[:-1] & buff[1:])
+    end = np.flatnonzero(buff[:-1] & ~buff[1:])
+    indices = np.column_stack((begin, end - 1))
+    windows = timestamp[indices]
+
+    # Return as array of SAAEntry objects
+    return np.array([(win[0].unix, win[1].unix) for win in windows])
+
+
+@pytest.fixture
+def swift_ephem():
+    # Define a TLE by hand
+    satname = "SWIFT"
+    tle1 = "1 28485U 04047A   24029.43721350  .00012795  00000-0  63383-3 0  9994"
+    tle2 = "2 28485  20.5570  98.6682 0008279 273.6948  86.2541 15.15248522 52921"
+    tleentry = TLEEntry(satname=satname, tle1=tle1, tle2=tle2)
+
+    # Manually load this TLE
+    tle = SwiftTLE(epoch=Time("2024-01-29"), tle=tleentry)
+
+    # Calculate a Swift Ephemeris
+    return SwiftEphem(begin=Time("2024-01-29"), end=Time("2024-01-30"), tle=tle.tle)
+
+
+@pytest.fixture
+def swiftapi_saa_entries():
+    # Calculate Swift SAA passages using Swift API
+    # from swifttools.swift_too import SAA
+    #
+    # swift_saa = SAA(begin=Time("2024-01-29"), end=Time("2024-01-30"))
+    # swift_saa_entries = np.array(
+    #     [(e.begin.timestamp(), e.end.timestamp()) for e in swift_saa]
+    # )
+    return np.array(
+        [
+            [1.70648924e09, 1.70649016e09],
+            [1.70652691e09, 1.70652721e09],
+            [1.70653264e09, 1.70653389e09],
+            [1.70653851e09, 1.70653998e09],
+            [1.70654440e09, 1.70654596e09],
+            [1.70655034e09, 1.70655191e09],
+            [1.70655640e09, 1.70655785e09],
+            [1.70656248e09, 1.70656379e09],
+            [1.70656855e09, 1.70656972e09],
+        ]
+    )
+
+
+@pytest.fixture
+def burstcube_ephem():
+    # Define a TLE by hand
+    satname = "ISS (ZARYA)"
+    tle1 = "1 25544U 98067A   24003.59801929  .00015877  00000-0  28516-3 0  9995"
+    tle2 = "2 25544  51.6422  55.8239 0003397 348.6159 108.6885 15.50043818432877"
+    tleentry = TLEEntry(satname=satname, tle1=tle1, tle2=tle2)
+
+    # Manually load this TLE
+    tle = BurstCubeTLE(epoch=Time("2024-01-29"), tle=tleentry)
+
+    stepsize = 60 * u.s
+
+    # Calculate a BurstCube Ephemeris
+    eph = BurstCubeEphem(
+        begin=Time("2024-01-29"), end=Time("2024-01-30"), tle=tle.tle, stepsize=stepsize
+    )
+    return eph
+
+
+@pytest.fixture
+def burstcube_skyfield_saa():
+    # Calculate BurstCube SAA passages using skyfield
+    # from skyfield.api import load, wgs84, EarthSatellite, utc
+
+    # ts = load.timescale()
+    # satellite = EarthSatellite(tle1, tle2, satname, ts)
+    # bodies = load("de421.bsp")
+    # nowts = ts.from_datetimes([dt.replace(tzinfo=utc) for dt in eph.timestamp.datetime])
+    # gcrs = satellite.at(nowts)
+    # lat, lon = wgs84.latlon_of(gcrs)
+    # skyfield_lat = lat.degrees
+    # skyfield_lon = lon.degrees
+
+    # # Define a manual SAA polygon
+    # skyfield_saapoly = Polygon(
+    #     [
+    #         (33.900000, -30.0),
+    #         (12.398, -19.876),
+    #         (-9.103, -9.733),
+    #         (-30.605, 0.4),
+    #         (-38.4, 2.0),
+    #         (-45.0, 2.0),
+    #         (-65.0, -1.0),
+    #         (-84.0, -6.155),
+    #         (-89.2, -8.880),
+    #         (-94.3, -14.220),
+    #         (-94.3, -18.404),
+    #         (-84.48631, -31.84889),
+    #         (-86.100000, -30.0),
+    #         (-72.34921, -43.98599),
+    #         (-54.5587, -52.5815),
+    #         (-28.1917, -53.6258),
+    #         (-0.2095279, -46.88834),
+    #         (28.8026, -34.0359),
+    #         (33.900000, -30.0),
+    #     ]
+    # )
+
+    # # Calculate a boolean array of when BurstCube is inside this polygon
+    # skyfield_saa = skyfield_saapoly.contains(points(skyfield_lon, skyfield_lat))
+
+    # # Construct start and end windows
+    # skyfield_saa_windows = make_windows(skyfield_saa, eph.timestamp.unix)
+    skyfield_saa_windows = np.array(
+        [
+            [1.70648724e09, 1.70648790e09],
+            [1.70649264e09, 1.70649360e09],
+            [1.70649828e09, 1.70649930e09],
+            [1.70650392e09, 1.70650500e09],
+            [1.70651028e09, 1.70651088e09],
+            [1.70651130e09, 1.70651154e09],
+            [1.70651634e09, 1.70651724e09],
+            [1.70652210e09, 1.70652300e09],
+            [1.70652786e09, 1.70652870e09],
+            [1.70653362e09, 1.70653440e09],
+            [1.70653944e09, 1.70653992e09],
+            [1.70657082e09, 1.70657136e09],
+        ]
+    )
+    return skyfield_saa_windows
+
+
+@pytest.fixture
+def target():
+    return SkyCoord(120, 34, unit="deg")
+
+
+@pytest.fixture
+def swiftapi_visibility():
+    # from swifttools.swift_too import VisQuery
+    # target = SkyCoord(120,34,unit='deg')
+    # swift_vis = VisQuery(skycoord=target,begin=Time("2024-01-29"), end=Time("2024-01-30"),hires=True)
+    # swift_windows = np.array([(e.begin.timestamp(),e.end.timestamp())for e in swift_vis.entries])
+    swift_windows = np.array(
+        [
+            [1.70649018e09, 1.70649174e09],
+            [1.70649498e09, 1.70649744e09],
+            [1.70650068e09, 1.70650314e09],
+            [1.70650638e09, 1.70650884e09],
+            [1.70651208e09, 1.70651454e09],
+            [1.70651778e09, 1.70652018e09],
+            [1.70652348e09, 1.70652588e09],
+            [1.70652918e09, 1.70653158e09],
+            [1.70653488e09, 1.70653728e09],
+            [1.70654058e09, 1.70654298e09],
+            [1.70654628e09, 1.70654868e09],
+            [1.70655198e09, 1.70655438e09],
+            [1.70655786e09, 1.70656008e09],
+            [1.70656380e09, 1.70656578e09],
+            [1.70656974e09, 1.70657148e09],
+        ]
+    )
+    return swift_windows
+
+
+@pytest.fixture
+def swift_insaa(swift_ephem):
+    return swift_saa_constraint(time=swift_ephem.timestamp, ephem=swift_ephem)
+
+
+@pytest.fixture
+def swift_saa_entries(swift_ephem, swift_insaa):
+    return make_windows(swift_insaa, swift_ephem.timestamp)
+
+
+@pytest.fixture
+def swift_windows(swift_ephem, swift_insaa, target):
+    swift_earth_occult = swift_earth_constraint(
+        skycoord=target, time=swift_ephem.timestamp, ephem=swift_ephem
+    )
+    return make_windows(
+        np.logical_not(swift_earth_occult | swift_insaa), swift_ephem.timestamp
+    )
+
+
+@pytest.fixture
+def burstcube_insaa(burstcube_ephem):
+    return burstcube_saa_constraint(
+        time=burstcube_ephem.timestamp, ephem=burstcube_ephem
+    )
+
+
+@pytest.fixture
+def burstcube_saa_windows(burstcube_ephem, burstcube_insaa):
+    return make_windows(burstcube_insaa, burstcube_ephem.timestamp)
+
+
+@pytest.fixture
+def burstcube_windows(burstcube_ephem, target):
+    burstcube_earth_occult = burstcube_earth_constraint(
+        skycoord=target, time=burstcube_ephem.timestamp, ephem=burstcube_ephem
+    )
+    return make_windows(
+        np.logical_not(burstcube_earth_occult),
+        burstcube_ephem.timestamp,
+    )
+
+
+@pytest.fixture
+def burstcube_skyfield_windows():
+    # from skyfield.api import load, wgs84, EarthSatellite, utc
+    # import numpy as np
+    # from datetime import datetime, timedelta
+    # import astropy.units as u
+    # from astropy.coordinates import SkyCoord
+    # from astropy.time import Time
+
+    # satname = "ISS (ZARYA)"
+    # tle1 = "1 25544U 98067A   24003.59801929  .00015877  00000-0  28516-3 0  9995"
+    # tle2 = "2 25544  51.6422  55.8239 0003397 348.6159 108.6885 15.50043818432877"
+
+    # # Compute GCRS position using Skyfield library
+
+    # timestamps = [datetime(2024,1,29,tzinfo=utc)+timedelta(seconds=60*i) for i in range(1441)]
+
+    # ts = load.timescale()
+    # satellite = EarthSatellite(tle1, tle2, satname, ts)
+    # bodies = load("de421.bsp")
+    # nowts = ts.from_datetimes(timestamps)
+    # earthpos = (bodies["Earth"] + satellite).at(nowts).observe(bodies["Earth"])
+    # radec = earthpos.radec()
+    # skyfield_earthra = radec[0]._degrees * u.deg
+    # skyfield_earthdec = radec[1].degrees * u.deg
+    # skyfield_earthdec
+
+    # target = SkyCoord(120, 34, unit="deg")
+    # earth = SkyCoord(skyfield_earthra, skyfield_earthdec)
+    # inoccult = target.separation(earth).value < 70
+    # make_windows(inoccult,Time(timestamps))
+
+    return np.array(
+        [
+            [1.70648640e09, 1.70648844e09],
+            [1.70649060e09, 1.70649402e09],
+            [1.70649612e09, 1.70649960e09],
+            [1.70650170e09, 1.70650512e09],
+            [1.70650728e09, 1.70651070e09],
+            [1.70651286e09, 1.70651628e09],
+            [1.70651844e09, 1.70652186e09],
+            [1.70652402e09, 1.70652744e09],
+            [1.70652954e09, 1.70653302e09],
+            [1.70653512e09, 1.70653860e09],
+            [1.70654070e09, 1.70654412e09],
+            [1.70654628e09, 1.70654970e09],
+            [1.70655186e09, 1.70655528e09],
+            [1.70655738e09, 1.70656086e09],
+            [1.70656296e09, 1.70656644e09],
+            [1.70656854e09, 1.70657202e09],
+        ]
+    )

--- a/python/tests/constraints/conftest.py
+++ b/python/tests/constraints/conftest.py
@@ -1,25 +1,28 @@
 # Copyright © 2023 United States Government as represented by the
 # Administrator of the National Aeronautics and Space Administration.
 # All Rights Reserved.
+from datetime import datetime, timedelta
 
 import astropy.units as u  # type: ignore
 import numpy as np
 import pytest
 from across_api.base.schema import TLEEntry  # type: ignore
-from across_api.burstcube.ephem import BurstCubeEphem  # type: ignore
-from across_api.burstcube.tle import BurstCubeTLE  # type: ignore
 from across_api.burstcube.constraints import (  # type: ignore
-    burstcube_saa_constraint,
     burstcube_earth_constraint,
+    burstcube_saa_constraint,
 )
+from across_api.burstcube.ephem import BurstCubeEphem  # type: ignore
 from across_api.swift.constraints import (  # type: ignore
     swift_earth_constraint,
     swift_saa_constraint,
 )
 from across_api.swift.ephem import SwiftEphem  # type: ignore
 from across_api.swift.tle import SwiftTLE  # type: ignore
-from astropy.coordinates import SkyCoord  # type: ignore
-from astropy.time import Time  # type: ignore
+from astropy.coordinates import SkyCoord  # type: ignore[import]
+from astropy.time import Time  # type: ignore[import]
+from skyfield.api import EarthSatellite, load, utc, wgs84  # type: ignore
+from swifttools.swift_too import SAA, VisQuery  # type: ignore[import]
+from shapely import Polygon, points  # type: ignore[import]
 
 
 def make_windows(insaa, timestamp):
@@ -54,107 +57,88 @@ def swift_ephem():
 @pytest.fixture
 def swiftapi_saa_entries():
     # Calculate Swift SAA passages using Swift API
-    # from swifttools.swift_too import SAA
-    #
-    # swift_saa = SAA(begin=Time("2024-01-29"), end=Time("2024-01-30"))
-    # swift_saa_entries = np.array(
-    #     [(e.begin.timestamp(), e.end.timestamp()) for e in swift_saa]
-    # )
-    return np.array(
-        [
-            [1.70648924e09, 1.70649016e09],
-            [1.70652691e09, 1.70652721e09],
-            [1.70653264e09, 1.70653389e09],
-            [1.70653851e09, 1.70653998e09],
-            [1.70654440e09, 1.70654596e09],
-            [1.70655034e09, 1.70655191e09],
-            [1.70655640e09, 1.70655785e09],
-            [1.70656248e09, 1.70656379e09],
-            [1.70656855e09, 1.70656972e09],
-        ]
-    )
+
+    swift_saa = SAA(begin=Time("2024-01-29"), end=Time("2024-01-30"))
+    return np.array([(e.begin.timestamp(), e.end.timestamp()) for e in swift_saa])
 
 
 @pytest.fixture
-def burstcube_ephem():
+def burstcube_tle():
     # Define a TLE by hand
     satname = "ISS (ZARYA)"
     tle1 = "1 25544U 98067A   24003.59801929  .00015877  00000-0  28516-3 0  9995"
     tle2 = "2 25544  51.6422  55.8239 0003397 348.6159 108.6885 15.50043818432877"
     tleentry = TLEEntry(satname=satname, tle1=tle1, tle2=tle2)
 
-    # Manually load this TLE
-    tle = BurstCubeTLE(epoch=Time("2024-01-29"), tle=tleentry)
+    return tleentry
 
+
+@pytest.fixture
+def burstcube_ephem(burstcube_tle):
+    """BurstCube Ephemeris fixture"""
     stepsize = 60 * u.s
 
     # Calculate a BurstCube Ephemeris
     eph = BurstCubeEphem(
-        begin=Time("2024-01-29"), end=Time("2024-01-30"), tle=tle.tle, stepsize=stepsize
+        begin=Time("2024-01-29"),
+        end=Time("2024-01-30"),
+        tle=burstcube_tle,
+        stepsize=stepsize,
     )
     return eph
 
 
 @pytest.fixture
-def burstcube_skyfield_saa():
+def burstcube_skyfield_saa(burstcube_tle):
     # Calculate BurstCube SAA passages using skyfield
     # from skyfield.api import load, wgs84, EarthSatellite, utc
 
-    # ts = load.timescale()
-    # satellite = EarthSatellite(tle1, tle2, satname, ts)
-    # bodies = load("de421.bsp")
-    # nowts = ts.from_datetimes([dt.replace(tzinfo=utc) for dt in eph.timestamp.datetime])
-    # gcrs = satellite.at(nowts)
-    # lat, lon = wgs84.latlon_of(gcrs)
-    # skyfield_lat = lat.degrees
-    # skyfield_lon = lon.degrees
+    ts = load.timescale()
+    satellite = EarthSatellite(
+        burstcube_tle.tle1, burstcube_tle.tle2, burstcube_tle.satname, ts
+    )
 
-    # # Define a manual SAA polygon
-    # skyfield_saapoly = Polygon(
-    #     [
-    #         (33.900000, -30.0),
-    #         (12.398, -19.876),
-    #         (-9.103, -9.733),
-    #         (-30.605, 0.4),
-    #         (-38.4, 2.0),
-    #         (-45.0, 2.0),
-    #         (-65.0, -1.0),
-    #         (-84.0, -6.155),
-    #         (-89.2, -8.880),
-    #         (-94.3, -14.220),
-    #         (-94.3, -18.404),
-    #         (-84.48631, -31.84889),
-    #         (-86.100000, -30.0),
-    #         (-72.34921, -43.98599),
-    #         (-54.5587, -52.5815),
-    #         (-28.1917, -53.6258),
-    #         (-0.2095279, -46.88834),
-    #         (28.8026, -34.0359),
-    #         (33.900000, -30.0),
-    #     ]
-    # )
+    timestamps = [
+        datetime(2024, 1, 29, tzinfo=utc) + timedelta(seconds=60 * i)
+        for i in range(1441)
+    ]
+    nowts = ts.from_datetimes(timestamps)
+    gcrs = satellite.at(nowts)
+    lat, lon = wgs84.latlon_of(gcrs)
+    skyfield_lat = lat.degrees
+    skyfield_lon = lon.degrees
 
-    # # Calculate a boolean array of when BurstCube is inside this polygon
-    # skyfield_saa = skyfield_saapoly.contains(points(skyfield_lon, skyfield_lat))
-
-    # # Construct start and end windows
-    # skyfield_saa_windows = make_windows(skyfield_saa, eph.timestamp.unix)
-    skyfield_saa_windows = np.array(
+    # Define a manual SAA polygon
+    skyfield_saapoly = Polygon(
         [
-            [1.70648724e09, 1.70648790e09],
-            [1.70649264e09, 1.70649360e09],
-            [1.70649828e09, 1.70649930e09],
-            [1.70650392e09, 1.70650500e09],
-            [1.70651028e09, 1.70651088e09],
-            [1.70651130e09, 1.70651154e09],
-            [1.70651634e09, 1.70651724e09],
-            [1.70652210e09, 1.70652300e09],
-            [1.70652786e09, 1.70652870e09],
-            [1.70653362e09, 1.70653440e09],
-            [1.70653944e09, 1.70653992e09],
-            [1.70657082e09, 1.70657136e09],
+            (33.900000, -30.0),
+            (12.398, -19.876),
+            (-9.103, -9.733),
+            (-30.605, 0.4),
+            (-38.4, 2.0),
+            (-45.0, 2.0),
+            (-65.0, -1.0),
+            (-84.0, -6.155),
+            (-89.2, -8.880),
+            (-94.3, -14.220),
+            (-94.3, -18.404),
+            (-84.48631, -31.84889),
+            (-86.100000, -30.0),
+            (-72.34921, -43.98599),
+            (-54.5587, -52.5815),
+            (-28.1917, -53.6258),
+            (-0.2095279, -46.88834),
+            (28.8026, -34.0359),
+            (33.900000, -30.0),
         ]
     )
+
+    # Calculate a boolean array of when BurstCube is inside this polygon
+    skyfield_saa = skyfield_saapoly.contains(points(skyfield_lon, skyfield_lat))
+
+    # Construct start and end windows
+    skyfield_saa_windows = make_windows(skyfield_saa, Time(timestamps))
+
     return skyfield_saa_windows
 
 
@@ -165,28 +149,12 @@ def target():
 
 @pytest.fixture
 def swiftapi_visibility():
-    # from swifttools.swift_too import VisQuery
-    # target = SkyCoord(120,34,unit='deg')
-    # swift_vis = VisQuery(skycoord=target,begin=Time("2024-01-29"), end=Time("2024-01-30"),hires=True)
-    # swift_windows = np.array([(e.begin.timestamp(),e.end.timestamp())for e in swift_vis.entries])
+    target = SkyCoord(120, 34, unit="deg")
+    swift_vis = VisQuery(
+        skycoord=target, begin=Time("2024-01-29"), end=Time("2024-01-30"), hires=True
+    )
     swift_windows = np.array(
-        [
-            [1.70649018e09, 1.70649174e09],
-            [1.70649498e09, 1.70649744e09],
-            [1.70650068e09, 1.70650314e09],
-            [1.70650638e09, 1.70650884e09],
-            [1.70651208e09, 1.70651454e09],
-            [1.70651778e09, 1.70652018e09],
-            [1.70652348e09, 1.70652588e09],
-            [1.70652918e09, 1.70653158e09],
-            [1.70653488e09, 1.70653728e09],
-            [1.70654058e09, 1.70654298e09],
-            [1.70654628e09, 1.70654868e09],
-            [1.70655198e09, 1.70655438e09],
-            [1.70655786e09, 1.70656008e09],
-            [1.70656380e09, 1.70656578e09],
-            [1.70656974e09, 1.70657148e09],
-        ]
+        [(e.begin.timestamp(), e.end.timestamp()) for e in swift_vis.entries]
     )
     return swift_windows
 
@@ -235,54 +203,26 @@ def burstcube_windows(burstcube_ephem, target):
 
 
 @pytest.fixture
-def burstcube_skyfield_windows():
-    # from skyfield.api import load, wgs84, EarthSatellite, utc
-    # import numpy as np
-    # from datetime import datetime, timedelta
-    # import astropy.units as u
-    # from astropy.coordinates import SkyCoord
-    # from astropy.time import Time
+def burstcube_skyfield_windows(burstcube_tle):
+    # BurstCube TLE
 
-    # satname = "ISS (ZARYA)"
-    # tle1 = "1 25544U 98067A   24003.59801929  .00015877  00000-0  28516-3 0  9995"
-    # tle2 = "2 25544  51.6422  55.8239 0003397 348.6159 108.6885 15.50043818432877"
-
-    # # Compute GCRS position using Skyfield library
-
-    # timestamps = [datetime(2024,1,29,tzinfo=utc)+timedelta(seconds=60*i) for i in range(1441)]
-
-    # ts = load.timescale()
-    # satellite = EarthSatellite(tle1, tle2, satname, ts)
-    # bodies = load("de421.bsp")
-    # nowts = ts.from_datetimes(timestamps)
-    # earthpos = (bodies["Earth"] + satellite).at(nowts).observe(bodies["Earth"])
-    # radec = earthpos.radec()
-    # skyfield_earthra = radec[0]._degrees * u.deg
-    # skyfield_earthdec = radec[1].degrees * u.deg
-    # skyfield_earthdec
-
-    # target = SkyCoord(120, 34, unit="deg")
-    # earth = SkyCoord(skyfield_earthra, skyfield_earthdec)
-    # inoccult = target.separation(earth).value < 70
-    # make_windows(inoccult,Time(timestamps))
-
-    return np.array(
-        [
-            [1.70648640e09, 1.70648844e09],
-            [1.70649060e09, 1.70649402e09],
-            [1.70649612e09, 1.70649960e09],
-            [1.70650170e09, 1.70650512e09],
-            [1.70650728e09, 1.70651070e09],
-            [1.70651286e09, 1.70651628e09],
-            [1.70651844e09, 1.70652186e09],
-            [1.70652402e09, 1.70652744e09],
-            [1.70652954e09, 1.70653302e09],
-            [1.70653512e09, 1.70653860e09],
-            [1.70654070e09, 1.70654412e09],
-            [1.70654628e09, 1.70654970e09],
-            [1.70655186e09, 1.70655528e09],
-            [1.70655738e09, 1.70656086e09],
-            [1.70656296e09, 1.70656644e09],
-            [1.70656854e09, 1.70657202e09],
-        ]
+    # Compute GCRS position using Skyfield library
+    timestamps = [
+        datetime(2024, 1, 29, tzinfo=utc) + timedelta(seconds=60 * i)
+        for i in range(1441)
+    ]
+    ts = load.timescale()
+    satellite = EarthSatellite(
+        burstcube_tle.tle1, burstcube_tle.tle2, burstcube_tle.satname, ts
     )
+    bodies = load("de421.bsp")
+    nowts = ts.from_datetimes(timestamps)
+    earthpos = (bodies["Earth"] + satellite).at(nowts).observe(bodies["Earth"])
+    radec = earthpos.radec()
+    skyfield_earthra = radec[0]._degrees * u.deg
+    skyfield_earthdec = radec[1].degrees * u.deg
+
+    target = SkyCoord(120, 34, unit="deg")
+    earth = SkyCoord(skyfield_earthra, skyfield_earthdec)
+    inoccult = target.separation(earth).value < 70
+    return make_windows(np.logical_not(inoccult), Time(timestamps))

--- a/python/tests/constraints/test_burstcube_earthlimb.py
+++ b/python/tests/constraints/test_burstcube_earthlimb.py
@@ -1,0 +1,14 @@
+# Copyright © 2023 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+
+
+import numpy as np
+
+
+def test_burstcube_earthconstraint(burstcube_skyfield_windows, burstcube_windows):
+    errors = np.ravel(abs(burstcube_windows - burstcube_skyfield_windows))
+    # Check that visibility windows match to within 60 seconds
+    assert max(errors) <= 60
+    # Make sure < 5% of the start/stop times are off by +/-60 seconds
+    assert len(np.where(errors != 0)) / len(errors) < 0.05

--- a/python/tests/constraints/test_burstcube_saa.py
+++ b/python/tests/constraints/test_burstcube_saa.py
@@ -1,0 +1,9 @@
+# Copyright © 2023 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+
+
+def test_burstcube_saa(burstcube_skyfield_saa, burstcube_saa_windows):
+    assert (
+        (burstcube_saa_windows - burstcube_skyfield_saa) == 0
+    ).all(), "SAA calculated windows don't match"

--- a/python/tests/constraints/test_swift_earthlimb.py
+++ b/python/tests/constraints/test_swift_earthlimb.py
@@ -1,0 +1,14 @@
+# Copyright © 2023 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+
+
+import numpy as np
+
+
+def test_swift_earthconstraint(swiftapi_visibility, swift_windows):
+    errors = np.ravel(abs(swift_windows - swiftapi_visibility))
+    # Check that visibility windows match to within 60 seconds
+    assert max(errors) <= 60
+    # Make sure < 5% of the start/stop times are off by +/-60 seconds
+    assert len(np.where(errors != 0)) / len(errors) < 0.05

--- a/python/tests/constraints/test_swift_saa.py
+++ b/python/tests/constraints/test_swift_saa.py
@@ -1,0 +1,12 @@
+# Copyright © 2023 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+
+
+import numpy as np
+
+
+def test_swift_saa(swift_ephem, swiftapi_saa_entries, swift_saa_entries):
+    # Convert this to a list of start/stop windows
+    assert len(swiftapi_saa_entries) == len(swift_saa_entries)
+    assert (np.abs(swift_saa_entries - swiftapi_saa_entries) <= 60).all()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,6 @@ pytest
 types-requests
 types-cachetools
 types-python-jose
+skyfield==1.48
+swifttools==3.0.21
 -r python/requirements.txt


### PR DESCRIPTION
# Constraint Classes

This PR adds the following constraint classes. 

## `SAAPolygonConstraint`  

Calculate for a given spacecraft SAA polygon, if the spacecraft is in the SAA at a given time. The constraint class is instantiated with the polygon as an argument, and the object uses `__call__` to calculate a bool or array of bools indicating if the spacecraft is inside (`True`) or outside (`False`) the SAA. Arguments for are `time`, an astropy`Time` object (scalar or array-like) and a pre-calculated ephemeris object (e.g. `BurstCubeEphem`). `time` must be a subset of the times for which the ephemeris was calculated.

Constraint classes for BurstCube and Swift are instantiated with the correct SAA polygons for those missions.

## `EarthLimbConstraint` 

Calculates if a target is inside an Earth Limb constraint. When instantiating the class, `min_angle` determines how close to the Earth limb is considered a constraint, setting this to zero means you are calculating for a pure Earth occultation. Arguments for the object are the same as for `SAAPolygonConstraint` except it adds a required `skycoord` parameter which calculates the Earth limb constraint for a given `SkyCoord` object, this can be scalar or array-like.

## Tests

The PR also adds `pytest` tests for each constraint class, validating against pre-calculated values using third party methods, including using `skyfield` derived numbers and the [Swift TOO API](https://github.com/Swift-SOT/swifttools). 