### PR TITLE
Hide dropdown content when clicking away 

### DIFF
--- a/app/routes/circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/circulars._archive._index/DateSelectorMenu.tsx
@@ -17,7 +17,7 @@ import {
   Radio,
 } from '@trussworks/react-uswds'
 import classNames from 'classnames'
-import { type ChangeEvent, forwardRef, useRef, useState } from 'react'
+import { type ChangeEvent, useRef, useState } from 'react'
 import { useOnClickOutside } from 'usehooks-ts'
 
 import DetailsDropdownContent from '~/components/DetailsDropdownContent'
@@ -69,17 +69,15 @@ function DateSelectorButton({
   )
 }
 
-export const DateSelector = forwardRef<
-  HTMLDivElement,
-  {
-    form?: string
-    defaultStartDate?: string
-    defaultEndDate?: string
-  }
->(function DateSelector(
-  { form, defaultStartDate, defaultEndDate },
-  ref: React.Ref<HTMLDivElement>
-) {
+export function DateSelector({
+  form,
+  defaultStartDate,
+  defaultEndDate,
+}: {
+  form?: string
+  defaultStartDate?: string
+  defaultEndDate?: string
+}) {
   const dateSelectorRef = useRef<HTMLDivElement>(null)
   const [showDateSelector, setShowDateSelector] = useState(false)
   useOnClickOutside(dateSelectorRef, () => {
@@ -227,4 +225,4 @@ export const DateSelector = forwardRef<
       </DetailsDropdownContent>
     </div>
   )
-})
+}

--- a/app/routes/circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/circulars._archive._index/DateSelectorMenu.tsx
@@ -69,163 +69,167 @@ function DateSelectorButton({
 }
 
 interface DateSelectorProps {
-  form?: string;
-  defaultStartDate?: string;
-  defaultEndDate?: string;
-  showDateSelector: boolean;
-  setShowDateSelector: React.Dispatch<React.SetStateAction<boolean>>;
+  form?: string
+  defaultStartDate?: string
+  defaultEndDate?: string
+  showContent: boolean
+  setShowContent: React.Dispatch<React.SetStateAction<boolean>>
 }
 
-export const DateSelector = forwardRef<HTMLDivElement, DateSelectorProps>(function DateSelector(
-  {
-    form,
-    defaultStartDate,
-    defaultEndDate,
-    showDateSelector,
-    setShowDateSelector,
-  },
-  ref: React.Ref<HTMLDivElement>
-) {
-  const defaultShowDateRange = Boolean(
-    (defaultStartDate && !dateSelectorLabels[defaultStartDate]) ||
-      defaultEndDate
-  )
-  const [showDateRange, setShowDateRange] = useState(defaultShowDateRange)
-  const startDateInputRef = useRef<HTMLInputElement>(null)
-  const endDateInputRef = useRef<HTMLInputElement>(null)
-  const submit = useSubmit()
+export const DateSelector = forwardRef<HTMLDivElement, DateSelectorProps>(
+  function DateSelector(
+    {
+      form,
+      defaultStartDate,
+      defaultEndDate,
+      showContent: showDateSelector,
+      setShowContent,
+    },
+    ref: React.Ref<HTMLDivElement>
+  ) {
+    const defaultShowDateRange = Boolean(
+      (defaultStartDate && !dateSelectorLabels[defaultStartDate]) ||
+        defaultEndDate
+    )
+    const [showDateRange, setShowDateRange] = useState(defaultShowDateRange)
+    const startDateInputRef = useRef<HTMLInputElement>(null)
+    const endDateInputRef = useRef<HTMLInputElement>(null)
+    const submit = useSubmit()
 
-  function setStartDate(value: string) {
-    if (startDateInputRef.current) startDateInputRef.current.value = value
-  }
+    function setStartDate(value: string) {
+      if (startDateInputRef.current) startDateInputRef.current.value = value
+    }
 
-  function setEndDate(value: string) {
-    if (endDateInputRef.current) endDateInputRef.current.value = value
-  }
+    function setEndDate(value: string) {
+      if (endDateInputRef.current) endDateInputRef.current.value = value
+    }
 
-  function radioOnChange({ target: { value } }: ChangeEvent<HTMLInputElement>) {
-    setShowDateRange(false)
-    setStartDate(value)
-    setEndDate('')
-    setShowDateSelector(false)
-    const form = startDateInputRef.current?.form
-    if (form) submit(form)
-  }
+    function radioOnChange({
+      target: { value },
+    }: ChangeEvent<HTMLInputElement>) {
+      setShowDateRange(false)
+      setStartDate(value)
+      setEndDate('')
+      setShowContent(false)
+      const form = startDateInputRef.current?.form
+      if (form) submit(form)
+    }
 
-  return (
-    <div ref={ref}>
-      <input
-        type="hidden"
-        name="startDate"
-        form={form}
-        ref={startDateInputRef}
-        defaultValue={defaultStartDate}
-      />
-      <input
-        type="hidden"
-        name="endDate"
-        form={form}
-        ref={endDateInputRef}
-        defaultValue={defaultEndDate}
-      />
-      <DateSelectorButton
-        startDate={defaultStartDate}
-        endDate={defaultEndDate}
-        onClick={() => {
-          setShowDateSelector((shown) => !shown)
-        }}
-        expanded={showDateSelector}
-      />
-      <DetailsDropdownContent
-        className={classNames('maxw-card-xlg', {
-          'display-none': !showDateSelector,
-        })}
-      >
-        <CardBody>
-          <Grid row>
-            <Grid col={4} key="radio-alltime">
-              <Radio
-                form=""
-                id="radio-alltime"
-                name="radio-date"
-                value=""
-                label="All Time"
-                defaultChecked={!defaultStartDate && !defaultEndDate}
-                onChange={radioOnChange}
-              />
-            </Grid>
-            {Object.entries(dateSelectorLabels).map(([value, label]) => (
-              <Grid col={4} key={`radio-${value}`}>
+    return (
+      <div ref={ref}>
+        <input
+          type="hidden"
+          name="startDate"
+          form={form}
+          ref={startDateInputRef}
+          defaultValue={defaultStartDate}
+        />
+        <input
+          type="hidden"
+          name="endDate"
+          form={form}
+          ref={endDateInputRef}
+          defaultValue={defaultEndDate}
+        />
+        <DateSelectorButton
+          startDate={defaultStartDate}
+          endDate={defaultEndDate}
+          onClick={() => {
+            setShowContent((shown) => !shown)
+          }}
+          expanded={showDateSelector}
+        />
+        <DetailsDropdownContent
+          className={classNames('maxw-card-xlg', {
+            'display-none': !showDateSelector,
+          })}
+        >
+          <CardBody>
+            <Grid row>
+              <Grid col={4} key="radio-alltime">
                 <Radio
                   form=""
-                  id={`radio-${value}`}
+                  id="radio-alltime"
                   name="radio-date"
-                  value={value}
-                  label={label}
-                  defaultChecked={value === defaultStartDate}
+                  value=""
+                  label="All Time"
+                  defaultChecked={!defaultStartDate && !defaultEndDate}
                   onChange={radioOnChange}
                 />
               </Grid>
-            ))}
-            <Grid col={4}>
-              <Radio
-                form=""
-                id="radio-custom"
-                name="radio-date"
-                value="custom"
-                label="Custom Range..."
-                defaultChecked={defaultShowDateRange}
-                onChange={({ target: { checked } }) => {
-                  setShowDateRange(checked)
+              {Object.entries(dateSelectorLabels).map(([value, label]) => (
+                <Grid col={4} key={`radio-${value}`}>
+                  <Radio
+                    form=""
+                    id={`radio-${value}`}
+                    name="radio-date"
+                    value={value}
+                    label={label}
+                    defaultChecked={value === defaultStartDate}
+                    onChange={radioOnChange}
+                  />
+                </Grid>
+              ))}
+              <Grid col={4}>
+                <Radio
+                  form=""
+                  id="radio-custom"
+                  name="radio-date"
+                  value="custom"
+                  label="Custom Range..."
+                  defaultChecked={defaultShowDateRange}
+                  onChange={({ target: { checked } }) => {
+                    setShowDateRange(checked)
+                  }}
+                />
+              </Grid>
+            </Grid>
+            {showDateRange && (
+              <DateRangePicker
+                startDateHint="YYYY-MM-DD"
+                startDateLabel="Start Date"
+                className="margin-bottom-2"
+                startDatePickerProps={{
+                  form: '',
+                  id: 'event-date-start',
+                  name: 'event-date-start',
+                  dateFormat: 'YYYY-MM-DD',
+                  defaultValue: defaultStartDate,
+                  onChange: (value) => {
+                    setStartDate(value ?? '')
+                  },
+                }}
+                endDateHint="YYYY-MM-DD"
+                endDateLabel="End Date"
+                endDatePickerProps={{
+                  form: '',
+                  id: 'event-date-end',
+                  name: 'event-date-end',
+                  dateFormat: 'YYYY-MM-DD',
+                  defaultValue: defaultEndDate,
+                  onChange: (value) => {
+                    setEndDate(value ?? '')
+                  },
                 }}
               />
-            </Grid>
-          </Grid>
+            )}
+          </CardBody>
           {showDateRange && (
-            <DateRangePicker
-              startDateHint="YYYY-MM-DD"
-              startDateLabel="Start Date"
-              className="margin-bottom-2"
-              startDatePickerProps={{
-                form: '',
-                id: 'event-date-start',
-                name: 'event-date-start',
-                dateFormat: 'YYYY-MM-DD',
-                defaultValue: defaultStartDate,
-                onChange: (value) => {
-                  setStartDate(value ?? '')
-                },
-              }}
-              endDateHint="YYYY-MM-DD"
-              endDateLabel="End Date"
-              endDatePickerProps={{
-                form: '',
-                id: 'event-date-end',
-                name: 'event-date-end',
-                dateFormat: 'YYYY-MM-DD',
-                defaultValue: defaultEndDate,
-                onChange: (value) => {
-                  setEndDate(value ?? '')
-                },
-              }}
-            />
+            <CardFooter>
+              <Button
+                type="button"
+                onClick={() => {
+                  setShowContent(false)
+                  const form = startDateInputRef.current?.form
+                  if (form) submit(form)
+                }}
+              >
+                Submit
+              </Button>
+            </CardFooter>
           )}
-        </CardBody>
-        {showDateRange && (
-          <CardFooter>
-            <Button
-              type="button"
-              onClick={() => {
-                setShowDateSelector(false)
-                const form = startDateInputRef.current?.form
-                if (form) submit(form)
-              }}
-            >
-              Submit
-            </Button>
-          </CardFooter>
-        )}
-      </DetailsDropdownContent>
-    </div>
-  )
-})
+        </DetailsDropdownContent>
+      </div>
+    )
+  }
+)

--- a/app/routes/circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/circulars._archive._index/DateSelectorMenu.tsx
@@ -75,19 +75,16 @@ export const DateSelector = forwardRef<
     form?: string
     defaultStartDate?: string
     defaultEndDate?: string
-    showContent: boolean
-    setShowContent: React.Dispatch<React.SetStateAction<boolean>>
   }
 >(function DateSelector(
-  {
-    form,
-    defaultStartDate,
-    defaultEndDate,
-    showContent: showDateSelector,
-    setShowContent,
-  },
+  { form, defaultStartDate, defaultEndDate },
   ref: React.Ref<HTMLDivElement>
 ) {
+  const dateSelectorRef = useRef<HTMLDivElement>(null)
+  const [showDateSelector, setShowDateSelector] = useState(false)
+  useOnClickOutside(dateSelectorRef, () => {
+    setShowDateSelector(false)
+  })
   const defaultShowDateRange = Boolean(
     (defaultStartDate && !dateSelectorLabels[defaultStartDate]) ||
       defaultEndDate
@@ -109,13 +106,13 @@ export const DateSelector = forwardRef<
     setShowDateRange(false)
     setStartDate(value)
     setEndDate('')
-    setShowContent(false)
+    setShowDateSelector(false)
     const form = startDateInputRef.current?.form
     if (form) submit(form)
   }
 
   return (
-    <div ref={ref}>
+    <div ref={dateSelectorRef}>
       <input
         type="hidden"
         name="startDate"
@@ -134,7 +131,7 @@ export const DateSelector = forwardRef<
         startDate={defaultStartDate}
         endDate={defaultEndDate}
         onClick={() => {
-          setShowContent((shown) => !shown)
+          setShowDateSelector((shown) => !shown)
         }}
         expanded={showDateSelector}
       />
@@ -218,7 +215,7 @@ export const DateSelector = forwardRef<
             <Button
               type="button"
               onClick={() => {
-                setShowContent(false)
+                setShowDateSelector(false)
                 const form = startDateInputRef.current?.form
                 if (form) submit(form)
               }}

--- a/app/routes/circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/circulars._archive._index/DateSelectorMenu.tsx
@@ -68,19 +68,25 @@ function DateSelectorButton({
   )
 }
 
-export const DateSelector = forwardRef(function DateSelector(
+interface DateSelectorProps {
+  form?: string;
+  defaultStartDate?: string;
+  defaultEndDate?: string;
+  showDateSelector: boolean;
+  setShowDateSelector: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const DateSelector = forwardRef<HTMLDivElement, DateSelectorProps>(function DateSelector(
   {
     form,
     defaultStartDate,
     defaultEndDate,
-  }: {
-    form?: string
-    defaultStartDate?: string
-    defaultEndDate?: string
+    showDateSelector,
+    setShowDateSelector,
   },
   ref: React.Ref<HTMLDivElement>
 ) {
-  const [showContent, setShowContent] = useState(false)
+  // const [showDateSelector, setShowDateSelector] = useState(false)
   const defaultShowDateRange = Boolean(
     (defaultStartDate && !dateSelectorLabels[defaultStartDate]) ||
       defaultEndDate
@@ -102,7 +108,7 @@ export const DateSelector = forwardRef(function DateSelector(
     setShowDateRange(false)
     setStartDate(value)
     setEndDate('')
-    setShowContent(false)
+    setShowDateSelector(false)
     const form = startDateInputRef.current?.form
     if (form) submit(form)
   }
@@ -127,13 +133,13 @@ export const DateSelector = forwardRef(function DateSelector(
         startDate={defaultStartDate}
         endDate={defaultEndDate}
         onClick={() => {
-          setShowContent((shown) => !shown)
+          setShowDateSelector((shown) => !shown)
         }}
-        expanded={showContent}
+        expanded={showDateSelector}
       />
       <DetailsDropdownContent
         className={classNames('maxw-card-xlg', {
-          'display-none': !showContent,
+          'display-none': !showDateSelector,
         })}
       >
         <CardBody>
@@ -211,7 +217,7 @@ export const DateSelector = forwardRef(function DateSelector(
             <Button
               type="button"
               onClick={() => {
-                setShowContent(false)
+                setShowDateSelector(false)
                 const form = startDateInputRef.current?.form
                 if (form) submit(form)
               }}

--- a/app/routes/circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/circulars._archive._index/DateSelectorMenu.tsx
@@ -78,9 +78,9 @@ export function DateSelector({
   defaultStartDate?: string
   defaultEndDate?: string
 }) {
-  const dateSelectorRef = useRef<HTMLDivElement>(null)
+  const ref = useRef<HTMLDivElement>(null)
   const [showContent, setShowContent] = useState(false)
-  useOnClickOutside(dateSelectorRef, () => {
+  useOnClickOutside(ref, () => {
     setShowContent(false)
   })
   const defaultShowDateRange = Boolean(
@@ -110,7 +110,7 @@ export function DateSelector({
   }
 
   return (
-    <div ref={dateSelectorRef}>
+    <div ref={ref}>
       <input
         type="hidden"
         name="startDate"

--- a/app/routes/circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/circulars._archive._index/DateSelectorMenu.tsx
@@ -18,6 +18,7 @@ import {
 } from '@trussworks/react-uswds'
 import classNames from 'classnames'
 import { type ChangeEvent, forwardRef, useRef, useState } from 'react'
+import { useOnClickOutside } from 'usehooks-ts'
 
 import DetailsDropdownContent from '~/components/DetailsDropdownContent'
 
@@ -68,168 +69,165 @@ function DateSelectorButton({
   )
 }
 
-interface DateSelectorProps {
-  form?: string
-  defaultStartDate?: string
-  defaultEndDate?: string
-  showContent: boolean
-  setShowContent: React.Dispatch<React.SetStateAction<boolean>>
-}
+export const DateSelector = forwardRef<
+  HTMLDivElement,
+  {
+    form?: string
+    defaultStartDate?: string
+    defaultEndDate?: string
+    showContent: boolean
+    setShowContent: React.Dispatch<React.SetStateAction<boolean>>
+  }
+>(function DateSelector(
+  {
+    form,
+    defaultStartDate,
+    defaultEndDate,
+    showContent: showDateSelector,
+    setShowContent,
+  },
+  ref: React.Ref<HTMLDivElement>
+) {
+  const defaultShowDateRange = Boolean(
+    (defaultStartDate && !dateSelectorLabels[defaultStartDate]) ||
+      defaultEndDate
+  )
+  const [showDateRange, setShowDateRange] = useState(defaultShowDateRange)
+  const startDateInputRef = useRef<HTMLInputElement>(null)
+  const endDateInputRef = useRef<HTMLInputElement>(null)
+  const submit = useSubmit()
 
-export const DateSelector = forwardRef<HTMLDivElement, DateSelectorProps>(
-  function DateSelector(
-    {
-      form,
-      defaultStartDate,
-      defaultEndDate,
-      showContent: showDateSelector,
-      setShowContent,
-    },
-    ref: React.Ref<HTMLDivElement>
-  ) {
-    const defaultShowDateRange = Boolean(
-      (defaultStartDate && !dateSelectorLabels[defaultStartDate]) ||
-        defaultEndDate
-    )
-    const [showDateRange, setShowDateRange] = useState(defaultShowDateRange)
-    const startDateInputRef = useRef<HTMLInputElement>(null)
-    const endDateInputRef = useRef<HTMLInputElement>(null)
-    const submit = useSubmit()
+  function setStartDate(value: string) {
+    if (startDateInputRef.current) startDateInputRef.current.value = value
+  }
 
-    function setStartDate(value: string) {
-      if (startDateInputRef.current) startDateInputRef.current.value = value
-    }
+  function setEndDate(value: string) {
+    if (endDateInputRef.current) endDateInputRef.current.value = value
+  }
 
-    function setEndDate(value: string) {
-      if (endDateInputRef.current) endDateInputRef.current.value = value
-    }
+  function radioOnChange({ target: { value } }: ChangeEvent<HTMLInputElement>) {
+    setShowDateRange(false)
+    setStartDate(value)
+    setEndDate('')
+    setShowContent(false)
+    const form = startDateInputRef.current?.form
+    if (form) submit(form)
+  }
 
-    function radioOnChange({
-      target: { value },
-    }: ChangeEvent<HTMLInputElement>) {
-      setShowDateRange(false)
-      setStartDate(value)
-      setEndDate('')
-      setShowContent(false)
-      const form = startDateInputRef.current?.form
-      if (form) submit(form)
-    }
-
-    return (
-      <div ref={ref}>
-        <input
-          type="hidden"
-          name="startDate"
-          form={form}
-          ref={startDateInputRef}
-          defaultValue={defaultStartDate}
-        />
-        <input
-          type="hidden"
-          name="endDate"
-          form={form}
-          ref={endDateInputRef}
-          defaultValue={defaultEndDate}
-        />
-        <DateSelectorButton
-          startDate={defaultStartDate}
-          endDate={defaultEndDate}
-          onClick={() => {
-            setShowContent((shown) => !shown)
-          }}
-          expanded={showDateSelector}
-        />
-        <DetailsDropdownContent
-          className={classNames('maxw-card-xlg', {
-            'display-none': !showDateSelector,
-          })}
-        >
-          <CardBody>
-            <Grid row>
-              <Grid col={4} key="radio-alltime">
+  return (
+    <div ref={ref}>
+      <input
+        type="hidden"
+        name="startDate"
+        form={form}
+        ref={startDateInputRef}
+        defaultValue={defaultStartDate}
+      />
+      <input
+        type="hidden"
+        name="endDate"
+        form={form}
+        ref={endDateInputRef}
+        defaultValue={defaultEndDate}
+      />
+      <DateSelectorButton
+        startDate={defaultStartDate}
+        endDate={defaultEndDate}
+        onClick={() => {
+          setShowContent((shown) => !shown)
+        }}
+        expanded={showDateSelector}
+      />
+      <DetailsDropdownContent
+        className={classNames('maxw-card-xlg', {
+          'display-none': !showDateSelector,
+        })}
+      >
+        <CardBody>
+          <Grid row>
+            <Grid col={4} key="radio-alltime">
+              <Radio
+                form=""
+                id="radio-alltime"
+                name="radio-date"
+                value=""
+                label="All Time"
+                defaultChecked={!defaultStartDate && !defaultEndDate}
+                onChange={radioOnChange}
+              />
+            </Grid>
+            {Object.entries(dateSelectorLabels).map(([value, label]) => (
+              <Grid col={4} key={`radio-${value}`}>
                 <Radio
                   form=""
-                  id="radio-alltime"
+                  id={`radio-${value}`}
                   name="radio-date"
-                  value=""
-                  label="All Time"
-                  defaultChecked={!defaultStartDate && !defaultEndDate}
+                  value={value}
+                  label={label}
+                  defaultChecked={value === defaultStartDate}
                   onChange={radioOnChange}
                 />
               </Grid>
-              {Object.entries(dateSelectorLabels).map(([value, label]) => (
-                <Grid col={4} key={`radio-${value}`}>
-                  <Radio
-                    form=""
-                    id={`radio-${value}`}
-                    name="radio-date"
-                    value={value}
-                    label={label}
-                    defaultChecked={value === defaultStartDate}
-                    onChange={radioOnChange}
-                  />
-                </Grid>
-              ))}
-              <Grid col={4}>
-                <Radio
-                  form=""
-                  id="radio-custom"
-                  name="radio-date"
-                  value="custom"
-                  label="Custom Range..."
-                  defaultChecked={defaultShowDateRange}
-                  onChange={({ target: { checked } }) => {
-                    setShowDateRange(checked)
-                  }}
-                />
-              </Grid>
-            </Grid>
-            {showDateRange && (
-              <DateRangePicker
-                startDateHint="YYYY-MM-DD"
-                startDateLabel="Start Date"
-                className="margin-bottom-2"
-                startDatePickerProps={{
-                  form: '',
-                  id: 'event-date-start',
-                  name: 'event-date-start',
-                  dateFormat: 'YYYY-MM-DD',
-                  defaultValue: defaultStartDate,
-                  onChange: (value) => {
-                    setStartDate(value ?? '')
-                  },
-                }}
-                endDateHint="YYYY-MM-DD"
-                endDateLabel="End Date"
-                endDatePickerProps={{
-                  form: '',
-                  id: 'event-date-end',
-                  name: 'event-date-end',
-                  dateFormat: 'YYYY-MM-DD',
-                  defaultValue: defaultEndDate,
-                  onChange: (value) => {
-                    setEndDate(value ?? '')
-                  },
+            ))}
+            <Grid col={4}>
+              <Radio
+                form=""
+                id="radio-custom"
+                name="radio-date"
+                value="custom"
+                label="Custom Range..."
+                defaultChecked={defaultShowDateRange}
+                onChange={({ target: { checked } }) => {
+                  setShowDateRange(checked)
                 }}
               />
-            )}
-          </CardBody>
+            </Grid>
+          </Grid>
           {showDateRange && (
-            <CardFooter>
-              <Button
-                type="button"
-                onClick={() => {
-                  setShowContent(false)
-                  const form = startDateInputRef.current?.form
-                  if (form) submit(form)
-                }}
-              >
-                Submit
-              </Button>
-            </CardFooter>
+            <DateRangePicker
+              startDateHint="YYYY-MM-DD"
+              startDateLabel="Start Date"
+              className="margin-bottom-2"
+              startDatePickerProps={{
+                form: '',
+                id: 'event-date-start',
+                name: 'event-date-start',
+                dateFormat: 'YYYY-MM-DD',
+                defaultValue: defaultStartDate,
+                onChange: (value) => {
+                  setStartDate(value ?? '')
+                },
+              }}
+              endDateHint="YYYY-MM-DD"
+              endDateLabel="End Date"
+              endDatePickerProps={{
+                form: '',
+                id: 'event-date-end',
+                name: 'event-date-end',
+                dateFormat: 'YYYY-MM-DD',
+                defaultValue: defaultEndDate,
+                onChange: (value) => {
+                  setEndDate(value ?? '')
+                },
+              }}
+            />
           )}
-        </DetailsDropdownContent>
-      </div>
-    )
-  }
-)
+        </CardBody>
+        {showDateRange && (
+          <CardFooter>
+            <Button
+              type="button"
+              onClick={() => {
+                setShowContent(false)
+                const form = startDateInputRef.current?.form
+                if (form) submit(form)
+              }}
+            >
+              Submit
+            </Button>
+          </CardFooter>
+        )}
+      </DetailsDropdownContent>
+    </div>
+  )
+})

--- a/app/routes/circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/circulars._archive._index/DateSelectorMenu.tsx
@@ -17,7 +17,7 @@ import {
   Radio,
 } from '@trussworks/react-uswds'
 import classNames from 'classnames'
-import { type ChangeEvent, useRef, useState } from 'react'
+import { type ChangeEvent, forwardRef, useRef, useState } from 'react'
 
 import DetailsDropdownContent from '~/components/DetailsDropdownContent'
 
@@ -68,15 +68,18 @@ function DateSelectorButton({
   )
 }
 
-export function DateSelector({
-  form,
-  defaultStartDate,
-  defaultEndDate,
-}: {
-  form?: string
-  defaultStartDate?: string
-  defaultEndDate?: string
-}) {
+export const DateSelector = forwardRef(function DateSelector(
+  {
+    form,
+    defaultStartDate,
+    defaultEndDate,
+  }: {
+    form?: string
+    defaultStartDate?: string
+    defaultEndDate?: string
+  },
+  ref: React.Ref<HTMLDivElement>
+) {
   const [showContent, setShowContent] = useState(false)
   const defaultShowDateRange = Boolean(
     (defaultStartDate && !dateSelectorLabels[defaultStartDate]) ||
@@ -105,7 +108,7 @@ export function DateSelector({
   }
 
   return (
-    <>
+    <div ref={ref}>
       <input
         type="hidden"
         name="startDate"
@@ -218,6 +221,6 @@ export function DateSelector({
           </CardFooter>
         )}
       </DetailsDropdownContent>
-    </>
+    </div>
   )
-}
+})

--- a/app/routes/circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/circulars._archive._index/DateSelectorMenu.tsx
@@ -86,7 +86,6 @@ export const DateSelector = forwardRef<HTMLDivElement, DateSelectorProps>(functi
   },
   ref: React.Ref<HTMLDivElement>
 ) {
-  // const [showDateSelector, setShowDateSelector] = useState(false)
   const defaultShowDateRange = Boolean(
     (defaultStartDate && !dateSelectorLabels[defaultStartDate]) ||
       defaultEndDate

--- a/app/routes/circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/circulars._archive._index/DateSelectorMenu.tsx
@@ -79,9 +79,9 @@ export function DateSelector({
   defaultEndDate?: string
 }) {
   const dateSelectorRef = useRef<HTMLDivElement>(null)
-  const [showDateSelector, setShowDateSelector] = useState(false)
+  const [showContent, setShowContent] = useState(false)
   useOnClickOutside(dateSelectorRef, () => {
-    setShowDateSelector(false)
+    setShowContent(false)
   })
   const defaultShowDateRange = Boolean(
     (defaultStartDate && !dateSelectorLabels[defaultStartDate]) ||
@@ -104,7 +104,7 @@ export function DateSelector({
     setShowDateRange(false)
     setStartDate(value)
     setEndDate('')
-    setShowDateSelector(false)
+    setShowContent(false)
     const form = startDateInputRef.current?.form
     if (form) submit(form)
   }
@@ -129,13 +129,13 @@ export function DateSelector({
         startDate={defaultStartDate}
         endDate={defaultEndDate}
         onClick={() => {
-          setShowDateSelector((shown) => !shown)
+          setShowContent((shown) => !shown)
         }}
-        expanded={showDateSelector}
+        expanded={showContent}
       />
       <DetailsDropdownContent
         className={classNames('maxw-card-xlg', {
-          'display-none': !showDateSelector,
+          'display-none': !showContent,
         })}
       >
         <CardBody>
@@ -213,7 +213,7 @@ export function DateSelector({
             <Button
               type="button"
               onClick={() => {
-                setShowDateSelector(false)
+                setShowContent(false)
                 const form = startDateInputRef.current?.form
                 if (form) submit(form)
               }}

--- a/app/routes/circulars._archive._index/SortSelectorButton.tsx
+++ b/app/routes/circulars._archive._index/SortSelectorButton.tsx
@@ -16,7 +16,7 @@ import {
 } from '@trussworks/react-uswds'
 import classNames from 'classnames'
 import type { ChangeEvent } from 'react'
-import { forwardRef, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { useOnClickOutside } from 'usehooks-ts'
 
 import DetailsDropdownContent from '~/components/DetailsDropdownContent'
@@ -52,16 +52,13 @@ function SortButton({
   )
 }
 
-export const SortSelector = forwardRef<
-  HTMLDivElement,
-  {
-    form?: string
-    defaultValue?: string
-  }
->(function SortSelector(
-  { form, defaultValue },
-  ref: React.Ref<HTMLDivElement>
-) {
+export function SortSelector({
+  form,
+  defaultValue,
+}: {
+  form?: string
+  defaultValue?: string
+}) {
   const submit = useSubmit()
   const SortSelectorRef = useRef<HTMLDivElement>(null)
   const [showSortSelector, setShowSortSelector] = useState(false)
@@ -117,4 +114,4 @@ export const SortSelector = forwardRef<
       </DetailsDropdownContent>
     </div>
   )
-})
+}

--- a/app/routes/circulars._archive._index/SortSelectorButton.tsx
+++ b/app/routes/circulars._archive._index/SortSelectorButton.tsx
@@ -16,7 +16,8 @@ import {
 } from '@trussworks/react-uswds'
 import classNames from 'classnames'
 import type { ChangeEvent } from 'react'
-import { forwardRef } from 'react'
+import { forwardRef, useRef, useState } from 'react'
+import { useOnClickOutside } from 'usehooks-ts'
 
 import DetailsDropdownContent from '~/components/DetailsDropdownContent'
 
@@ -56,17 +57,20 @@ export const SortSelector = forwardRef<
   {
     form?: string
     defaultValue?: string
-    showContent: boolean
-    setShowContent: React.Dispatch<React.SetStateAction<boolean>>
   }
 >(function SortSelector(
-  { form, defaultValue, showContent, setShowContent },
+  { form, defaultValue },
   ref: React.Ref<HTMLDivElement>
 ) {
   const submit = useSubmit()
+  const SortSelectorRef = useRef<HTMLDivElement>(null)
+  const [showSortSelector, setShowSortSelector] = useState(false)
+  useOnClickOutside(SortSelectorRef, () => {
+    setShowSortSelector(false)
+  })
 
   function radioOnChange({ target }: ChangeEvent<HTMLInputElement>) {
-    setShowContent(false)
+    setShowSortSelector(false)
     if (target.form) submit(target.form)
   }
 
@@ -91,18 +95,18 @@ export const SortSelector = forwardRef<
   )
 
   return (
-    <div ref={ref}>
+    <div ref={SortSelectorRef}>
       <SortButton
         sort={sanitizedValue}
-        expanded={showContent}
+        expanded={showSortSelector}
         onClick={() => {
-          setShowContent((shown) => !shown)
+          setShowSortSelector((shown) => !shown)
         }}
       />
 
       <DetailsDropdownContent
         className={classNames('maxw-card-xlg', {
-          'display-none': !showContent,
+          'display-none': !showSortSelector,
         })}
       >
         <CardBody>

--- a/app/routes/circulars._archive._index/SortSelectorButton.tsx
+++ b/app/routes/circulars._archive._index/SortSelectorButton.tsx
@@ -60,9 +60,9 @@ export function SortSelector({
   defaultValue?: string
 }) {
   const submit = useSubmit()
-  const SortSelectorRef = useRef<HTMLDivElement>(null)
+  const ref = useRef<HTMLDivElement>(null)
   const [showContent, setShowContent] = useState(false)
-  useOnClickOutside(SortSelectorRef, () => {
+  useOnClickOutside(ref, () => {
     setShowContent(false)
   })
 
@@ -92,7 +92,7 @@ export function SortSelector({
   )
 
   return (
-    <div ref={SortSelectorRef}>
+    <div ref={ref}>
       <SortButton
         sort={sanitizedValue}
         expanded={showContent}

--- a/app/routes/circulars._archive._index/SortSelectorButton.tsx
+++ b/app/routes/circulars._archive._index/SortSelectorButton.tsx
@@ -63,8 +63,6 @@ export const SortSelector = forwardRef<HTMLDivElement, SortSelectorProps>(
     { form, defaultValue, showContent, setShowContent },
     ref: React.Ref<HTMLDivElement>
   ) {
-    // const [showContent, setShowContent] = useState(false)
-
     const submit = useSubmit()
 
     function radioOnChange({ target }: ChangeEvent<HTMLInputElement>) {

--- a/app/routes/circulars._archive._index/SortSelectorButton.tsx
+++ b/app/routes/circulars._archive._index/SortSelectorButton.tsx
@@ -16,7 +16,7 @@ import {
 } from '@trussworks/react-uswds'
 import classNames from 'classnames'
 import type { ChangeEvent } from 'react'
-import { useState } from 'react'
+import { forwardRef } from 'react'
 
 import DetailsDropdownContent from '~/components/DetailsDropdownContent'
 
@@ -51,63 +51,69 @@ function SortButton({
   )
 }
 
-export function SortSelector({
-  form,
-  defaultValue,
-}: {
+interface SortSelectorProps {
   form?: string
   defaultValue?: string
-}) {
-  const [showContent, setShowContent] = useState(false)
-
-  const submit = useSubmit()
-
-  function radioOnChange({ target }: ChangeEvent<HTMLInputElement>) {
-    setShowContent(false)
-    if (target.form) submit(target.form)
-  }
-
-  const sanitizedValue =
-    defaultValue && defaultValue in sortOptions ? defaultValue : 'circularID'
-
-  const SortRadioButtons = () => (
-    <>
-      {Object.entries(sortOptions).map(([value, label]) => (
-        <Radio
-          key={value}
-          id={value}
-          name="sort"
-          value={value}
-          label={label}
-          form={form}
-          defaultChecked={sanitizedValue === value}
-          onChange={radioOnChange}
-        />
-      ))}
-    </>
-  )
-
-  return (
-    <>
-      <SortButton
-        sort={sanitizedValue}
-        expanded={showContent}
-        onClick={() => {
-          setShowContent((shown) => !shown)
-        }}
-      />
-
-      <DetailsDropdownContent
-        className={classNames('maxw-card-xlg', {
-          'display-none': !showContent,
-        })}
-      >
-        <CardBody>
-          <Grid col={1}>
-            <SortRadioButtons />
-          </Grid>
-        </CardBody>
-      </DetailsDropdownContent>
-    </>
-  )
+  showContent: boolean
+  setShowContent: React.Dispatch<React.SetStateAction<boolean>>
 }
+
+export const SortSelector = forwardRef<HTMLDivElement, SortSelectorProps>(
+  function SortSelector(
+    { form, defaultValue, showContent, setShowContent },
+    ref: React.Ref<HTMLDivElement>
+  ) {
+    // const [showContent, setShowContent] = useState(false)
+
+    const submit = useSubmit()
+
+    function radioOnChange({ target }: ChangeEvent<HTMLInputElement>) {
+      setShowContent(false)
+      if (target.form) submit(target.form)
+    }
+
+    const sanitizedValue =
+      defaultValue && defaultValue in sortOptions ? defaultValue : 'circularID'
+
+    const SortRadioButtons = () => (
+      <>
+        {Object.entries(sortOptions).map(([value, label]) => (
+          <Radio
+            key={value}
+            id={value}
+            name="sort"
+            value={value}
+            label={label}
+            form={form}
+            defaultChecked={sanitizedValue === value}
+            onChange={radioOnChange}
+          />
+        ))}
+      </>
+    )
+
+    return (
+      <div ref={ref}>
+        <SortButton
+          sort={sanitizedValue}
+          expanded={showContent}
+          onClick={() => {
+            setShowContent((shown) => !shown)
+          }}
+        />
+
+        <DetailsDropdownContent
+          className={classNames('maxw-card-xlg', {
+            'display-none': !showContent,
+          })}
+        >
+          <CardBody>
+            <Grid col={1}>
+              <SortRadioButtons />
+            </Grid>
+          </CardBody>
+        </DetailsDropdownContent>
+      </div>
+    )
+  }
+)

--- a/app/routes/circulars._archive._index/SortSelectorButton.tsx
+++ b/app/routes/circulars._archive._index/SortSelectorButton.tsx
@@ -61,13 +61,13 @@ export function SortSelector({
 }) {
   const submit = useSubmit()
   const SortSelectorRef = useRef<HTMLDivElement>(null)
-  const [showSortSelector, setShowSortSelector] = useState(false)
+  const [showContent, setShowContent] = useState(false)
   useOnClickOutside(SortSelectorRef, () => {
-    setShowSortSelector(false)
+    setShowContent(false)
   })
 
   function radioOnChange({ target }: ChangeEvent<HTMLInputElement>) {
-    setShowSortSelector(false)
+    setShowContent(false)
     if (target.form) submit(target.form)
   }
 
@@ -95,15 +95,15 @@ export function SortSelector({
     <div ref={SortSelectorRef}>
       <SortButton
         sort={sanitizedValue}
-        expanded={showSortSelector}
+        expanded={showContent}
         onClick={() => {
-          setShowSortSelector((shown) => !shown)
+          setShowContent((shown) => !shown)
         }}
       />
 
       <DetailsDropdownContent
         className={classNames('maxw-card-xlg', {
-          'display-none': !showSortSelector,
+          'display-none': !showContent,
         })}
       >
         <CardBody>

--- a/app/routes/circulars._archive._index/SortSelectorButton.tsx
+++ b/app/routes/circulars._archive._index/SortSelectorButton.tsx
@@ -51,67 +51,66 @@ function SortButton({
   )
 }
 
-interface SortSelectorProps {
-  form?: string
-  defaultValue?: string
-  showContent: boolean
-  setShowContent: React.Dispatch<React.SetStateAction<boolean>>
-}
-
-export const SortSelector = forwardRef<HTMLDivElement, SortSelectorProps>(
-  function SortSelector(
-    { form, defaultValue, showContent, setShowContent },
-    ref: React.Ref<HTMLDivElement>
-  ) {
-    const submit = useSubmit()
-
-    function radioOnChange({ target }: ChangeEvent<HTMLInputElement>) {
-      setShowContent(false)
-      if (target.form) submit(target.form)
-    }
-
-    const sanitizedValue =
-      defaultValue && defaultValue in sortOptions ? defaultValue : 'circularID'
-
-    const SortRadioButtons = () => (
-      <>
-        {Object.entries(sortOptions).map(([value, label]) => (
-          <Radio
-            key={value}
-            id={value}
-            name="sort"
-            value={value}
-            label={label}
-            form={form}
-            defaultChecked={sanitizedValue === value}
-            onChange={radioOnChange}
-          />
-        ))}
-      </>
-    )
-
-    return (
-      <div ref={ref}>
-        <SortButton
-          sort={sanitizedValue}
-          expanded={showContent}
-          onClick={() => {
-            setShowContent((shown) => !shown)
-          }}
-        />
-
-        <DetailsDropdownContent
-          className={classNames('maxw-card-xlg', {
-            'display-none': !showContent,
-          })}
-        >
-          <CardBody>
-            <Grid col={1}>
-              <SortRadioButtons />
-            </Grid>
-          </CardBody>
-        </DetailsDropdownContent>
-      </div>
-    )
+export const SortSelector = forwardRef<
+  HTMLDivElement,
+  {
+    form?: string
+    defaultValue?: string
+    showContent: boolean
+    setShowContent: React.Dispatch<React.SetStateAction<boolean>>
   }
-)
+>(function SortSelector(
+  { form, defaultValue, showContent, setShowContent },
+  ref: React.Ref<HTMLDivElement>
+) {
+  const submit = useSubmit()
+
+  function radioOnChange({ target }: ChangeEvent<HTMLInputElement>) {
+    setShowContent(false)
+    if (target.form) submit(target.form)
+  }
+
+  const sanitizedValue =
+    defaultValue && defaultValue in sortOptions ? defaultValue : 'circularID'
+
+  const SortRadioButtons = () => (
+    <>
+      {Object.entries(sortOptions).map(([value, label]) => (
+        <Radio
+          key={value}
+          id={value}
+          name="sort"
+          value={value}
+          label={label}
+          form={form}
+          defaultChecked={sanitizedValue === value}
+          onChange={radioOnChange}
+        />
+      ))}
+    </>
+  )
+
+  return (
+    <div ref={ref}>
+      <SortButton
+        sort={sanitizedValue}
+        expanded={showContent}
+        onClick={() => {
+          setShowContent((shown) => !shown)
+        }}
+      />
+
+      <DetailsDropdownContent
+        className={classNames('maxw-card-xlg', {
+          'display-none': !showContent,
+        })}
+      >
+        <CardBody>
+          <Grid col={1}>
+            <SortRadioButtons />
+          </Grid>
+        </CardBody>
+      </DetailsDropdownContent>
+    </div>
+  )
+})

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -24,7 +24,8 @@ import {
   TextInput,
 } from '@trussworks/react-uswds'
 import clamp from 'lodash/clamp'
-import { useId, useState } from 'react'
+import { useId, useRef, useState } from 'react'
+import { useOnClickOutside } from 'usehooks-ts'
 
 import { getUser } from '../_auth/user.server'
 import {
@@ -170,6 +171,12 @@ export default function () {
   const formId = useId()
   const submit = useSubmit()
 
+  const dateSelectorRef = useRef<HTMLDivElement>(null)
+
+  useOnClickOutside(dateSelectorRef, () => {
+    console.log('clicked outside date selector')
+  })
+
   return (
     <>
       {result?.intent === 'correction' && (
@@ -224,6 +231,7 @@ export default function () {
           form={formId}
           defaultStartDate={startDate}
           defaultEndDate={endDate}
+          ref={dateSelectorRef}
         />
         {query && <SortSelector form={formId} defaultValue={sort} />}
         <Link to={`/circulars/new${searchString}`}>

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -232,8 +232,8 @@ export default function () {
           form={formId}
           defaultStartDate={startDate}
           defaultEndDate={endDate}
-          showDateSelector={showDateSelector}
-          setShowDateSelector={setShowDateSelector}
+          showContent={showDateSelector}
+          setShowContent={setShowDateSelector}
           ref={dateSelectorRef}
         />
         {query && <SortSelector form={formId} defaultValue={sort} />}

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -171,13 +171,6 @@ export default function () {
   const formId = useId()
   const submit = useSubmit()
 
-  const dateSelectorRef = useRef<HTMLDivElement>(null)
-  const [showDateSelector, setShowDateSelector] = useState(false)
-
-  useOnClickOutside(dateSelectorRef, () => {
-    setShowDateSelector(false)
-  })
-
   return (
     <>
       {result?.intent === 'correction' && (
@@ -232,9 +225,6 @@ export default function () {
           form={formId}
           defaultStartDate={startDate}
           defaultEndDate={endDate}
-          showContent={showDateSelector}
-          setShowContent={setShowDateSelector}
-          ref={dateSelectorRef}
         />
         {query && <SortSelector form={formId} defaultValue={sort} />}
         <Link to={`/circulars/new${searchString}`}>

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -172,6 +172,7 @@ export default function () {
   const submit = useSubmit()
 
   const dateSelectorRef = useRef<HTMLDivElement>(null)
+  const [showDateSelector, setShowDateSelector] = useState(false)
 
   useOnClickOutside(dateSelectorRef, () => {
     console.log('clicked outside date selector')
@@ -231,6 +232,8 @@ export default function () {
           form={formId}
           defaultStartDate={startDate}
           defaultEndDate={endDate}
+          showDateSelector={showDateSelector}
+          setShowDateSelector={setShowDateSelector}
           ref={dateSelectorRef}
         />
         {query && <SortSelector form={formId} defaultValue={sort} />}

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -173,14 +173,9 @@ export default function () {
 
   const dateSelectorRef = useRef<HTMLDivElement>(null)
   const [showDateSelector, setShowDateSelector] = useState(false)
-  const SortSelectorRef = useRef<HTMLDivElement>(null)
-  const [showSortSelector, setShowSortSelector] = useState(false)
 
   useOnClickOutside(dateSelectorRef, () => {
     setShowDateSelector(false)
-  })
-  useOnClickOutside(SortSelectorRef, () => {
-    setShowSortSelector(false)
   })
 
   return (
@@ -241,15 +236,7 @@ export default function () {
           setShowContent={setShowDateSelector}
           ref={dateSelectorRef}
         />
-        {query && (
-          <SortSelector
-            form={formId}
-            defaultValue={sort}
-            showContent={showSortSelector}
-            setShowContent={setShowSortSelector}
-            ref={SortSelectorRef}
-          />
-        )}
+        {query && <SortSelector form={formId} defaultValue={sort} />}
         <Link to={`/circulars/new${searchString}`}>
           <Button
             type="button"

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -173,9 +173,14 @@ export default function () {
 
   const dateSelectorRef = useRef<HTMLDivElement>(null)
   const [showDateSelector, setShowDateSelector] = useState(false)
+  const SortSelectorRef = useRef<HTMLDivElement>(null)
+  const [showSortSelector, setShowSortSelector] = useState(false)
 
   useOnClickOutside(dateSelectorRef, () => {
     setShowDateSelector(false)
+  })
+  useOnClickOutside(SortSelectorRef, () => {
+    setShowSortSelector(false)
   })
 
   return (
@@ -236,7 +241,15 @@ export default function () {
           setShowContent={setShowDateSelector}
           ref={dateSelectorRef}
         />
-        {query && <SortSelector form={formId} defaultValue={sort} />}
+        {query && (
+          <SortSelector
+            form={formId}
+            defaultValue={sort}
+            showContent={showSortSelector}
+            setShowContent={setShowSortSelector}
+            ref={SortSelectorRef}
+          />
+        )}
         <Link to={`/circulars/new${searchString}`}>
           <Button
             type="button"

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -24,8 +24,7 @@ import {
   TextInput,
 } from '@trussworks/react-uswds'
 import clamp from 'lodash/clamp'
-import { useId, useRef, useState } from 'react'
-import { useOnClickOutside } from 'usehooks-ts'
+import { useId, useState } from 'react'
 
 import { getUser } from '../_auth/user.server'
 import {

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -175,7 +175,7 @@ export default function () {
   const [showDateSelector, setShowDateSelector] = useState(false)
 
   useOnClickOutside(dateSelectorRef, () => {
-    console.log('clicked outside date selector')
+    setShowDateSelector(false)
   })
 
   return (


### PR DESCRIPTION
This adds basic functionality to the DetailsDropdownContent component for listening for clicking away from a dropdown, which will cause the dropdown to be hidden from the user unless the dropdown button is pressed again. This will prevent dropdown menus drawing over one another in the circulars archive like so:

![image](https://github.com/nasa-gcn/gcn.nasa.gov/assets/57914086/2e1fd33b-09c7-443e-aece-46a18fede0c4)

and users won't have to manually hide dropdown menus should they choose to not impose any of the additional search filters.
