### PR TITLE
Add prettier lint-staged rule for .yml files

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -30,7 +30,7 @@ export default {
     return `eslint --cache --fix --max-warnings 0 ${filteredFiles}`
   },
   '*.{ts,tsx}': () => 'tsc',
-  '*.{css,scss,cjs,mjs,js,json,jsx,md,mdx,ts,tsx}': async (files) => {
+  '*.{css,scss,cjs,mjs,js,json,jsx,md,mdx,ts,tsx,yml}': async (files) => {
     const filteredFiles = prettierRemoveIgnoredFiles(files)
     if (!files) return []
     return `prettier --write ${filteredFiles}`


### PR DESCRIPTION
The CI pipeline checks that prettier has been run on all .yml files. Make sure that we run prettier automatically on .yml files in our pre-commit hook.