### PR TITLE
ACROSS API: Move to using aioboto3 and make things as async as possible

### DIFF
--- a/python/across_api/across/api.py
+++ b/python/across_api/across/api.py
@@ -6,8 +6,8 @@ from typing import Annotated, Optional
 
 from fastapi import Depends, Query, Security
 
-from ..base.api import app
 from ..auth.api import scope_authorize
+from ..base.api import app
 from .hello import Hello
 from .resolve import Resolve
 from .schema import HelloSchema, ResolveSchema
@@ -40,12 +40,14 @@ YourNameDep = Annotated[Optional[str], Depends(your_name)]
 
 # API End points
 @app.get("/")
-def hello(name: YourNameDep) -> HelloSchema:
+async def hello(name: YourNameDep) -> HelloSchema:
     """
     This function returns a JSON response with a greeting message and an optional name parameter.
     If the name parameter is provided, the greeting message will include the name.
     """
-    return Hello(name=name).schema
+    hello = Hello(name=name)
+    await hello.get()
+    return hello.schema
 
 
 @app.get(
@@ -59,12 +61,16 @@ async def secure_hello(name: YourNameDep) -> HelloSchema:
     This function returns a JSON response with a greeting message and an optional name parameter.
     If the name parameter is provided, the greeting message will include the name.
     """
-    return Hello(name=name).schema
+    hello = Hello(name=name)
+    await hello.get()
+    return hello.schema
 
 
 @app.get("/across/resolve")
-def resolve(name: SourceNameDep) -> ResolveSchema:
+async def resolve(name: SourceNameDep) -> ResolveSchema:
     """
     Resolve the name of an astronomical object to its coordinates.
     """
-    return Resolve(name=name).schema
+    resolve = Resolve(name=name)
+    await resolve.get()
+    return resolve.schema

--- a/python/across_api/across/hello.py
+++ b/python/across_api/across/hello.py
@@ -33,10 +33,8 @@ class Hello(ACROSSAPIBase):
             Your name
         """
         self.name = name
-        if self.validate_get():
-            self.get()
 
-    def get(self) -> bool:
+    async def get(self) -> bool:
         """
         GET method for ACROSS API Hello class.
 

--- a/python/across_api/base/database.py
+++ b/python/across_api/base/database.py
@@ -1,0 +1,16 @@
+import os
+
+import aioboto3  # type: ignore[import]
+from arc._lib import get_ports, use_aws  # type: ignore[import]
+
+
+def dynamodb_resource():
+    dynamodb_session = aioboto3.Session()
+    if use_aws():
+        return dynamodb_session.resource("dynamodb")
+    else:
+        port = get_ports()["tables"]
+        region_name = os.environ.get("AWS_REGION", "us-east-1")
+        return dynamodb_session.resource(
+            "dynamodb", endpoint_url=f"http://localhost:{port}", region_name=region_name
+        )

--- a/python/across_api/base/ephem.py
+++ b/python/across_api/base/ephem.py
@@ -93,18 +93,13 @@ class EphemBase:
         return index
 
     def __init__(self, begin: Time, end: Time, stepsize: u.Quantity = 60 * u.s):
-        # Check if TLE is loaded
-        if self.tle is None:
-            raise HTTPException(
-                status_code=404, detail="No TLE available for this epoch"
-            )
-
         # Parse inputs, round begin and end to stepsize
         self.begin = round_time(begin, stepsize)
         self.end = round_time(end, stepsize)
         self.stepsize = stepsize
 
-        # Check the TLE is available
+    def compute_ephem(self) -> bool:
+        # Check if TLE is loaded
         if self.tle is None:
             raise HTTPException(
                 status_code=404, detail="No TLE available for this epoch"
@@ -163,3 +158,5 @@ class EphemBase:
             self.earthsize = self.earth_radius * np.ones(len(self))
         else:
             self.earthsize = np.arcsin(R_earth / dist)
+
+        return True

--- a/python/across_api/swift/ephem.py
+++ b/python/across_api/swift/ephem.py
@@ -2,14 +2,10 @@
 # Administrator of the National Aeronautics and Space Administration.
 # All Rights Reserved.
 
-from typing import Optional
-import astropy.units as u  # type: ignore
-from astropy.time import Time  # type: ignore
 from cachetools import TTLCache, cached
 
 from ..base.common import ACROSSAPIBase
 from ..base.ephem import EphemBase
-from ..base.schema import TLEEntry
 from .tle import SwiftTLE
 
 
@@ -20,16 +16,13 @@ class SwiftEphem(EphemBase, ACROSSAPIBase):
     Satellite from TLE.
     """
 
-    def __init__(
-        self,
-        begin: Time,
-        end: Time,
-        stepsize: u.Quantity = 60 * u.s,
-        tle: Optional[TLEEntry] = None,
-    ):
-        # Load TLE data
-        self.tle = tle
+    async def get(self) -> bool:
         if self.tle is None:
-            self.tle = SwiftTLE(begin).tle
-        if self.tle is not None:
-            super().__init__(begin=begin, end=end, stepsize=stepsize)
+            # Get TLE
+            tle = SwiftTLE(self.begin)
+            await tle.get()
+            self.tle = tle.tle
+
+        # Compute ephemeris
+        self.compute_ephem()
+        return True

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -1,4 +1,5 @@
 --extra-index-url https://nasa-gcn.github.io/healpy-prerelease-pypi-index/simple/
+aioboto3
 architect-functions
 astropy
 astropy_healpix
@@ -6,9 +7,9 @@ cachetools
 email-validator
 fastapi
 healpy==0.1.dev1+g500357b
+httpx
 mangum
 python-multipart  # Required for file uploads in FastAPI; see https://fastapi.tiangolo.com/tutorial/request-files/
-requests
 shapely
 sgp4
 spacetrack

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,6 +6,18 @@
 #
 --extra-index-url https://nasa-gcn.github.io/healpy-prerelease-pypi-index/simple/
 
+aioboto3==12.3.0
+    # via -r requirements.in
+aiobotocore[boto3]==2.11.2
+    # via
+    #   aioboto3
+    #   aiobotocore
+aiohttp==3.9.3
+    # via aiobotocore
+aioitertools==0.11.0
+    # via aiobotocore
+aiosignal==1.3.1
+    # via aiohttp
 annotated-types==0.6.0
     # via pydantic
 anyio==3.7.1
@@ -24,18 +36,24 @@ astropy-healpix==1.0.2
 astropy-iers-data==0.2024.2.5.0.30.52
     # via astropy
 attrs==23.2.0
-    # via rush
+    # via
+    #   aiohttp
+    #   rush
+boto3==1.34.34
+    # via aiobotocore
+botocore==1.34.34
+    # via
+    #   aiobotocore
+    #   boto3
+    #   s3transfer
 cachetools==5.3.2
     # via -r requirements.in
 certifi==2023.11.17
     # via
     #   httpcore
     #   httpx
-    #   requests
 cffi==1.16.0
     # via cryptography
-charset-normalizer==3.3.2
-    # via requests
 cryptography==42.0.4
     # via architect-functions
 dnspython==2.4.2
@@ -46,6 +64,10 @@ email-validator==2.1.0.post1
     # via -r requirements.in
 fastapi==0.109.2
     # via -r requirements.in
+frozenlist==1.4.1
+    # via
+    #   aiohttp
+    #   aiosignal
 h11==0.14.0
     # via httpcore
 healpy==0.1.dev1+g500357b
@@ -53,17 +75,27 @@ healpy==0.1.dev1+g500357b
 httpcore==1.0.2
     # via httpx
 httpx==0.26.0
-    # via spacetrack
+    # via
+    #   -r requirements.in
+    #   spacetrack
 idna==3.6
     # via
     #   anyio
     #   email-validator
     #   httpx
-    #   requests
+    #   yarl
+jmespath==1.0.1
+    # via
+    #   boto3
+    #   botocore
 logbook==1.7.0.post0
     # via spacetrack
 mangum==0.17.0
     # via -r requirements.in
+multidict==6.0.5
+    # via
+    #   aiohttp
+    #   yarl
 numpy==1.26.2
     # via
     #   astropy
@@ -85,6 +117,8 @@ pydantic-core==2.14.5
     # via pydantic
 pyerfa==2.0.1.1
     # via astropy
+python-dateutil==2.9.0.post0
+    # via botocore
 python-jose==3.3.0
     # via architect-functions
 python-multipart==0.0.9
@@ -93,12 +127,12 @@ pyyaml==6.0.1
     # via astropy
 represent==2.0
     # via spacetrack
-requests==2.31.0
-    # via -r requirements.in
 rsa==4.9
     # via python-jose
 rush==2021.4.0
     # via spacetrack
+s3transfer==0.10.0
+    # via boto3
 sgp4==2.23
     # via -r requirements.in
 shapely==2.0.2
@@ -106,7 +140,9 @@ shapely==2.0.2
 simplejson==3.19.2
     # via architect-functions
 six==1.16.0
-    # via ecdsa
+    # via
+    #   ecdsa
+    #   python-dateutil
 sniffio==1.3.0
     # via
     #   anyio
@@ -123,4 +159,8 @@ typing-extensions==4.9.0
     #   pydantic
     #   pydantic-core
 urllib3==2.0.7
-    # via requests
+    # via botocore
+wrapt==1.16.0
+    # via aiobotocore
+yarl==1.9.4
+    # via aiohttp

--- a/python/tests/across/test_across_resolve.py
+++ b/python/tests/across/test_across_resolve.py
@@ -2,18 +2,23 @@
 # Administrator of the National Aeronautics and Space Administration.
 # All Rights Reserved.
 
+import pytest
 from across_api.across.resolve import Resolve
 
 
-def test_resolve_cds(expected_resolve_crab):
+@pytest.mark.asyncio
+async def test_resolve_cds(expected_resolve_crab):
     resolve = Resolve(expected_resolve_crab.name)
+    await resolve.get()
     assert abs(resolve.ra - expected_resolve_crab.ra) < 0.1 / 3600
     assert abs(resolve.dec - expected_resolve_crab.dec) < 0.1 / 3600
     assert resolve.resolver == expected_resolve_crab.resolver
 
 
-def test_resolve_antares(expected_resolve_ztf):
+@pytest.mark.asyncio
+async def test_resolve_antares(expected_resolve_ztf):
     resolve = Resolve(expected_resolve_ztf.name)
+    await resolve.get()
     assert abs(resolve.ra - expected_resolve_ztf.ra) < 0.1 / 3600
     assert abs(resolve.dec - expected_resolve_ztf.dec) < 0.1 / 3600
     assert resolve.resolver == expected_resolve_ztf.resolver

--- a/python/tests/ephem/conftest.py
+++ b/python/tests/ephem/conftest.py
@@ -3,6 +3,7 @@
 # All Rights Reserved.
 
 import pytest
+import pytest_asyncio
 from across_api.base.schema import TLEEntry  # type: ignore[import]
 from across_api.burstcube.ephem import BurstCubeEphem  # type: ignore[import]
 from across_api.swift.ephem import SwiftEphem  # type: ignore[import]
@@ -37,12 +38,13 @@ def burstcube_tle():
     return tleentry
 
 
-@pytest.fixture
-def burstcube_ephem(burstcube_tle):
+@pytest_asyncio.fixture
+async def burstcube_ephem(burstcube_tle):
     # Calculate a BurstCube Ephemeris
-    return BurstCubeEphem(
-        begin=Time("2024-01-01"), end=Time("2024-01-01 00:05:00"), tle=burstcube_tle
-    )
+    ephem = BurstCubeEphem(begin=Time("2024-01-01"), end=Time("2024-01-01 00:05:00"))
+    ephem.tle = burstcube_tle
+    await ephem.get()
+    return ephem
 
 
 @pytest.fixture
@@ -56,12 +58,13 @@ def swift_tle():
     return tleentry
 
 
-@pytest.fixture
-def swift_ephem(swift_tle):
+@pytest_asyncio.fixture
+async def swift_ephem(swift_tle):
     # Calculate a Swift Ephemeris
-    return SwiftEphem(
-        begin=Time("2024-01-29"), end=Time("2024-01-29 00:05:00"), tle=swift_tle
-    )
+    ephem = SwiftEphem(begin=Time("2024-01-29"), end=Time("2024-01-29 00:05:00"))
+    ephem.tle = swift_tle
+    await ephem.get()
+    return ephem
 
 
 @pytest.fixture

--- a/python/tests/fov/conftest.py
+++ b/python/tests/fov/conftest.py
@@ -3,6 +3,7 @@
 # All Rights Reserved.
 
 import pytest
+import pytest_asyncio
 from across_api.across.resolve import Resolve
 from astropy.coordinates import SkyCoord  # type: ignore[import]
 from astropy.time import Time  # type: ignore[import]
@@ -14,10 +15,11 @@ from across_api.burstcube.tle import BurstCubeTLE
 import astropy.units as u  # type: ignore[import]
 
 
-@pytest.fixture
-def AT2017gfo_skycoord():
+@pytest_asyncio.fixture
+async def AT2017gfo_skycoord():
     # Define the position of interesting event AT2017gfo
     r = Resolve(name="AT2017gfo")
+    await r.get()
     return SkyCoord(r.ra, r.dec, unit="deg")
 
 
@@ -30,8 +32,8 @@ def AT2017gfo_healpix_probability():
     return hdu[1].data["PROB"]
 
 
-@pytest.fixture
-def burstcube_fov():
+@pytest_asyncio.fixture
+async def burstcube_fov():
     # Define a TLE by hand. For the sake of this test, we're going to use the Fermi TLE on the day that GW170817 triggered.
     satname = "FGRST (GLAST)"
     tle1 = "1 33053U 08029A   17229.56317825 +.00000508 +00000-0 +12437-4 0  9995"
@@ -51,8 +53,9 @@ def burstcube_fov():
     eph = BurstCubeEphem(
         begin=trigger_time - 2 * u.s,
         end=trigger_time + 2 * u.s,
-        tle=tle.tle,
         stepsize=1 * u.s,
     )
+    eph.tle = tle.tle
+    await eph.get()
 
     return BurstCubeFOV(ephem=eph, time=trigger_time)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ mypy
 ruff
 hypothesis
 pytest
+pytest-asyncio
 types-requests
 types-cachetools
 types-python-jose


### PR DESCRIPTION
## Feature Request Details :star:
### Description

In response to Issue #2005, this moves the ACROSS API to use `aioboto3`, therefore making DynamoDB calls asynchronously. In addition it updates various components of the ACROSS API to be as async as possible. This involves solving several issues, caused by the fact that async functions can only be called by other async functions.

1. We currently use the `architect-functions` module to handle database connections. This does not support aioboto3, so we use aioboto3 direct, however we want to be able to run in local and testing modes. Therefore in order to support this, we use several internal calls from `architect-functions` to determine the table name with any prefixes, and also if we are running in a testing mode or on AWS.
2. Currently many modules can run automatically from instantiation if the correct variables are provide, where others cannot. We are moving all `get()`, `del()`, `put()` and `post()` functions to async, which cannot be called from `__init__()`, so therefore we removed this automatic running in all cases.
3. The `BurstCubeEphem` and `SwiftEphem` classes are slightly rewritten to have custom `get()` functions rather than `__init__()` in order to support async.
4. `pytest` tests updated to support `async` using the `pytest-asyncio` module.

In addition we rewrote the `TLE` class to use async fetch from spacetrack (supported by async support in the `spacetrack` module), and also fetch `async` from the ANTARES API in `Resolve`. Generally an effort has been made to make API endpoints async by default. 

### Reviewers
Leo Singer 
Samuel Wyatt

### Functional Requirements
* Use `aioboto3` library instead of `architect-functions` to perform database actions.
* Support the architect provided dev environment.

### Non-functional Requirements
* Move as many calls to be async as possible.

### Acceptance Criteria
* Pass code review.
* Pass testing.