### PR TITLE
ACROSS API: Add BurstCube TOO CRUD API

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -49,6 +49,9 @@ acrossapi_tle
   tle1 String
   tle2 String
 
+burstcube_too
+  id *String
+
 sessions
   _idx *String
   _ttl TTL
@@ -105,6 +108,11 @@ legacy_users
   PointInTimeRecovery true
 
 @tables-indexes
+burstcube_too
+  gsipk *String 
+  created_on **String
+  name byCreatedOn
+
 email_notification_subscription
   topic *String
   name byTopic

--- a/python/across_api/base/api.py
+++ b/python/across_api/base/api.py
@@ -4,10 +4,11 @@
 
 """
 Base API definitions for ACROSS API. This module is imported by all other API
-modules. Contains the FastAPI app definition.
+modules.
 """
 
 from fastapi import FastAPI
+
 
 # FastAPI app definition
 app = FastAPI(

--- a/python/across_api/base/constraints.py
+++ b/python/across_api/base/constraints.py
@@ -30,20 +30,10 @@ def get_slice(time: Time, ephem: EphemBase) -> slice:
     """
     # If we're just passing a single time, we can just find the index for that
     if time.isscalar:
-        # Check that the time is within the ephemeris range, this should never
-        # happen as the ephemeris is generated based on this range.
-        assert (
-            time >= ephem.begin and time <= ephem.end
-        ), "Time outside of ephemeris of range"
         # Find the index for the time and return a slice for that index
         index = ephem.ephindex(time)
         return slice(index, index + 1)
     else:
-        # Check that the time range is within the ephemeris range, as above.
-        assert (
-            time[0] >= ephem.begin and time[-1] <= ephem.end
-        ), "Time outside of ephemeris of range"
-
         # Find the indices for the start and end of the time range and return a
         # slice for that range
         return slice(ephem.ephindex(time[0]), ephem.ephindex(time[-1]) + 1)

--- a/python/across_api/base/depends.py
+++ b/python/across_api/base/depends.py
@@ -1,0 +1,172 @@
+# Copyright © 2023 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+
+from datetime import datetime
+from typing import Annotated, Optional
+
+import astropy.units as u  # type: ignore[import]
+from astropy.time import Time  # type: ignore[import]
+from fastapi import Depends, Path, Query
+
+
+# Depends functions for FastAPI calls.
+async def optional_daterange(
+    begin: Annotated[
+        Optional[datetime],
+        Query(
+            description="Start time of period to be calculated.",
+            title="Begin",
+        ),
+    ] = None,
+    end: Annotated[
+        Optional[datetime],
+        Query(
+            description="Start time of period to be calculated.",
+            title="End",
+        ),
+    ] = None,
+) -> dict:
+    """
+    Helper function to convert begin and end to datetime objects.
+    """
+    if begin is None or end is None:
+        return {"begin": None, "end": None}
+    return {"begin": Time(begin), "end": Time(end)}
+
+
+OptionalDateRangeDep = Annotated[dict, Depends(optional_daterange)]
+
+
+# Depends functions for FastAPI calls.
+async def optional_duration(
+    duration: Annotated[
+        Optional[float],
+        Query(
+            description="Duration of time (days).",
+            title="Duration",
+        ),
+    ] = None,
+) -> Optional[u.Quantity[u.day]]:
+    """
+    Helper function to convert a float duration in days to a u.Quantity
+    """
+    if duration is None:
+        return None
+    return duration * u.day
+
+
+OptionalDurationDep = Annotated[dict, Depends(optional_duration)]
+
+
+async def optional_limit(
+    limit: Annotated[
+        Optional[int],
+        Query(
+            ge=0,
+            title="Limit",
+            description="Maximum number of results to return.",
+        ),
+    ] = None,
+) -> Optional[int]:
+    return limit
+
+
+LimitDep = Annotated[Optional[int], Depends(optional_limit)]
+
+
+async def error_radius(
+    error_radius: Annotated[
+        Optional[float],
+        Query(
+            ge=0,
+            title="Error Radius",
+            description="Error radius in degrees.",
+        ),
+    ] = None,
+) -> Optional[u.Quantity[u.deg]]:
+    if error_radius is None:
+        return None
+    return error_radius * u.deg
+
+
+ErrorRadiusDep = Annotated[float, Depends(error_radius)]
+
+
+async def exposure(
+    exposure: Annotated[
+        float,
+        Query(
+            ge=0,
+            title="Exposure",
+            description="Exposure time in seconds.",
+        ),
+    ] = 200,
+) -> u.Quantity[u.s]:
+    return exposure * u.s
+
+
+ExposureDep = Annotated[float, Depends(exposure)]
+
+
+async def offset(
+    offset: Annotated[
+        float,
+        Query(
+            ge=-200,
+            le=200,
+            title="Offset",
+            description="Offset start of dump window from T0 by this amount (seconds).",
+        ),
+    ] = -50,
+) -> u.Quantity[u.s]:
+    return offset * u.s
+
+
+OffsetDep = Annotated[float, Depends(offset)]
+
+
+async def optional_ra_dec(
+    ra: Annotated[
+        Optional[float],
+        Query(
+            ge=0,
+            lt=360,
+            title="RA (J2000)",
+            description="Right Ascenscion in J2000 coordinates and units of decimal degrees.",
+        ),
+    ] = None,
+    dec: Annotated[
+        Optional[float],
+        Query(
+            ge=-90,
+            le=90,
+            title="Dec (J2000)",
+            description="Declination in J2000 coordinates in units of decimal degrees.",
+        ),
+    ] = None,
+) -> Optional[dict]:
+    if ra is None or dec is None:
+        return {"ra": None, "dec": None}
+    return {"ra": ra * u.deg, "dec": dec * u.deg}
+
+
+OptionalRaDecDep = Annotated[dict, Depends(optional_ra_dec)]
+
+
+IdDep = Annotated[str, Path(description="TOO ID string")]
+
+
+async def trigger_time(
+    trigger_time: Annotated[
+        datetime,
+        Query(
+            title="Trigger Time",
+            description="Time of trigger in UTC or ISO format.",
+        ),
+    ],
+) -> Optional[Time]:
+    return Time(trigger_time)
+
+
+TriggerTimeDep = Annotated[datetime, Depends(trigger_time)]

--- a/python/across_api/base/ephem.py
+++ b/python/across_api/base/ephem.py
@@ -86,7 +86,11 @@ class EphemBase:
         -------
             The index of the nearest time in the ephemeris.
         """
-        return int(np.argmin(np.abs((self.timestamp.datetime - t.datetime))))
+        index = np.round(
+            (t.jd - self.timestamp[0].jd) // self.stepsize.to_value(u.day)
+        ).astype(int)
+        assert index >= 0 and index < len(self), "Time outside of ephemeris of range"
+        return index
 
     def __init__(self, begin: Time, end: Time, stepsize: u.Quantity = 60 * u.s):
         # Check if TLE is loaded

--- a/python/across_api/burstcube/api.py
+++ b/python/across_api/burstcube/api.py
@@ -1,3 +1,186 @@
 # Copyright © 2023 United States Government as represented by the
 # Administrator of the National Aeronautics and Space Administration.
 # All Rights Reserved.
+
+import gzip
+from typing import Annotated, BinaryIO, Tuple, Union
+
+from astropy.io import fits  # type: ignore
+from fastapi import Depends, File, HTTPException, Security, UploadFile, status
+
+from ..auth.api import claims, scope_authorize
+from ..base.depends import (
+    ErrorRadiusDep,
+    ExposureDep,
+    IdDep,
+    LimitDep,
+    OffsetDep,
+    OptionalDateRangeDep,
+    OptionalDurationDep,
+    OptionalRaDecDep,
+    TriggerTimeDep,
+)
+from ..base.api import app
+from .schema import BurstCubeTOORequestsSchema, BurstCubeTOOSchema, BurstCubeTriggerInfo
+from .toorequest import BurstCubeTOO, BurstCubeTOORequests
+
+
+def read_healpix_file(healpix_file: UploadFile) -> Tuple[fits.FITS_rec, str]:
+    """Read in a HEALPix file in FITS format and return the HDUList. Supports
+    gzipped FITS files"""
+
+    # Type hint for the file object
+    file: Union[gzip.GzipFile, BinaryIO]
+
+    # If the file is a gzip file, open it with gzip.open, otherwise just
+    # pass along the filehandle
+    # FIXME: Remove compression handling if this issue is resolved:
+    # https://github.com/astropy/astropy/issues/16171
+    if healpix_file.content_type == "application/x-gzip":
+        file = gzip.open(healpix_file.file, "rb")
+    else:
+        file = healpix_file.file
+
+    # Open HEALPix fits file and extract data and ordering scheme
+    try:
+        with fits.open(file) as hdu:
+            healpix_data = hdu[1].data
+            healpix_scheme = hdu[1].header["ORDERING"]
+    except (OSError, KeyError, IndexError):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid HEALPix file.",
+        )
+    return healpix_data, healpix_scheme
+
+
+@app.post(
+    "/burstcube/too",
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[
+        Security(scope_authorize, scopes=["gcn.nasa.gov/burstcube-too-submitter"])
+    ],
+)
+async def burstcube_too_submit(
+    credential: Annotated[dict, Depends(claims)],
+    ra_dec: OptionalRaDecDep,
+    error_radius: ErrorRadiusDep,
+    trigger_time: TriggerTimeDep,
+    trigger_info: BurstCubeTriggerInfo,
+    exposure: ExposureDep,
+    offset: OffsetDep,
+    healpix_file: UploadFile = File(
+        None, description="HEALPix file describing the localization."
+    ),
+) -> BurstCubeTOOSchema:
+    """
+    Resolve the name of an astronomical object to its coordinates.
+    """
+    # Construct the TOO object.
+    too = BurstCubeTOO(
+        sub=credential["sub"],
+        ra=ra_dec["ra"],
+        dec=ra_dec["dec"],
+        error_radius=error_radius,
+        trigger_time=trigger_time,
+        trigger_info=trigger_info,
+        exposure=exposure,
+        offset=offset,
+    )
+    # If a HEALpix file was uploaded, open it and set the healpix_loc
+    # and healpix_scheme attributes.
+    if healpix_file is not None:
+        too.healpix_loc, too.healpix_scheme = read_healpix_file(healpix_file)
+    too.post()
+    return too.schema
+
+
+@app.put(
+    "/burstcube/too/{id}",
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[
+        Security(scope_authorize, scopes=["gcn.nasa.gov/burstcube-too-submitter"])
+    ],
+)
+async def burstcube_too_update(
+    id: IdDep,
+    credential: Annotated[dict, Depends(claims)],
+    ra_dec: OptionalRaDecDep,
+    error_radius: ErrorRadiusDep,
+    trigger_time: TriggerTimeDep,
+    trigger_info: BurstCubeTriggerInfo,
+    exposure: ExposureDep,
+    offset: OffsetDep,
+    healpix_file: UploadFile = File(
+        None, description="HEALPix file describing the localization."
+    ),
+) -> BurstCubeTOOSchema:
+    """
+    Update a BurstCube TOO object with the given ID number.
+    """
+    # Update the TOO object.
+    too = BurstCubeTOO(
+        id=id,
+        sub=credential["sub"],
+        ra=ra_dec["ra"],
+        dec=ra_dec["dec"],
+        error_radius=error_radius,
+        trigger_time=trigger_time,
+        trigger_info=trigger_info,
+        exposure=exposure,
+        offset=offset,
+    )
+    # If a HEALpix file was uploaded, open it and set the healpix_loc
+    # and healpix_scheme attributes.
+    if healpix_file is not None:
+        too.healpix_loc, too.healpix_scheme = read_healpix_file(healpix_file)
+    too.put()
+    return too.schema
+
+
+@app.get("/burstcube/too/", status_code=status.HTTP_200_OK)
+async def burstcube_too_requests(
+    daterange: OptionalDateRangeDep,
+    duration: OptionalDurationDep,
+    limit: LimitDep,
+) -> BurstCubeTOORequestsSchema:
+    """
+    Endpoint to retrieve BurstCube multiple TOO requests.
+    """
+    return BurstCubeTOORequests(
+        begin=daterange["begin"],
+        end=daterange["end"],
+        duration=duration,
+        limit=limit,
+    ).schema
+
+
+@app.get("/burstcube/too/{id}", status_code=status.HTTP_200_OK)
+async def burstcube_too(
+    id: IdDep,
+) -> BurstCubeTOOSchema:
+    """
+    Retrieve a BurstCube Target of Opportunity (TOO) by ID.
+    """
+    too = BurstCubeTOO(id=id)
+    too.get()
+    return too.schema
+
+
+@app.delete(
+    "/burstcube/too/{id}",
+    status_code=status.HTTP_200_OK,
+    dependencies=[
+        Security(scope_authorize, scopes=["gcn.nasa.gov/burstcube-too-submitter"])
+    ],
+)
+async def burstcube_delete_too(
+    credential: Annotated[dict, Depends(claims)],
+    id: IdDep,
+) -> BurstCubeTOOSchema:
+    """
+    Delete a BurstCube Target of Opportunity (TOO) with the given ID.
+    """
+    too = BurstCubeTOO(sub=credential["sub"], id=id)
+    too.delete()
+    return too.schema

--- a/python/across_api/burstcube/schema.py
+++ b/python/across_api/burstcube/schema.py
@@ -1,0 +1,190 @@
+# Copyright © 2023 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+
+
+from enum import Enum
+import json
+from typing import List, Optional
+
+import astropy.units as u  # type: ignore
+from astropy.time import Time  # type: ignore
+from pydantic import ConfigDict, model_validator  # type: ignore
+
+from ..base.schema import (
+    AstropySeconds,
+    AstropyTime,
+    BaseSchema,
+    OptionalDateRangeSchema,
+    OptionalPositionSchema,
+)
+
+
+class TOOReason(str, Enum):
+    """
+    Reasons for rejecting TOO observations
+
+    Attributes
+    ----------
+    saa
+        In SAA
+    earth_occult
+        Earth occulted
+    moon_occult
+        Moon occulted
+    sun_occult
+        Sun occulted
+    too_old
+        Too old
+    other
+        Other
+    none
+        None
+    """
+
+    saa = "In SAA"
+    earth_occult = "Earth occulted"
+    moon_occult = "Moon occulted"
+    sun_occult = "Sun occulted"
+    too_old = "Too old"
+    other = "Other"
+    none = "None"
+
+
+class TOOStatus(str, Enum):
+    """
+    Enumeration class representing the status of a Target of Opportunity (TOO) request.
+
+    Attributes:
+    requested
+        The TOO request has been submitted.
+    rejected
+        The TOO request has been rejected.
+    declined
+        The TOO request has been declined.
+    approved
+        The TOO request has been approved.
+    executed
+        The TOO request has been executed.
+    other
+        The TOO request has a status other than the predefined ones.
+    """
+
+    requested = "Requested"
+    rejected = "Rejected"
+    declined = "Declined"
+    approved = "Approved"
+    executed = "Executed"
+    deleted = "Deleted"
+    other = "Other"
+
+
+class BurstCubeTriggerInfo(BaseSchema):
+    """
+    Metadata schema for the BurstCube Target of Opportunity (TOO) request. Note
+    that this schema is not strictly defined, keys are only suggested, and
+    additional keys can be added as needed.
+    """
+
+    trigger_name: Optional[str] = None
+    trigger_mission: Optional[str] = None
+    trigger_instrument: Optional[str] = None
+    trigger_id: Optional[str] = None
+    trigger_duration: Optional[AstropySeconds] = None
+    classification: Optional[str] = None
+    justification: Optional[str] = None
+
+    model_config = ConfigDict(extra="allow")
+
+    @model_validator(mode="before")
+    def convert_json_string_to_dict(cls, data):
+        if isinstance(data, str):
+            return json.loads(data)
+        return data
+
+
+class BurstCubeTOOSchema(OptionalPositionSchema):
+    """
+    Schema describing a BurstCube TOO Request.
+    """
+
+    __tablename__ = "burstcube_too"
+    id: Optional[str] = None
+    created_by: str
+    created_on: AstropyTime
+    modified_by: Optional[str] = None
+    modified_on: Optional[AstropyTime] = None
+    trigger_time: AstropyTime
+    trigger_info: BurstCubeTriggerInfo
+    exposure: AstropySeconds
+    offset: AstropySeconds
+    reject_reason: TOOReason = TOOReason.none
+    status: TOOStatus = TOOStatus.requested
+    too_info: str = ""
+
+
+class BurstCubeTOODelSchema(BaseSchema):
+    """
+    Schema for BurstCubeTOO DELETE API call.
+
+    Attributes
+    ----------
+    id
+        The ID of the BurstCubeTOODel object.
+    """
+
+    id: str
+
+
+class BurstCubeTOOPostSchema(OptionalPositionSchema):
+    """
+    Schema to submit a TOO request for BurstCube.
+    """
+
+    trigger_time: AstropyTime
+    trigger_info: BurstCubeTriggerInfo
+    exposure: AstropySeconds = 200 * u.s
+    offset: AstropySeconds = -50 * u.s
+
+
+class BurstCubeTOOGetSchema(BaseSchema):
+    """
+    Schema for BurstCubeTOO GET request.
+    """
+
+    id: str
+
+
+class BurstCubeTOOPutSchema(BurstCubeTOOPostSchema):
+    """
+    Schema for BurstCubeTOO PUT request.
+    """
+
+    id: str
+
+
+class BurstCubeTOORequestsGetSchema(OptionalDateRangeSchema):
+    """
+    Schema for GET requests to retrieve BurstCube Target of Opportunity (TOO) requests.
+    """
+
+    length: Optional[u.Quantity] = None
+    limit: Optional[int] = None
+
+    @model_validator(mode="after")
+    def check_begin_and_end_or_length_set(self):
+        if self.begin is not None and self.end is not None and self.length is not None:
+            raise ValueError("Cannot set both begin and end and length.")
+        elif self.begin is not None and self.length is not None:
+            self.end = self.begin + self.length
+        elif self.begin is None and self.end is None and self.length is not None:
+            self.end = Time.now()
+            self.begin = self.end - self.length
+
+
+class BurstCubeTOORequestsSchema(BaseSchema):
+    """
+    Schema for BurstCube TOO requests.
+    """
+
+    entries: List[BurstCubeTOOSchema]

--- a/python/across_api/burstcube/toorequest.py
+++ b/python/across_api/burstcube/toorequest.py
@@ -1,0 +1,432 @@
+# Copyright © 2023 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+
+import hashlib
+import json
+from dataclasses import dataclass
+from decimal import Decimal  # type: ignore[import]
+from functools import cached_property
+from typing import Optional, Union
+
+import astropy.units as u  # type: ignore[import]
+import numpy as np
+from arc import tables  # type: ignore[import]
+from astropy.coordinates import (  # type: ignore[import]
+    Latitude,
+    Longitude,
+    SkyCoord,
+)
+from astropy.time import Time  # type: ignore[import]
+from boto3.dynamodb.conditions import Key  # type: ignore[import]
+from fastapi import HTTPException
+
+from ..base.common import ACROSSAPIBase
+from .constraints import burstcube_saa_constraint
+from .ephem import BurstCubeEphem
+from .fov import BurstCubeFOV
+from .schema import (
+    BurstCubeTOODelSchema,
+    BurstCubeTOOGetSchema,
+    BurstCubeTOOPostSchema,
+    BurstCubeTOOPutSchema,
+    BurstCubeTOORequestsGetSchema,
+    BurstCubeTOORequestsSchema,
+    BurstCubeTOOSchema,
+    BurstCubeTriggerInfo,
+    TOOReason,
+    TOOStatus,
+)
+
+
+@dataclass
+class BurstCubeTOO(ACROSSAPIBase):
+    """
+    Class to handle BurstCube Target of Opportunity Requests
+
+    Parameters
+    ----------
+    sub
+        sub of user making request
+    id
+        ID of BurstCubeTOO to fetch, by default None
+    created_by
+        sub of user who created the BurstCubeTOO, by default None
+    created_on
+        Time BurstCubeTOO was created, by default None
+    modified_by
+        sub of user who last modified the BurstCubeTOO, by default None
+    modified_on
+        Time BurstCubeTOO was last modified, by default None
+    trigger_time
+        Time of trigger, by default None
+    trigger_info
+        Information about the trigger, by default None
+    exposure
+        Exposure time, by default 200 * u.s
+    offset
+        Offset time, by default -50 * u.s
+    ra
+        Right Ascension, by default None
+    dec
+        Declination, by default None
+    error_radius
+        Error radius, by default None
+    healpix_loc
+        HEALPix location, by default None
+    healpix_scheme
+        HEALPix scheme, by default "nested"
+    reject_reason
+        Reason for rejection, by default `TOOReason.none`
+    status
+        Status of request, by default "Requested"
+    too_info
+        Information about the TOO, by default ""
+    min_prob
+        Minimum probability in FOV to accept a TOO request, by default 0.10
+    """
+
+    _schema = BurstCubeTOOSchema
+    _get_schema = BurstCubeTOOGetSchema
+    _put_schema = BurstCubeTOOPutSchema
+    _del_schema = BurstCubeTOODelSchema
+    _post_schema = BurstCubeTOOPostSchema
+
+    id: Optional[str] = None
+    sub: Optional[str] = None
+    created_by: Optional[str] = None
+    created_on: Optional[Time] = None
+    modified_by: Optional[str] = None
+    modified_on: Optional[Time] = None
+    trigger_time: Optional[Time] = None
+    trigger_info: Optional[BurstCubeTriggerInfo] = None
+    exposure: u.Quantity[u.s] = 200 * u.s
+    offset: u.Quantity[u.s] = -50 * u.s
+    ra: Union[u.Quantity[u.deg], Longitude, None] = None
+    dec: Union[u.Quantity[u.deg], Latitude, None] = None
+    error_radius: Optional[u.Quantity[u.deg]] = None
+    healpix_loc: Optional[np.ndarray] = None
+    healpix_scheme: str = "nested"
+    reject_reason: TOOReason = TOOReason.none
+    status: TOOStatus = TOOStatus.requested
+    too_info: str = ""
+    min_prob: float = 0.10  # 10% of probability in FOV
+
+    @property
+    def table(self):
+        """Return the table for the BurstCubeTOO."""
+        if not hasattr(self, "_table"):
+            self._table = tables.table(BurstCubeTOOSchema.__tablename__)
+        return self._table
+
+    @table.setter
+    def table(self, value):
+        self._table = value
+
+    @cached_property
+    def skycoord(self) -> Optional[SkyCoord]:
+        """Return the skycoord of the BurstCubeTOO."""
+        if self.ra is not None and self.dec is not None:
+            return SkyCoord(self.ra, self.dec)
+        return None
+
+    def get(self) -> bool:
+        """
+        Fetch a BurstCubeTOO for a given id.
+
+        Returns
+        -------
+            Did this work? True | False
+        """
+
+        # Fetch BurstCubeTOO from database
+        response = self.table.get_item(Key={"id": self.id})
+        if "Item" not in response:
+            raise HTTPException(404, "BurstCubeTOO not found.")
+
+        # Validate the response
+        too = BurstCubeTOOSchema.model_validate(response["Item"])
+
+        # Set the attributes of the BurstCubeTOO to the values from the database
+        for k, v in too:
+            setattr(self, k, v)
+        return True
+
+    def delete(self) -> bool:
+        """
+        Delete a given too, specified by id. created_by of BurstCubeTOO has to match yours.
+
+        Returns
+        -------
+            Did this work? True | False
+        """
+        if self.validate_del():
+            if self.get():
+                # FIXME: Need proper authentication here
+                if self.created_by != self.sub:
+                    raise HTTPException(401, "BurstCubeTOO not owned by user.")
+
+                self.status = TOOStatus.deleted
+                self.modified_by = self.sub
+                self.modified_on = Time.now().datetime.isoformat()
+                # Write updated BurstCubeTOO to the database
+                json_too = json.loads(
+                    self.schema.model_dump_json(), parse_float=Decimal
+                )
+                # Add fixed partition key for the GSI
+                json_too["gsipk"] = 1
+                self.table.put_item(Item=json_too)
+            return True
+        return False
+
+    def put(self) -> bool:
+        """
+        Alter existing BurstCube BurstCubeTOO using ACROSS API using POST
+
+        Returns
+        -------
+            Did this work? True | False
+        """
+        # Make sure the PUT request validates
+        if not self.validate_put():
+            return False
+
+        # Check if this BurstCubeTOO exists
+        response = self.table.get_item(Key={"id": self.id})
+
+        # Check if the TOO exists
+        if "Item" not in response:
+            raise HTTPException(404, "BurstCubeTOO not found.")
+
+        # Reconstruct the TOO as it exists in the database
+        old_too = BurstCubeTOO(**response["Item"])
+
+        # FIXME: Some validation as to whether the user is allowed to update
+        # this entry
+
+        # Check if the coordinates are being changed, if yes, run the
+        # check_constraints again. If a healpix file is being uploaded, run
+        # the check_constraints again, as we don't record the healpix_loc for comparison.
+        if (
+            self.ra != old_too.ra
+            or self.dec != old_too.dec
+            or self.error_radius != old_too.error_radius
+            or self.healpix_loc is not None
+        ):
+            # Check for various TOO constraints
+            if not self.check_constraints():
+                self.status = TOOStatus.rejected
+
+        # Write BurstCubeTOO to the database
+        self.modified_by = self.sub
+        self.modified_on = Time.now().datetime.isoformat()
+        json_too = json.loads(self.schema.model_dump_json(), parse_float=Decimal)
+        json_too["gsipk"] = 1
+        self.table.put_item(Item=json_too)
+
+        return True
+
+    def check_constraints(self):
+        """
+        Check if BurstCubeTOO parameters are valid.
+
+        Returns
+        -------
+            Are BurstCubeTOO parameters valid? True | False
+        """
+        # Reset too_info field
+        self.too_info = ""
+        # Check if the trigger time is in the future
+        # This is really just a sanity check, as the trigger time should be in the past
+        if self.trigger_time > Time.now():
+            self.too_info += "Trigger time is in the future. "
+            self.reject_reason = TOOReason.other
+            return False
+
+        # Reject if trigger is > 48 hours old
+        if self.trigger_time < Time.now() - 48 * u.hour:
+            self.reject_reason = TOOReason.too_old
+            self.too_info += "Trigger is too old. "
+            return False
+
+        # Calculate Ephemeris for the requested dump time at one second time
+        # resolution
+        ephem = BurstCubeEphem(
+            begin=self.trigger_time + self.offset,
+            end=self.trigger_time + self.offset + self.exposure,
+            stepsize=1 * u.s,
+        )
+
+        # Check if the trigger time is in the SAA
+        saa = burstcube_saa_constraint(time=self.trigger_time, ephem=ephem)
+        if saa is True:
+            self.too_info += "Trigger time inside SAA. "
+            self.reject_reason = TOOReason.saa
+            return False
+
+        # Check if the trigger is inside FOV at T0
+        if self.skycoord is not None or self.healpix_loc is not None:
+            fov = BurstCubeFOV(ephem=ephem, time=self.trigger_time)
+            infov = fov.probability_in_fov(
+                skycoord=self.skycoord,
+                error_radius=self.error_radius,
+                healpix_loc=self.healpix_loc,
+                healpix_scheme=self.healpix_scheme,
+            )
+
+            # Flag up if the required probability is not met
+            if infov < self.min_prob:
+                self.too_info += f"Probability inside FOV: {100*infov:.2f}%. Trigger was occulted at T0. "
+                self.reject_reason = TOOReason.earth_occult
+                return False
+            else:
+                self.too_info += f"Probability inside FOV: {100*infov:.2f}%. "
+
+        # Check if any part of the dump time is inside the SAA, warn if so
+        if True in burstcube_saa_constraint(time=ephem.timestamp, ephem=ephem):
+            self.too_info += "Dump time partially inside SAA."
+
+        #  Strip excess whitespace
+        self.too_info = self.too_info.strip()
+        return True
+
+    def post(self) -> bool:
+        """
+        Upload BurstCubeTOO to ACROSS API using POST
+
+        Returns
+        -------
+            Did this work? True | False
+        """
+        # Shouldn't run this unless a created_by is set
+        if self.sub is None:
+            raise HTTPException(401, "sub not set.")
+
+        # Validate supplied BurstCubeTOO values against the Schema
+        if not self.validate_post():
+            return False
+
+        # Set the created_on and created_by fields
+        self.created_on = Time.now()
+        self.created_by = self.sub
+
+        # Set the ID of this TOO
+        self.id = hashlib.md5(
+            f"{self.trigger_time}{self.exposure}{self.offset}".encode()
+        ).hexdigest()
+
+        # Check if this BurstCubeTOO exists. As the id is just a hash of the
+        # trigger_time, exposure and offset, then repeated requests for values
+        # that match this will be caught.
+        response = self.table.get_item(Key={"id": self.id})
+        if response.get("Item"):
+            raise HTTPException(409, "BurstCubeTOO already exists.")
+
+        # Check for various TOO constraints
+        if not self.check_constraints():
+            self.status = TOOStatus.rejected
+
+        # Write BurstCubeTOO to the database
+        json_too = json.loads(self.schema.model_dump_json(), parse_float=Decimal)
+        json_too["gsipk"] = 1
+        self.table.put_item(Item=json_too)
+
+        return True
+
+
+class BurstCubeTOORequests(ACROSSAPIBase):
+    """
+    Class to fetch multiple BurstCubeTOO requests, based on various filters.
+
+    Note that the filtering right now is based on DynamoDB scan, which is not
+    very efficient. This should be replaced with a query at some point.
+
+    Parameters
+    ----------
+    begin
+        Start time of plan search
+    end
+        End time of plan search
+    limit
+        Limit number of searches
+    duration
+        Duration of time to search from now
+
+    Attributes
+    ----------
+    entries
+        List of BurstCubeTOO requests
+    status
+        Status of BurstCubeTOO query
+    """
+
+    _schema = BurstCubeTOORequestsSchema
+    _get_schema = BurstCubeTOORequestsGetSchema
+    mission = "ACROSS"
+
+    def __getitem__(self, i):
+        return self.entries[i]
+
+    def __len__(self):
+        return len(self.entries)
+
+    def __init__(
+        self,
+        begin: Optional[Time] = None,
+        end: Optional[Time] = None,
+        duration: Optional[u.Quantity] = None,
+        limit: Optional[int] = None,
+    ):
+        # Default parameters
+        self.limit = limit
+        self.begin = begin
+        self.end = end
+        self.duration = duration
+        # Attributes
+        self.entries: list = []
+
+        # Parse Arguments
+        if self.validate_get():
+            self.get()
+
+    def get(self) -> bool:
+        """
+        Get a list of BurstCubeTOO requests
+        """
+        # Validate query
+        if not self.validate_get():
+            return False
+        table = tables.table(BurstCubeTOOSchema.__tablename__)
+
+        if self.duration is not None:
+            self.end = Time.now()
+            self.begin = self.end - self.duration
+
+        # Search for entries that overlap a given date range
+        if self.begin is not None and self.end is not None:
+            toos = table.query(
+                IndexName="byCreatedOn",
+                KeyConditionExpression=Key("gsipk").eq("1")
+                & Key("created_on").between(self.begin.isot, self.end.isot),
+            )
+        elif self.limit is not None:
+            # Fetch the most recent number of entries (specified by limit) in
+            # reverse order of submission
+            toos = table.query(
+                IndexName="byCreatedOn",
+                KeyConditionExpression=Key("gsipk").eq("1"),
+                Limit=self.limit,
+                ScanIndexForward=False,
+            )
+        else:
+            # Fetch everything
+            toos = table.scan()
+
+        # Convert entries for return
+        self.entries = [BurstCubeTOOSchema.model_validate(too) for too in toos["Items"]]
+
+        return True
+
+
+# Short aliases for classes
+TOORequests = BurstCubeTOORequests

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -6,6 +6,7 @@ email-validator
 fastapi
 healpy
 mangum
+python-multipart  # Required for file uploads in FastAPI; see https://fastapi.tiangolo.com/tutorial/request-files/
 requests
 shapely
 sgp4

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -106,6 +106,8 @@ python-dateutil==2.8.2
     # via matplotlib
 python-jose==3.3.0
     # via architect-functions
+python-multipart==0.0.9
+    # via -r requirements.in
 pyyaml==6.0.1
     # via astropy
 represent==2.0


### PR DESCRIPTION
### ACROSS API: Add BurstCube TOO CRUD API

### Description

PR adds BurstCubeTOO GET / POST / DELETE / PUT endpoints for submission, editing, fetching and deleting of BurstCube TOOs. This also provides the backend database and constraint checking for incoming TOOs. Broadly this PR addresses the issues listed in Issue #1976.


### Reviewers
Leo Singer
Samuel Wyatt

### Changes
This adds the following classes:

`BurstCubeTOO` - class to handle CRUD for BurstCubeTOO events which are made available through the API using standard `GET`, `POST`, `PUT` and `DELETE`. `POST` (i.e. submitting a new TOO) initiates checks on feasibility of the particular trigger. If coordinates are given, then probability of being in the BurstCube FOV are performed using the `BurstCubeFOV` class. In addition the TOO is checked for age and if BurstCube was inside the South Atlantic Anomaly 

`BurstCubeTOORequests` - a class to handle the fetching of multiple TOO requests based on date range, number limit, or most recent number of days. 

The adds the following endpoint to the api interface: `/burstcube/too`. For `PUT`, `POST` and `DELETE` authentication is required. For `GET` no authentication is required. `PUT`, `DELETE` and optionally `GET` pass the TOO `id` which is generated and returned with a `POST` using the form `/burstcube/too/{id}`. For `GET` if `id` is not passed, then `begin` and `end` parameters can be passed to specify date ranges, number limits and length of days to fetch using the `BurstCubeTOO` class.

### Acceptance Criteria
Passing code review and CI checks.

### Related Issue(s)
Fixes #1976
#1899

### Testing
~~pytest tests are included to test CRUD actions and a to validate some rejection criteria (double TOO submission, trigger > 48 hours old).~~
pytests will be added in a later PR
