### PR TITLE
Add icon to plain text button

### DIFF
--- a/app/routes/_gcn.circulars.edit.$circularId/RichEditor/index.tsx
+++ b/app/routes/_gcn.circulars.edit.$circularId/RichEditor/index.tsx
@@ -30,6 +30,7 @@ import { onKeyDown } from './onKeyDown'
 import styles from './index.module.css'
 import iconBold from '@gitlab/svgs/dist/sprite_icons/bold.svg'
 import iconCode from '@gitlab/svgs/dist/sprite_icons/code.svg'
+import iconText from '@gitlab/svgs/dist/sprite_icons/doc-text.svg'
 import iconEllipsis from '@gitlab/svgs/dist/sprite_icons/ellipsis_h.svg'
 import iconHeading from '@gitlab/svgs/dist/sprite_icons/heading.svg'
 import iconItalic from '@gitlab/svgs/dist/sprite_icons/italic.svg'
@@ -58,7 +59,8 @@ function PlainTextButton({
 >) {
   return (
     <SlimButton outline={!checked} type="button" {...props}>
-      Plain Text
+      <GitLabIcon src={iconText} className="width-2 height-2" />
+      <span className="display-none tablet-lg:display-inline"> Plain Text</span>
     </SlimButton>
   )
 }
@@ -371,17 +373,11 @@ export function RichEditor({
             name="format"
             value={markdown ? 'text/markdown' : 'text/plain'}
           />
-          <ButtonGroup
-            type="segmented"
-            className="display-none desktop:display-flex"
-          >
+          <ButtonGroup type="segmented">
             <PlainTextButton
               {...toggleMarkdownButtonProps}
               checked={!markdown}
             />
-            <MarkdownButton {...toggleMarkdownButtonProps} checked={markdown} />
-          </ButtonGroup>
-          <ButtonGroup className="display-inline-block desktop:display-none">
             <MarkdownButton {...toggleMarkdownButtonProps} checked={markdown} />
           </ButtonGroup>
         </Grid>


### PR DESCRIPTION
| Size | Before | After |
| - | - | - |
| Mobile | <img width="763" alt="Screenshot 2024-02-22 at 10 20 46" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/360fe85c-9cc6-4694-bb65-6990387d7e63"> | <img width="763" alt="Screenshot 2024-02-22 at 10 19 40" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/ece0617c-db9c-4e73-a2db-51bf7fc3239f"> |
| Desktop | <img width="1207" alt="Screenshot 2024-02-22 at 10 20 51" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/a9c4dfcd-4f27-4588-bdf3-db9d418a278f"> | <img width="1207" alt="Screenshot 2024-02-22 at 10 19 18" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/de0bd14d-5b35-42b1-9d5a-053167657f3c"> |