### PR TITLE
Unify error boundaries and root component using layout export

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -201,7 +201,7 @@ function Progress() {
   return <>{showProgress && <TopBarProgress />}</>
 }
 
-function Document({ children }: { children?: ReactNode }) {
+export function Layout({ children }: { children?: ReactNode }) {
   const noIndex = useHostname() !== 'gcn.nasa.gov'
 
   return (
@@ -245,75 +245,69 @@ function Document({ children }: { children?: ReactNode }) {
 
 function ErrorUnexpected({ children }: { children?: ReactNode }) {
   return (
-    <Document>
-      <GridContainer className="usa-section">
-        <h1>Unexpected error {children}</h1>
-        <p className="usa-intro">An unexpected error occurred.</p>
-        <FormGroup>
-          <ButtonGroup>
-            <Link to="/" className="usa-button">
-              Go home
-            </Link>
-          </ButtonGroup>
-        </FormGroup>
-      </GridContainer>
-    </Document>
+    <GridContainer className="usa-section">
+      <h1>Unexpected error {children}</h1>
+      <p className="usa-intro">An unexpected error occurred.</p>
+      <FormGroup>
+        <ButtonGroup>
+          <Link to="/" className="usa-button">
+            Go home
+          </Link>
+        </ButtonGroup>
+      </FormGroup>
+    </GridContainer>
   )
 }
 
 function ErrorUnauthorized() {
   const url = useUrl()
   return (
-    <Document>
-      <GridContainer className="usa-section">
-        <h1>Unauthorized</h1>
-        <p className="usa-intro">
-          We're sorry, you must log in to access the page you're looking for.
-        </p>
-        <p className="usa-paragraph">Log in to access that page, or go home.</p>
-        <FormGroup>
-          <ButtonGroup>
-            <Link
-              to={`/login?redirect=${encodeURIComponent(url)}`}
-              className="usa-button"
-            >
-              Log in and take me there
-            </Link>
-            <Link to="/" className="usa-button usa-button--outline">
-              Go home
-            </Link>
-          </ButtonGroup>
-        </FormGroup>
-      </GridContainer>
-    </Document>
+    <GridContainer className="usa-section">
+      <h1>Unauthorized</h1>
+      <p className="usa-intro">
+        We're sorry, you must log in to access the page you're looking for.
+      </p>
+      <p className="usa-paragraph">Log in to access that page, or go home.</p>
+      <FormGroup>
+        <ButtonGroup>
+          <Link
+            to={`/login?redirect=${encodeURIComponent(url)}`}
+            className="usa-button"
+          >
+            Log in and take me there
+          </Link>
+          <Link to="/" className="usa-button usa-button--outline">
+            Go home
+          </Link>
+        </ButtonGroup>
+      </FormGroup>
+    </GridContainer>
   )
 }
 
 function ErrorNotFound() {
   return (
-    <Document>
-      <GridContainer className="usa-section">
-        <h1>Page not found</h1>
-        <p className="usa-intro">
-          We're sorry, we can't find the page you're looking for. It might have
-          been removed, changed its name, or is otherwise unavailable.
-        </p>
-        <p className="usa-paragraph">
-          Visit our homepage for helpful tools and resources, or contact us and
-          we'll point you in the right direction.
-        </p>
-        <FormGroup>
-          <ButtonGroup>
-            <Link to="/" className="usa-button">
-              Visit homepage
-            </Link>
-            <Link to="/contact" className="usa-button usa-button--outline">
-              Contact us
-            </Link>
-          </ButtonGroup>
-        </FormGroup>
-      </GridContainer>
-    </Document>
+    <GridContainer className="usa-section">
+      <h1>Page not found</h1>
+      <p className="usa-intro">
+        We're sorry, we can't find the page you're looking for. It might have
+        been removed, changed its name, or is otherwise unavailable.
+      </p>
+      <p className="usa-paragraph">
+        Visit our homepage for helpful tools and resources, or contact us and
+        we'll point you in the right direction.
+      </p>
+      <FormGroup>
+        <ButtonGroup>
+          <Link to="/" className="usa-button">
+            Visit homepage
+          </Link>
+          <Link to="/contact" className="usa-button usa-button--outline">
+            Contact us
+          </Link>
+        </ButtonGroup>
+      </FormGroup>
+    </GridContainer>
   )
 }
 
@@ -335,9 +329,5 @@ export function ErrorBoundary() {
 }
 
 export default function () {
-  return (
-    <Document>
-      <Outlet />
-    </Document>
-  )
+  return <Outlet />
 }


### PR DESCRIPTION
Remix recently introduced a new `layout` export that is inherited by both `ErrorBoundary` components and default components. Use this in our root layout.

See https://remix.run/docs/en/main/file-conventions/root#layout-export