### PR TITLE
Remove old, silly CSS rule

### DIFF
--- a/app/routes/_gcn.circulars.edit.$circularId/RichEditor/index.module.scss
+++ b/app/routes/_gcn.circulars.edit.$circularId/RichEditor/index.module.scss
@@ -28,11 +28,6 @@
     border-left: 1px solid darkslategray;
     border-right: 1px solid darkslategray;
     border-bottom: 1px solid darkslategray;
-
-    & :first-child {
-      padding-top: 0;
-      margin-top: 0;
-    }
   }
 
   textarea {


### PR DESCRIPTION
Remove a :first-child rule that was left over from an earlier iteration of the rich text editor.

I'm not sure what this was for, but it resulted in artifacts in table headings.

# Before

![Screenshot 2024-02-21 at 23 08 39](https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/4d34f21a-5e9c-40b3-ba48-b578c8c4e856)

# After

![Screenshot 2024-02-21 at 23 06 29](https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/a0e2484f-258a-4c1a-9665-84da98095185)