### PR TITLE
Fix ugly line break in ADS button on mobile

### DIFF
--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -104,8 +104,9 @@ export default function () {
             <Link
               to={`https://ui.adsabs.harvard.edu/abs/${bibcode}`}
               className="usa-button usa-button--outline"
+              title="Retrieve bibliographic record from the SAO/NASA Astrophysics Data Service (ADS)."
             >
-              Cite (ADS)
+              Cite
             </Link>
           ) : (
             <Button
@@ -114,7 +115,7 @@ export default function () {
               outline
               title="The ADS entry for this Circular is not yet available. ADS entries are updated every week on Monday at 08:00 UTC. Please check back later."
             >
-              Cite (ADS)
+              Cite
             </Button>
           )}
         </ButtonGroup>


### PR DESCRIPTION
Remove "(ADS)" from the button text because it could be confused with the word "ads."

# Before

![Screenshot 2024-03-21 at 11 06 35](https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/146b3976-ca9b-4141-b96a-06a90126518c)

# After

![Screenshot 2024-03-21 at 11 09 47](https://github.com/nasa-gcn/gcn.nasa.gov/assets/728407/e01b6d7c-d3b9-43f4-9a98-3b02a1d8fcd8)
