### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,7 +39,7 @@ jobs:
         run: mypy python
 
       - name: Upload to Codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts nasa-gcn/gcn.nasa.gov#1881. See https://github.com/codecov/codecov-action/issues/1293