### PR TITLE
Don't rely on @trussworks/react-uswds types that are not exported

### DIFF
--- a/app/components/DetailsDropdownButton.tsx
+++ b/app/components/DetailsDropdownButton.tsx
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { Button, Icon } from '@trussworks/react-uswds'
-import type { ButtonProps } from '@trussworks/react-uswds/lib/components/Button/Button'
 import type { ReactNode } from 'react'
 
 export default function DetailsDropdownButton({
@@ -14,7 +13,7 @@ export default function DetailsDropdownButton({
   ...props
 }: {
   children: ReactNode
-} & Omit<ButtonProps & JSX.IntrinsicElements['button'], 'type'>) {
+} & Omit<Parameters<typeof Button>[0], 'type'>) {
   return (
     <Button type="button" {...props}>
       {children}


### PR DESCRIPTION
Closes #2047.