### PR TITLE
Add small finishing touches to project board docs

### DIFF
--- a/app/routes/_gcn.docs.contributing.project/route.mdx
+++ b/app/routes/_gcn.docs.contributing.project/route.mdx
@@ -12,7 +12,11 @@ import ticketMetadata from './ticketMetadata.png'
 
 # GitHub Project Board
 
-We use GitHub Projects to organize our development process. This is the [GCN Project Board.](https://github.com/orgs/nasa-gcn/projects/6)
+<a href="https://github.com/orgs/nasa-gcn/projects/6" className="usa-button">
+  Go to GCN Project Board
+</a>
+
+We use GitHub Projects to organize our development process.
 We chose GitHub Projects becase we already extensively use GitHub Issues and Milestones.
 [GitHub's Projects Documentation](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects)
 
@@ -64,11 +68,11 @@ We have a total of six possible ticket states.
     <tr>
       <td>Done</td>
       <td>
-        These are tickets that have merged PRs or completed tasks. Use (GitHub
+        These are tickets that have merged PRs or completed tasks. Use [GitHub
         trigger
-        words)[https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests]
-        ("closes #123") to ensure tickets are linked to PRs and this will
-        automatically happen on merge.
+        keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)
+        (for example, `closes #123`) to ensure tickets are linked to PRs and
+        this will automatically happen on merge.
       </td>
     </tr>
   </tbody>
@@ -119,7 +123,7 @@ We create Issues for all work. All Issues should have a detailed title, descript
 We point tickets as a group during planning meetings.
 We use the description and acceptance criteria written in the GitHub Issue to ensure group understanding of the work.
 Once we have agreed that we understand the scope and request, we vote on the level of complexity for that body of work.
-We use the unique numbers in the Fibonacci sequence to represent complexity. We only go up to 21 points, making our options 1, 2, 3, 5, 8, 13, and 21. We also have the additional options of `coffee` or `question mark`.
+We use the unique numbers in the [Fibonacci sequence](https://www.scrum.org/resources/blog/practical-fibonacci-beginners-guide-relative-sizing) to represent complexity. We only go up to 21 points, making our options 1, 2, 3, 5, 8, 13, and 21. We also have the additional options of `coffee` or `question mark`.
 We average the votes if there is not wide variation in pointing values, so a ticket may be pointed at values not found in our pointing options.
 If there is a difference of more than a couple of points, we discuss why we voted higher/lower. Someone might have information that the others don't have.
 


### PR DESCRIPTION
- Convert the link to our project board to a button. There wasn't a natural way to incorporate it into the text other than by writing, "This is the project board," which is a bit tautological.
- Fix Markdown link syntax.
- Add a link for Fibonacci pointing.