### PR TITLE
Use https for arXiv query

### DIFF
--- a/app/routes/circulars.$circularId.($version)/AstroData.components.tsx
+++ b/app/routes/circulars.$circularId.($version)/AstroData.components.tsx
@@ -41,7 +41,7 @@ export function Arxiv({ children, value }: JSX.IntrinsicElements['data']) {
       to={`https://arxiv.org/abs/${value}`}
       fetch={async () => {
         const response = await fetch(
-          `http://export.arxiv.org/api/query?id_list=${value}`
+          `https://export.arxiv.org/api/query?id_list=${value}`
         )
         const text = await response.text()
         const entry = new DOMParser()


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

### Description
I accidentally used http instead of https for this request. As a result, browsers refuse to load it due to access control checks.