### PR TITLE
Rename backlog to Open

### DIFF
--- a/app/routes/docs.contributing.project/route.mdx
+++ b/app/routes/docs.contributing.project/route.mdx
@@ -37,7 +37,7 @@ We have a total of six possible ticket states.
       </td>
     </tr>
     <tr>
-      <td>Backlog</td>
+      <td>Open</td>
       <td>
         These are tickets that are fully refined and pointed and are ready to
         go. They may be planned for a particular sprint or have no sprint
@@ -199,7 +199,7 @@ If there is a difference of more than a couple of points, we discuss why we vote
   </tbody>
 </Table>
 
-Tickets with clear descriptions and acceptance criteria are pointed before being placed in the backlog.
+Tickets with clear descriptions and acceptance criteria are pointed before being placed in the Open column.
 
 ## Iterations/sprints
 


### PR DESCRIPTION
We renamed it in the project board, so update the docs.