### PR TITLE
adding batch delete

### DIFF
--- a/app/routes/_gcn.synonyms/synonyms.server.ts
+++ b/app/routes/_gcn.synonyms/synonyms.server.ts
@@ -89,21 +89,21 @@ export async function putSynonyms({
  * BatchWriteItem has a limit of 25 items, so the user may not delete
  *  more than 25 synonyms at a time.
  */
-export async function deleteSynonyms({ uuid }: { uuid: string }) {
-  if (!uuid) return
+export async function deleteSynonyms(uuid: string) {
   const db = await tables()
   const client = db._doc as unknown as DynamoDBDocument
   const TableName = db.name('synonyms')
   const results = await db.synonyms.query({
     IndexName: 'synonymsByUuid',
     KeyConditionExpression: 'uuid = :uuid',
+    ProjectionExpression: 'eventId',
     ExpressionAttributeValues: {
       ':uuid': uuid,
     },
   })
-  const writes = results.Items.map((i) => ({
-    PutRequest: {
-      Item: { uuid: i.uuid, eventId: i.eventId },
+  const writes = results.Items.map(({ eventId }) => ({
+    DeleteRequest: {
+      Key: { uuid, eventId },
     },
   }))
   const params = {


### PR DESCRIPTION
### IMPORTANT: Please do not create a Pull Request without creating an issue first.

### Title   
 feat: add delete to synonym server

### Description
Adding a function to delete a synonym by deleting all of its members.

### Reviewers
@lpsinger - he has reviewed the other synonym functions 

### Changes
Adding a currently unused function to delete synonyms by deleting its members. 

### Acceptance Criteria
this is currently unused. must pass syntax check.

### Related Issue(s)
closes #1936 

### Testing
this function is currently unused.
