### PR TITLE
Update accessibility link in footer

### DIFF
--- a/app/routes/_gcn/Footer.tsx
+++ b/app/routes/_gcn/Footer.tsx
@@ -116,7 +116,7 @@ export function Footer() {
         <IdentifierLinkItem>
           <IdentifierLink
             rel="external"
-            href="https://www.nasa.gov/content/section-508-accessibility-at-nasa"
+            href="https://www.nasa.gov/accessibility/"
           >
             Accessibility
           </IdentifierLink>


### PR DESCRIPTION
From NASA's OCIO:

> Section 508 Compliance and Digital Accessibility
>
> NASA is committed to creating a better digital experience for people with disabilities. OMB recently released M-24-08, Strengthening Digital Accessibility and the Management of Section 508 of the Rehabilitation Act. This memo reinforces the importance of cultivating a positive culture of digital accessibility and assigns immediate action to those managing NASA’s digital content.
>
> By March 20, 2024, website owners must verify that their websites link to NASA’s accessibility statement, located at https://www.nasa.gov/accessibility/. This link is required to appear in the footer of all of NASA's web sites, both external and internal.  As this is not a new requirement, most websites should already be linking to this statement.
>
> For guidance on how to meet this requirement and validate your link to NASA’s Accessibility Statement, please visit OMB Guidance on Accessibility Statements on Web Sites.
>
> In the months to come, we will be rolling out more agency-wide guidance, training, and tooling to empower everyone at NASA to contribute to our culture of digital accessibility. Visit our Section 508 intranet site for links to the latest resources.