### PR TITLE
Change command `arc` to `npx arc`

### DIFF
--- a/app/routes/docs.contributing.configuration/route.mdx
+++ b/app/routes/docs.contributing.configuration/route.mdx
@@ -34,8 +34,8 @@ For both [local development](.) and [deployment](deployment), the configuration 
 - [**`arc env` command:**](https://arc.codes/docs/en/reference/cli/env) Adjust settings for production by running the following commands.
 
   ```text
-  arc env -e production --add FOO value_of_foo_for_deployment
-  arc env -e production --add BAR value_of_bar_for_deployment
+  npx arc env -e production --add FOO value_of_foo_for_deployment
+  npx arc env -e production --add BAR value_of_bar_for_deployment
   ```
 
 ## Supported environment variables


### PR DESCRIPTION
`arc` by itself will only work if you have architect installed globally. `npx arc` will work regardless.