### PR TITLE
Remove duplicate validation in putSynonyms

### DIFF
--- a/app/routes/_gcn.synonyms/synonyms.server.ts
+++ b/app/routes/_gcn.synonyms/synonyms.server.ts
@@ -58,12 +58,11 @@ export async function putSynonyms({
   additions?: string[]
   subtractions?: string[]
 }) {
+  if (!subtractions?.length && !additions?.length) return
   const db = await tables()
   const client = db._doc as unknown as DynamoDBDocument
   const TableName = db.name('synonyms')
   const writes = []
-  if (!subtractions && !additions) return
-  if (subtractions?.length === 0 && additions?.length === 0) return
   if (subtractions) {
     const subtraction_writes = subtractions.map((eventId) => ({
       DeleteRequest: {


### PR DESCRIPTION
Also, perform the validation earlier to prevent unnecessary work.