### PR TITLE
Adjust husky settings for husky v9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev:sass": "sass --watch -Inode_modules/nasawds/src/theme -Inode_modules/@uswds -Inode_modules/@uswds/uswds/packages app:app",
     "dev:esbuild": "node esbuild.js --dev",
     "dev": "run-p \"dev:*\"",
-    "prepare": "husky install",
+    "prepare": "husky",
     "deploy": "arc deploy --prune --production",
     "clean": "rimraf --glob build/static app/css \"build/**/index.*\" \"build/**/metafile.*\" \"build/**/version.txt\" \"app/**/*.css\" \"app/**/*.css.map\" sam.json sam.yaml .cache python/vendor",
     "test": "jest",


### PR DESCRIPTION
This fixes the following warning when runnning `npm i`:

```
$ npm i

> prepare
> husky install

install command is deprecated
```