### PR TITLE
Run arc hydrate verbosely in CI workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Install Python dependencies
-        run: docker run --rm --platform linux/arm64 -v $(pwd):/src python:3.11 sh -c 'apt-get update && apt-get -y install --no-install-recommends npm && cd src && npx arc hydrate'
+        run: docker run --rm --platform linux/arm64 -v $(pwd):/src python:3.11 sh -c 'apt-get update && apt-get -y install --no-install-recommends npm && cd src && npx arc hydrate -v'
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Build
         run: npm run build
       - name: Install Python dependencies
-        run: docker run --rm --platform linux/arm64 -v $(pwd):/src python:3.11 sh -c 'apt-get update && apt-get -y install --no-install-recommends npm && cd src && npx arc hydrate'
+        run: docker run --rm --platform linux/arm64 -v $(pwd):/src python:3.11 sh -c 'apt-get update && apt-get -y install --no-install-recommends npm && cd src && npx arc hydrate -v'


### PR DESCRIPTION
The default output is not very useful: it's a CLI spinner that doesn't even show up properly in the CI logs. Instead, show verbose output.