### PR TITLE
ACROSS API: Make blocking IO async and fix missing awaits

### DIFF
--- a/python/across_api/across/resolve.py
+++ b/python/across_api/across/resolve.py
@@ -8,6 +8,7 @@ from typing import Optional, Tuple
 import httpx
 from astropy.coordinates.name_resolve import NameResolveError  # type: ignore
 from astropy.coordinates.sky_coordinate import SkyCoord  # type: ignore
+from asyncer import asyncify
 
 from ..base.common import ACROSSAPIBase
 from .schema import ResolveGetSchema, ResolveSchema
@@ -116,7 +117,7 @@ class Resolve(ACROSSAPIBase):
 
         # Check using the CDS resolver
         try:
-            skycoord = SkyCoord.from_name(self.name)
+            skycoord = await asyncify(SkyCoord.from_name)(self.name)
             self.ra, self.dec = skycoord.ra.deg, skycoord.dec.deg
             self.resolver = "CDS"
             return True

--- a/python/across_api/base/tle.py
+++ b/python/across_api/base/tle.py
@@ -371,7 +371,7 @@ class TLEBase(ACROSSAPIBase):
         # of this format (for the NuSTAR mission), see here:
         # https://nustarsoc.caltech.edu/NuSTAR_Public/NuSTAROperationSite/NuSTAR.tle
         if self.tle_concat is not None:
-            if self.read_tle_concat() is True:
+            if await self.read_tle_concat() is True:
                 # Write the TLE to the database for next time
                 if self.tle is not None:
                     await self.tle.write()
@@ -383,7 +383,7 @@ class TLEBase(ACROSSAPIBase):
         # `tle_bad` days of the current epoch.
         if self.tle_url is not None:
             if self.epoch > Time.now().utc - self.tle_bad:
-                if self.read_tle_web() is True:
+                if await self.read_tle_web() is True:
                     # Write the TLE to the database for next time
                     if self.tle is not None:
                         await self.tle.write()

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -1,6 +1,7 @@
 --extra-index-url https://nasa-gcn.github.io/healpy-prerelease-pypi-index/simple/
 aioboto3
 architect-functions
+asyncer
 astropy
 astropy_healpix
 cachetools

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -11,7 +11,9 @@ aioboto3==12.3.0
     #   -r requirements.in
     #   dynamodb-autoincrement
 aiobotocore[boto3]==2.11.2
-    # via aioboto3
+    # via
+    #   aioboto3
+    #   aiobotocore
 aiohttp==3.9.3
     # via aiobotocore
 aioitertools==0.11.0
@@ -22,6 +24,7 @@ annotated-types==0.6.0
     # via pydantic
 anyio==3.7.1
     # via
+    #   asyncer
     #   httpx
     #   starlette
 architect-functions==1.0.0
@@ -35,6 +38,8 @@ astropy-healpix==1.0.2
     # via -r requirements.in
 astropy-iers-data==0.2024.2.5.0.30.52
     # via astropy
+asyncer==0.0.5
+    # via -r requirements.in
 attrs==23.2.0
     # via
     #   aiohttp


### PR DESCRIPTION
# Description
This PR covers 2 main changes.

1. There are some missing awaits in the `tle.py` code, this adds them back in. This code would never get run in the current configuration, but is a bug, which this fixes.
2. Makes 2 examples of blocking IO run asynchronously.

For item 2, the two blocking IO cases are the reading in of a FITS HEALPix file, and the using `SkyCoord.from_name` for name resolution. As `astropy` does not have support for `async`, we use the lightweight [Asyncer](https://asyncer.tiangolo.com) library to allow these to run asynchronously. 

Using Asyncer's `syncify` function, you can place blocking IO into its own worker thread, so it will not block the event loop. To the programmer this just turns a non-async function into an async coroutine that can be awaited.