### PR TITLE
Do not require Healpy on Windows

### DIFF
--- a/python/requirements.in
+++ b/python/requirements.in
@@ -7,7 +7,7 @@ cachetools
 dynamodb-autoincrement>=0.2.0
 email-validator
 fastapi
-healpy==0.1.dev1+g500357b
+healpy==0.1.dev1+g500357b; platform_system!="Windows"  # Healpy does not have any Windows builds; see https://github.com/healpy/healpy/issues/25
 httpx
 mangum
 python-multipart  # Required for file uploads in FastAPI; see https://fastapi.tiangolo.com/tutorial/request-files/

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -11,9 +11,7 @@ aioboto3==12.3.0
     #   -r requirements.in
     #   dynamodb-autoincrement
 aiobotocore[boto3]==2.11.2
-    # via
-    #   aioboto3
-    #   aiobotocore
+    # via aioboto3
 aiohttp==3.9.3
     # via aiobotocore
 aioitertools==0.11.0
@@ -80,7 +78,7 @@ frozenlist==1.4.1
     #   aiosignal
 h11==0.14.0
     # via httpcore
-healpy==0.1.dev1+g500357b
+healpy==0.1.dev1+g500357b ; platform_system != "Windows"
     # via -r requirements.in
 httpcore==1.0.2
     # via httpx


### PR DESCRIPTION
Healpy does not have builds for windows; see
https://github.com/healpy/healpy/issues/25.

`npm run dev` will now work again on Windows, although the ACROSS API endpoints will bne nonfunctional on Windows.

Addresses #2038.