### PR TITLE
Update nasawds to NPM release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
         "jest-transform-stub": "^2.0.0",
         "lint-staged": "^15.2.2",
         "lowlight": "^3.0.0",
-        "nasawds": "github:lpsinger/nasawds#uswds-3.8.0",
+        "nasawds": "^4.0.60-beta.0",
         "npm-run-all": "^4.1.5",
         "oidc-provider": "^8.4.3",
         "postcss-csso": "^6.0.1",
@@ -21077,8 +21077,9 @@
       "optional": true
     },
     "node_modules/nasawds": {
-      "version": "4.0.58",
-      "resolved": "git+ssh://git@github.com/lpsinger/nasawds.git#98c8b13c4a76c098f10792d3b760a4a63023e351",
+      "version": "4.0.60-beta.0",
+      "resolved": "https://registry.npmjs.org/nasawds/-/nasawds-4.0.60-beta.0.tgz",
+      "integrity": "sha512-FO0A4elnNF06JyqGBbziQWN9ArrYlwHZx+YQ1lYBvPFcyYiED8V9hpOwJONfMjExxkDrz0/PtMTZIiXsTU+CUQ==",
       "dev": true
     },
     "node_modules/natural-compare": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "jest-transform-stub": "^2.0.0",
     "lint-staged": "^15.2.2",
     "lowlight": "^3.0.0",
-    "nasawds": "github:lpsinger/nasawds#uswds-3.8.0",
+    "nasawds": "^4.0.60-beta.0",
     "npm-run-all": "^4.1.5",
     "oidc-provider": "^8.4.3",
     "postcss-csso": "^6.0.1",


### PR DESCRIPTION
https://github.com/bruffridge/nasawds/pull/17 has been fixed upstream.