### PR TITLE
adding synonym getters

### DIFF
--- a/app/routes/_gcn.synonyms/synonyms.server.ts
+++ b/app/routes/_gcn.synonyms/synonyms.server.ts
@@ -7,7 +7,104 @@
  */
 import { tables } from '@architect/functions'
 import type { DynamoDBDocument } from '@aws-sdk/lib-dynamodb/dist-types/DynamoDBDocument'
+import { search as getSearchClient } from '@nasa-gcn/architect-functions-search'
 import crypto from 'crypto'
+
+import type { Synonym } from './synonyms.lib'
+
+export async function getSynonymsByUuid(uuid: string) {
+  const db = await tables()
+
+  const { Items } = await db.synonym.query({
+    IndexName: 'synonymsByUuid',
+    KeyConditionExpression: 'uuid = :uuid',
+    ExpressionAttributeValues: {
+      ':uuid': uuid,
+    },
+  })
+  if (!Items.length)
+    throw new Response(null, {
+      status: 404,
+    })
+
+  return Items as Synonym[]
+}
+
+export async function searchSynonymsByEventId({
+  limit = 10,
+  page,
+  eventId,
+}: {
+  limit?: number
+  page: number
+  eventId?: string
+}): Promise<{
+  synonyms: Record<string, string[]>
+  totalItems: number
+  totalPages: number
+  page: number
+}> {
+  const client = await getSearchClient()
+  const query: any = {
+    bool: {
+      should: [
+        {
+          match_all: {},
+        },
+      ],
+      minimum_should_match: 1,
+    },
+  }
+
+  if (eventId) {
+    query.bool.should.push({
+      match: {
+        eventId: {
+          query: eventId,
+          fuzziness: 'AUTO',
+        },
+      },
+    })
+  }
+
+  const {
+    body: {
+      hits: {
+        total: { value: totalItems },
+        hits,
+      },
+    },
+  } = await client.search({
+    index: 'synonyms',
+    from: page && limit && (page - 1) * limit,
+    size: limit,
+    body: {
+      query,
+    },
+  })
+
+  const totalPages: number = Math.ceil(totalItems / limit)
+  const results: Record<string, string[]> = {}
+
+  hits.forEach(
+    ({
+      _source: body,
+    }: {
+      _source: Synonym
+      fields: { eventId: string; uuid: string }
+    }) =>
+      results[body.uuid]
+        ? results[body.uuid].push(body.eventId)
+        : (results[body.uuid] = [body.eventId])
+  )
+
+  return {
+    synonyms: results,
+    totalItems,
+    totalPages,
+    page,
+  }
+}
 
 /*
  * If an eventId already has a synonym and is passed in, it will unlink the

--- a/app/routes/_gcn.synonyms/synonyms.server.ts
+++ b/app/routes/_gcn.synonyms/synonyms.server.ts
@@ -22,10 +22,6 @@ export async function getSynonymsByUuid(uuid: string) {
       ':uuid': uuid,
     },
   })
-  if (!Items.length)
-    throw new Response(null, {
-      status: 404,
-    })
 
   return Items as Synonym[]
 }


### PR DESCRIPTION
### Title   
 feat: add gets to synonym server

### Description
This PR adds 2 functions. One for getting synonyms by uuid and one for getting or searching synonyms by eventId.
The search utilizes opensearch.

### Reviewers
@dakota002  - he can review this pr for style and syntax

### Changes
Adds two server functions that are currently unused. 

### Acceptance Criteria
there are server functions to
- get synonyms by uuid
- get/search synonyms by eventId

### Related Issue(s)
Resolves #1935 

### Testing
syntax and style only. Function is unused and we have not established our db testing methodology yet. A PR will be forthcoming with tests for this and all other functions in the server when that has been decided.
