### PR TITLE
Use ruff instead of black for formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "[python]": {
-    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.defaultFormatter": "charliermarsh.ruff",
     "editor.tabSize": 4
   },
   "editor.tabSize": 2,


### PR DESCRIPTION
Switch VSCode to use Ruff for Python formatting instead of Black, to be consistent with the rest of the codebase.

Fixes #2013 