### PR TITLE
adding update synonym function

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -151,7 +151,6 @@ legacy_users
 
 synonyms
   uuid *String
-  eventId **String
   name synonymsByUuid
 
 @aws

--- a/app/routes/_gcn.synonyms/synonyms.server.ts
+++ b/app/routes/_gcn.synonyms/synonyms.server.ts
@@ -61,34 +61,21 @@ export async function putSynonyms({
   const db = await tables()
   const client = db._doc as unknown as DynamoDBDocument
   const writes = []
-  if (!subtractions && !additions) {
-    const { Items } = await db.synonym.query({
-      IndexName: 'synonymsByUuid',
-      KeyConditionExpression: 'uuid = :uuid',
-      ExpressionAttributeValues: {
-        ':uuid': uuid,
-      },
-    })
-    return Items
-  }
+  if (!subtractions && !additions) return
   if (subtractions) {
-    const subtraction_writes = subtractions
-      .filter((eventId) => Boolean(eventId))
-      .map((eventId) => ({
-        DeleteRequest: {
-          Key: { uuid, eventId },
-        },
-      }))
+    const subtraction_writes = subtractions.map((eventId) => ({
+      DeleteRequest: {
+        Key: { uuid, eventId },
+      },
+    }))
     writes.push(subtraction_writes)
   }
   if (additions) {
-    const addition_writes = additions
-      .filter((eventId) => Boolean(eventId))
-      .map((eventId) => ({
-        PutRequest: {
-          Item: { uuid, eventId },
-        },
-      }))
+    const addition_writes = additions.map((eventId) => ({
+      PutRequest: {
+        Item: { uuid, eventId },
+      },
+    }))
     writes.push(addition_writes)
   }
   const params = {

--- a/app/routes/_gcn.synonyms/synonyms.server.ts
+++ b/app/routes/_gcn.synonyms/synonyms.server.ts
@@ -61,7 +61,16 @@ export async function putSynonyms({
   const db = await tables()
   const client = db._doc as unknown as DynamoDBDocument
   const writes = []
-  if (!subtractions && !additions) return await db.synonyms.get({ uuid })
+  if (!subtractions && !additions) {
+    const { Items } = await db.synonym.query({
+      IndexName: 'synonymsByUuid',
+      KeyConditionExpression: 'uuid = :uuid',
+      ExpressionAttributeValues: {
+        ':uuid': uuid,
+      },
+    })
+    return Items
+  }
   if (subtractions) {
     const subtraction_writes = subtractions
       .filter((eventId) => Boolean(eventId))

--- a/app/routes/_gcn.synonyms/synonyms.server.ts
+++ b/app/routes/_gcn.synonyms/synonyms.server.ts
@@ -60,8 +60,10 @@ export async function putSynonyms({
 }) {
   const db = await tables()
   const client = db._doc as unknown as DynamoDBDocument
+  const TableName = db.name('synonyms')
   const writes = []
   if (!subtractions && !additions) return
+  if (subtractions?.length === 0 && additions?.length === 0) return
   if (subtractions) {
     const subtraction_writes = subtractions.map((eventId) => ({
       DeleteRequest: {
@@ -80,7 +82,7 @@ export async function putSynonyms({
   }
   const params = {
     RequestItems: {
-      synonyms: writes,
+      [TableName]: writes,
     },
   }
   await client.batchWrite(params)


### PR DESCRIPTION
### Title
feat: adds update to synonyms server

### Description
This adds functionality to update existing synonyms. It allows you to pass in additions and subtractions (eventIds to add or remove from the synonym) to update the existing synonym members.

### Reviewers
@dakota002 - this is something either one can review
@lpsinger  - this is something either one can review

### Changes
This adds one function that is currently unused. It is intended to be used to update synonyms.
This also changes one index. We don't typically have the eventId in cases where we want to get synonyms by uuid, so I removed the eventId constraint so it would just be uuid. This index is currently unused.

### Acceptance Criteria
The code is unused currently, so review for syntax, format, and general performance.

### Related Issue(s)
Resolves #1985 

### Testing
This code is unused.