### PR TITLE
ACROSS API: Fix error in route

### DIFF
--- a/python/across_api/burstcube/api.py
+++ b/python/across_api/burstcube/api.py
@@ -138,7 +138,7 @@ async def burstcube_too_update(
     return too.schema
 
 
-@app.get("/burstcube/too/", status_code=status.HTTP_200_OK)
+@app.get("/burstcube/too", status_code=status.HTTP_200_OK)
 async def burstcube_too_requests(
     daterange: OptionalDateRangeDep,
     duration: OptionalDurationDep,


### PR DESCRIPTION
Route for BurstCube TOO fetch includes a `/` which means just fetching `/burstcube/too` does not work. This PR removes that `/`.