### PR TITLE
Clean up TNS alternate event names

### DIFF
--- a/app/routes/api.tooltip.tns.$.ts
+++ b/app/routes/api.tooltip.tns.$.ts
@@ -51,7 +51,13 @@ export async function loader({ params: { '*': value } }: LoaderFunctionArgs) {
   if (!(ra && dec && names)) throw new Response(null, { status: 404 })
 
   return json(
-    { ra: ra.split(splitter), dec: dec.split(splitter), names },
+    {
+      ra: ra.split(splitter),
+      dec: dec.split(splitter),
+      // Some TNS events have values of `internal_names` that have an orphaned
+      // leading or trailing comma, such as `', PS24brk'`. Strip them out.
+      names: names.split(/\s*,\s*/).filter(Boolean),
+    },
     { headers: publicStaticShortTermCacheControlHeaders }
   )
 }

--- a/app/routes/circulars.$circularId.($version)/AstroData.components.tsx
+++ b/app/routes/circulars.$circularId.($version)/AstroData.components.tsx
@@ -95,7 +95,7 @@ export function Tns({ children, value }: JSX.IntrinsicElements['data']) {
       fetch={() => fetchTooltipData<typeof tnsTooltipLoader>('tns', value)}
       label={({ ra, dec, names }) => (
         <>
-          <div>{names}</div>
+          <div>{names.join(', ')}</div>
           <div className={styles.ra}>
             <span className={styles.h}>{ra[0]}</span>
             <span className={styles.sep}>


### PR DESCRIPTION
Some TNS events have values of `internal_names` that have an orphaned
leading or trailing comma, such as `', PS24brk'`. Strip them out.
