### PR TITLE
ACROSS API: Add TOO history recording

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -52,6 +52,11 @@ acrossapi_tle
 burstcube_too
   id *String
 
+burstcube_too_history
+  id *String
+  version **Number
+  PointInTimeRecovery true
+
 sessions
   _idx *String
   _ttl TTL

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -4,6 +4,7 @@ architect-functions
 astropy
 astropy_healpix
 cachetools
+dynamodb-autoincrement>=0.2.0
 email-validator
 fastapi
 healpy==0.1.dev1+g500357b

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,7 +7,9 @@
 --extra-index-url https://nasa-gcn.github.io/healpy-prerelease-pypi-index/simple/
 
 aioboto3==12.3.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   dynamodb-autoincrement
 aiobotocore[boto3]==2.11.2
     # via
     #   aioboto3
@@ -41,11 +43,17 @@ attrs==23.2.0
     #   rush
 boto3==1.34.34
     # via aiobotocore
+boto3-missing==0.1.0
+    # via dynamodb-autoincrement
 botocore==1.34.34
     # via
     #   aiobotocore
     #   boto3
     #   s3transfer
+botocore-stubs==1.34.60
+    # via
+    #   types-aioboto3
+    #   types-aiobotocore
 cachetools==5.3.2
     # via -r requirements.in
 certifi==2023.11.17
@@ -58,6 +66,8 @@ cryptography==42.0.4
     # via architect-functions
 dnspython==2.4.2
     # via email-validator
+dynamodb-autoincrement==0.2.0
+    # via -r requirements.in
 ecdsa==0.18.0
     # via python-jose
 email-validator==2.1.0.post1
@@ -152,12 +162,25 @@ spacetrack==1.2.0
     # via -r requirements.in
 starlette==0.36.3
     # via fastapi
+types-aioboto3[dynamodb]==12.3.0
+    # via dynamodb-autoincrement
+types-aiobotocore==2.12.1
+    # via types-aioboto3
+types-aiobotocore-dynamodb==2.12.1
+    # via types-aioboto3
+types-awscrt==0.20.5
+    # via botocore-stubs
+types-s3transfer==0.10.0
+    # via types-aioboto3
 typing-extensions==4.9.0
     # via
     #   fastapi
     #   mangum
     #   pydantic
     #   pydantic-core
+    #   types-aioboto3
+    #   types-aiobotocore
+    #   types-aiobotocore-dynamodb
 urllib3==2.0.7
     # via botocore
 wrapt==1.16.0


### PR DESCRIPTION
### Title
ACROSS API: Add TOO history recording

### Description
Adds support for recording history of changes too BurstCube TOO entries.

### Reviewers
Leo Singer 
Sam Wyatt

### Changes
Adds support for recording history of changes too BurstCube TOO entries, utilizing https://github.com/nasa-gcn/python-dynamodb-autoincrement. Note that this requires that `dynamodb-autoincrement` supports the use of `aioboto3`, which is covered by https://github.com/nasa-gcn/python-dynamodb-autoincrement/pull/4.

This pull adds recording of history to `BurstCubeTOO` PUT and DELETE in a DynamoDB table called `burstcube_too_history`, which has an additional attribute, `version` which increments by 1 every time the table is recorded. Historical values are only recorded on change.

Currently no method exists for fetching this history, this PR only adds support for writing. 

### Acceptance Criteria
Code review.

### Related Issue(s)
Resolves #2052 
### Testing
Local testing performed. pytests for this and `BurstCubeTOORequest` on hold in seperate PR.