### PR TITLE
Configure jsx-curly-brace-presence rule

### DIFF
--- a/app/routes/circulars._archive._index/SortSelectorButton.tsx
+++ b/app/routes/circulars._archive._index/SortSelectorButton.tsx
@@ -40,7 +40,7 @@ function SortButton({
           sortOptions.circularID}
       </Button>
       <Button type="button" className={`${slimClasses} padding-x-2`}>
-        {<Icon.FilterList role="presentation" />}
+        <Icon.FilterList role="presentation" />
         {expanded ? (
           <Icon.ExpandLess role="presentation" />
         ) : (

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -164,8 +164,8 @@ export default function () {
     <>
       {result?.intent === 'correction' && (
         <Alert
-          type={'success'}
-          headingLevel={'h1'}
+          type="success"
+          headingLevel="h1"
           slim
           heading="Request Submitted"
         >

--- a/app/routes/news.email.tsx
+++ b/app/routes/news.email.tsx
@@ -92,7 +92,7 @@ export default function () {
               name="subject"
               id="subject"
               type="text"
-              defaultValue={'GCN Announcement: [NEW FEATURE]'}
+              defaultValue="GCN Announcement: [NEW FEATURE]"
               required
               onChange={({ target: { value } }) => {
                 setSubjectValid(Boolean(value))
@@ -148,7 +148,7 @@ export default function () {
             )}
           </div>
           <ButtonGroup>
-            <Link to={`/news`} className="usa-button usa-button--outline">
+            <Link to="/news" className="usa-button usa-button--outline">
               Back
             </Link>
             <Button disabled={!valid} type="submit" value="save">

--- a/package.json
+++ b/package.json
@@ -180,7 +180,15 @@
       ],
       "object-shorthand": "error",
       "prefer-const": "error",
-      "react/jsx-boolean-value": "error"
+      "react/jsx-boolean-value": "error",
+      "react/jsx-curly-brace-presence": [
+        "error",
+        {
+          "props": "never",
+          "children": "never",
+          "propElementValues": "always"
+        }
+      ]
     },
     "overrides": [
       {


### PR DESCRIPTION
Automatically transform `<Foo bar={'bat'}>` to `<Foo bar="bat">`.