### PR TITLE
Circulars hide sort button without a query

### DIFF
--- a/app/routes/_gcn.circulars._archive._index/route.tsx
+++ b/app/routes/_gcn.circulars._archive._index/route.tsx
@@ -157,7 +157,7 @@ export default function () {
           defaultStartDate={startDate}
           defaultEndDate={endDate}
         />
-        <SortSelector form={formId} defaultValue={sort} />
+        {query && <SortSelector form={formId} defaultValue={sort} />}
         <Link to={`/circulars/new${searchString}`}>
           <Button
             type="button"

--- a/app/routes/_gcn.circulars/circulars.server.ts
+++ b/app/routes/_gcn.circulars/circulars.server.ts
@@ -145,7 +145,7 @@ export async function search({
   const [startTime, endTime] = getValidDates(startDate, endDate)
 
   const sortObj =
-    sort === 'relevance'
+    sort === 'relevance' && query
       ? {}
       : {
           circularId: {


### PR DESCRIPTION
This is just a basic implementation that hides the button if there is no query. Will need to modify further to prevent it from being possible to manually add the url parameters to include `sort=relevance` and have the circulars load in the random order

Fixes #1926 