### PR TITLE
Responsive hamburger and navbar menus

### DIFF
--- a/app/root/header/Header.tsx
+++ b/app/root/header/Header.tsx
@@ -13,6 +13,7 @@ import {
   Title,
   Header as USWDSHeader,
 } from '@trussworks/react-uswds'
+import classNames from 'classnames'
 import { useState } from 'react'
 
 import { Meatball } from '~/components/meatball/Meatball'
@@ -86,9 +87,10 @@ export function Header() {
 
   return (
     <>
-      {expanded && (
-        <div className="usa-overlay is-visible" onClick={hideMobileNav} />
-      )}
+      <div
+        className={classNames('usa-overlay', { 'is-visible': expanded })}
+        onClick={hideMobileNav}
+      />
       <USWDSHeader basic className={`usa-header--dark ${styles.header}`}>
         <div className="usa-nav-container">
           <div className="usa-navbar">
@@ -102,6 +104,7 @@ export function Header() {
           </div>
           <PrimaryNav
             mobileExpanded={expanded}
+            onToggleMobileNav={toggleMobileNav}
             items={[
               <NavLink
                 className="usa-nav__link"
@@ -211,7 +214,6 @@ export function Header() {
                 </Link>
               ),
             ]}
-            onToggleMobileNav={toggleMobileNav}
           />
         </div>
       </USWDSHeader>

--- a/app/root/header/Header.tsx
+++ b/app/root/header/Header.tsx
@@ -14,7 +14,7 @@ import {
   Header as USWDSHeader,
 } from '@trussworks/react-uswds'
 import classNames from 'classnames'
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useOnClickOutside } from 'usehooks-ts'
 
 import { Meatball } from '~/components/meatball/Meatball'

--- a/app/root/header/Header.tsx
+++ b/app/root/header/Header.tsx
@@ -14,7 +14,7 @@ import {
   Header as USWDSHeader,
 } from '@trussworks/react-uswds'
 import classNames from 'classnames'
-import { useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useOnClickOutside } from 'usehooks-ts'
 
 import { Meatball } from '~/components/meatball/Meatball'
@@ -79,7 +79,7 @@ export function Header() {
     typeof window !== 'undefined' ? window.innerWidth < 1025 : false
   )
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (typeof window !== 'undefined') {
       const updateMobile = () => {
         setMobile(window.innerWidth < 1025)

--- a/app/root/header/Header.tsx
+++ b/app/root/header/Header.tsx
@@ -14,7 +14,7 @@ import {
   Header as USWDSHeader,
 } from '@trussworks/react-uswds'
 import classNames from 'classnames'
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { useOnClickOutside, useWindowSize } from 'usehooks-ts'
 
 import { Meatball } from '~/components/meatball/Meatball'

--- a/app/root/header/Header.tsx
+++ b/app/root/header/Header.tsx
@@ -234,7 +234,7 @@ export function Header() {
                   </>
                 ) : (
                   <Link
-                    className="usa-nav__link"
+                    className="usa-nav__link text-no-wrap"
                     to="/login"
                     key="/login"
                     onClick={hideMobileNav}

--- a/app/root/header/Header.tsx
+++ b/app/root/header/Header.tsx
@@ -14,7 +14,8 @@ import {
   Header as USWDSHeader,
 } from '@trussworks/react-uswds'
 import classNames from 'classnames'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
+import { useOnClickOutside } from 'usehooks-ts'
 
 import { Meatball } from '~/components/meatball/Meatball'
 import { useEmail, useUserIdp } from '~/root'
@@ -71,6 +72,16 @@ export function Header() {
   const idp = useUserIdp()
   const [expanded, setExpanded] = useState(false)
   const [userMenuIsOpen, setUserMenuIsOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const userMenuRef = useRef<HTMLDivElement>(null)
+
+  useOnClickOutside(menuRef, () => {
+    if (expanded) setExpanded(false)
+  })
+
+  useOnClickOutside(userMenuRef, () => {
+    if (userMenuIsOpen) setUserMenuIsOpen(false)
+  })
 
   function toggleMobileNav() {
     setExpanded((expanded) => !expanded)
@@ -87,10 +98,7 @@ export function Header() {
 
   return (
     <>
-      <div
-        className={classNames('usa-overlay', { 'is-visible': expanded })}
-        onClick={hideMobileNav}
-      />
+      <div className={classNames('usa-overlay', { 'is-visible': expanded })} />
       <USWDSHeader basic className={`usa-header--dark ${styles.header}`}>
         <div className="usa-nav-container">
           <div className="usa-navbar">
@@ -102,119 +110,123 @@ export function Header() {
             </Title>
             <NavMenuButton onClick={toggleMobileNav} label="Menu" />
           </div>
-          <PrimaryNav
-            mobileExpanded={expanded}
-            onToggleMobileNav={toggleMobileNav}
-            items={[
-              <NavLink
-                className="usa-nav__link"
-                to="/missions"
-                key="/missions"
-                onClick={hideMobileNav}
-              >
-                Missions
-              </NavLink>,
-              <NavLink
-                className="usa-nav__link"
-                to="/notices"
-                key="/notices"
-                onClick={hideMobileNav}
-              >
-                Notices
-              </NavLink>,
-              <NavLink
-                className="usa-nav__link"
-                to="/circulars"
-                key="/circulars"
-                onClick={hideMobileNav}
-              >
-                Circulars
-              </NavLink>,
-              <NavLink
-                className="usa-nav__link"
-                to="/docs"
-                key="/docs"
-                onClick={hideMobileNav}
-              >
-                Documentation
-              </NavLink>,
-              email ? (
-                <>
-                  <NavDropDownButton
-                    to="/user"
-                    type="button"
-                    key="user"
-                    label={email}
-                    isOpen={userMenuIsOpen}
-                    onToggle={() => {
-                      setUserMenuIsOpen(!userMenuIsOpen)
-                    }}
-                    menuId="user"
-                  />
-                  <Menu
-                    id="user"
-                    isOpen={userMenuIsOpen}
-                    items={[
-                      <NavLink
-                        end
-                        key="user"
-                        to="/user"
-                        onClick={onClickUserMenuItem}
-                      >
-                        Profile
-                      </NavLink>,
-                      <NavLink
-                        key="endorsements"
-                        to="/user/endorsements"
-                        onClick={onClickUserMenuItem}
-                      >
-                        Peer Endorsements
-                      </NavLink>,
-                      !idp && (
-                        <NavLink
-                          key="password"
-                          to="/user/password"
-                          onClick={onClickUserMenuItem}
-                        >
-                          Reset Password
-                        </NavLink>
-                      ),
-                      <NavLink
-                        key="credentials"
-                        to="/user/credentials"
-                        onClick={onClickUserMenuItem}
-                      >
-                        Client Credentials
-                      </NavLink>,
-                      <NavLink
-                        key="email"
-                        to="/user/email"
-                        onClick={onClickUserMenuItem}
-                      >
-                        Email Notifications
-                      </NavLink>,
-                      <Link
-                        key="logout"
-                        to="/logout"
-                        onClick={onClickUserMenuItem}
-                      >
-                        Sign Out
-                      </Link>,
-                    ]}
-                  />
-                </>
-              ) : (
-                <Link
+          <div ref={menuRef}>
+            <PrimaryNav
+              mobileExpanded={expanded}
+              onToggleMobileNav={toggleMobileNav}
+              items={[
+                <NavLink
                   className="usa-nav__link"
-                  to="/login"
-                  key="/login"
+                  to="/missions"
+                  key="/missions"
                   onClick={hideMobileNav}
                 >
-                  Sign in / Sign up
-                </Link>
-              ),
-            ]}
-          />
+                  Missions
+                </NavLink>,
+                <NavLink
+                  className="usa-nav__link"
+                  to="/notices"
+                  key="/notices"
+                  onClick={hideMobileNav}
+                >
+                  Notices
+                </NavLink>,
+                <NavLink
+                  className="usa-nav__link"
+                  to="/circulars"
+                  key="/circulars"
+                  onClick={hideMobileNav}
+                >
+                  Circulars
+                </NavLink>,
+                <NavLink
+                  className="usa-nav__link"
+                  to="/docs"
+                  key="/docs"
+                  onClick={hideMobileNav}
+                >
+                  Documentation
+                </NavLink>,
+                email ? (
+                  <>
+                    <NavDropDownButton
+                      to="/user"
+                      type="button"
+                      key="user"
+                      label={email}
+                      isOpen={userMenuIsOpen}
+                      onToggle={() => {
+                        setUserMenuIsOpen(!userMenuIsOpen)
+                      }}
+                      menuId="user"
+                    />
+                    <div ref={userMenuRef}>
+                      <Menu
+                        id="user"
+                        isOpen={userMenuIsOpen}
+                        items={[
+                          <NavLink
+                            end
+                            key="user"
+                            to="/user"
+                            onClick={onClickUserMenuItem}
+                          >
+                            Profile
+                          </NavLink>,
+                          <NavLink
+                            key="endorsements"
+                            to="/user/endorsements"
+                            onClick={onClickUserMenuItem}
+                          >
+                            Peer Endorsements
+                          </NavLink>,
+                          !idp && (
+                            <NavLink
+                              key="password"
+                              to="/user/password"
+                              onClick={onClickUserMenuItem}
+                            >
+                              Reset Password
+                            </NavLink>
+                          ),
+                          <NavLink
+                            key="credentials"
+                            to="/user/credentials"
+                            onClick={onClickUserMenuItem}
+                          >
+                            Client Credentials
+                          </NavLink>,
+                          <NavLink
+                            key="email"
+                            to="/user/email"
+                            onClick={onClickUserMenuItem}
+                          >
+                            Email Notifications
+                          </NavLink>,
+                          <Link
+                            key="logout"
+                            to="/logout"
+                            onClick={onClickUserMenuItem}
+                          >
+                            Sign Out
+                          </Link>,
+                        ]}
+                      />
+                    </div>
+                  </>
+                ) : (
+                  <Link
+                    className="usa-nav__link"
+                    to="/login"
+                    key="/login"
+                    onClick={hideMobileNav}
+                  >
+                    Sign in / Sign up
+                  </Link>
+                ),
+              ]}
+            />
+          </div>
         </div>
       </USWDSHeader>
     </>

--- a/app/root/header/Header.tsx
+++ b/app/root/header/Header.tsx
@@ -93,8 +93,14 @@ export function Header() {
     if (expanded) setExpanded(false)
   })
 
-  useOnClickOutside(userMenuRef, () => {
-    if (userMenuIsOpen) setUserMenuIsOpen(false)
+  useOnClickOutside(userMenuRef, (event) => {
+    if (
+      !document
+        .querySelector('#userMenuDropdown')
+        ?.contains(event.target as Node) &&
+      userMenuIsOpen
+    )
+      setUserMenuIsOpen(false)
   })
 
   function toggleMobileNav() {
@@ -171,6 +177,7 @@ export function Header() {
                       to="/user"
                       type="button"
                       key="user"
+                      id="userMenuDropdown"
                       label={email}
                       isOpen={userMenuIsOpen}
                       onToggle={() => {

--- a/app/root/header/Header.tsx
+++ b/app/root/header/Header.tsx
@@ -76,12 +76,6 @@ export function Header() {
   const menuRef = useRef<HTMLDivElement>(null)
   const userMenuRef = useRef<HTMLDivElement>(null)
 
-  const [mobile, setMobile] = useState(isMobileWidth ?? false)
-
-  useEffect(() => {
-    setMobile(isMobileWidth)
-  }, [isMobileWidth])
-
   useOnClickOutside(menuRef, () => {
     if (expanded) setExpanded(false)
   })
@@ -113,7 +107,7 @@ export function Header() {
     <>
       <div
         className={classNames('usa-overlay', {
-          'is-visible': expanded && mobile,
+          'is-visible': expanded && isMobileWidth,
         })}
       />
       <USWDSHeader basic className={`usa-header--dark ${styles.header}`}>

--- a/app/root/header/Header.tsx
+++ b/app/root/header/Header.tsx
@@ -15,7 +15,7 @@ import {
 } from '@trussworks/react-uswds'
 import classNames from 'classnames'
 import { useEffect, useRef, useState } from 'react'
-import { useOnClickOutside } from 'usehooks-ts'
+import { useOnClickOutside, useWindowSize } from 'usehooks-ts'
 
 import { Meatball } from '~/components/meatball/Meatball'
 import { useEmail, useUserIdp } from '~/root'
@@ -68,6 +68,7 @@ function NavDropDownButton({
 }
 
 export function Header() {
+  const isMobileWidth = useWindowSize().width < 1024
   const email = useEmail()
   const idp = useUserIdp()
   const [expanded, setExpanded] = useState(false)
@@ -75,19 +76,11 @@ export function Header() {
   const menuRef = useRef<HTMLDivElement>(null)
   const userMenuRef = useRef<HTMLDivElement>(null)
 
-  const [mobile, setMobile] = useState(
-    typeof window !== 'undefined' ? window.innerWidth < 1025 : false
-  )
+  const [mobile, setMobile] = useState(isMobileWidth ?? false)
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const updateMobile = () => {
-        setMobile(window.innerWidth < 1025)
-      }
-      window.addEventListener('resize', updateMobile)
-      return () => window.removeEventListener('resize', updateMobile)
-    }
-  }, [])
+    setMobile(isMobileWidth)
+  }, [isMobileWidth])
 
   useOnClickOutside(menuRef, () => {
     if (expanded) setExpanded(false)

--- a/app/root/header/Header.tsx
+++ b/app/root/header/Header.tsx
@@ -14,7 +14,7 @@ import {
   Header as USWDSHeader,
 } from '@trussworks/react-uswds'
 import classNames from 'classnames'
-import { useRef, useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 import { useOnClickOutside } from 'usehooks-ts'
 
 import { Meatball } from '~/components/meatball/Meatball'
@@ -75,6 +75,20 @@ export function Header() {
   const menuRef = useRef<HTMLDivElement>(null)
   const userMenuRef = useRef<HTMLDivElement>(null)
 
+  const [mobile, setMobile] = useState(
+    typeof window !== 'undefined' ? window.innerWidth < 1025 : false
+  )
+
+  useLayoutEffect(() => {
+    if (typeof window !== 'undefined') {
+      const updateMobile = () => {
+        setMobile(window.innerWidth < 1025)
+      }
+      window.addEventListener('resize', updateMobile)
+      return () => window.removeEventListener('resize', updateMobile)
+    }
+  }, [])
+
   useOnClickOutside(menuRef, () => {
     if (expanded) setExpanded(false)
   })
@@ -98,7 +112,11 @@ export function Header() {
 
   return (
     <>
-      <div className={classNames('usa-overlay', { 'is-visible': expanded })} />
+      <div
+        className={classNames('usa-overlay', {
+          'is-visible': expanded && mobile,
+        })}
+      />
       <USWDSHeader basic className={`usa-header--dark ${styles.header}`}>
         <div className="usa-nav-container">
           <div className="usa-navbar">


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
This PR fixes the issue with the rendering of the hamburger menu when switching between mobile and desktop widths for the window by adding an event listener to check the width of the window.

As of 04981c32, the behaviour is such that opening the hamburger menu and resizing the window to be wider than 1025 pixels will cause the hamburger menu and overlay to disappear. Depending on feedback, it may be preferable to make it so going from <1025 pixel window to a >1025 pixel window sets the states for the hamburger menu to false by default, which can be accomplished by adding `if (window.innerWidth >= 1025) hideMobileNav()` to `updateMobile` or something similar.

The hamburger menu and user dropdown have also been altered to use useOnClickOutside to have them be hidden when a user clicks elsewhere on the page.

# Related Issue(s)
Resolves #2037

# Testing
Tested by setting the window width to below 1025 pixels (eg, mobile), opening the hamburger menu, and then resizing the window to be wider than 1025 pixels. The overlay element and hamburger menu should disappear. The click away aspect can be tested by expanding the user menu and clicking elsewhere on the page, or expanding the hamburger menu and clicking outside of the hamburger menu.
