### PR TITLE
Adjust button text for tense and capitalization

### DIFF
--- a/app/routes/_gcn.circulars._archive._index/SortSelectorButton.tsx
+++ b/app/routes/_gcn.circulars._archive._index/SortSelectorButton.tsx
@@ -35,7 +35,7 @@ function SortButton({
   return (
     <ButtonGroup type="segmented" {...props}>
       <Button type="button" className={`${slimClasses} padding-x-2`}>
-        Sorted By{' '}
+        Sort by{' '}
         {sortOptions[sort as keyof typeof sortOptions] ||
           sortOptions.circularID}
       </Button>


### PR DESCRIPTION
Change `Sorted By` to `Sort by` to agree with the tense and capitalization of `Filter by`.