### PR TITLE
Navigate between circulars within specific circulars pages

### DIFF
--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -148,7 +148,7 @@ export default function () {
       <h1 className="margin-bottom-0">GCN Circular {circularId}</h1>
       <FrontMatter {...frontMatter} />
       <Body className="margin-y-2">{body}</Body>
-      <ButtonGroup className="display-flex flex-row flex-align-center flex-justify-center">
+      <ButtonGroup className="display-flex flex-justify-center">
         <Link to={`${previousCircularLinkString}`} className="usa-button">
           <div className="position-relative">
             <Icon.ArrowBack

--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -73,6 +73,12 @@ export default function () {
   const linkString = `/circulars/${circularId}${
     !latest && version ? `/${version}` : ''
   }`
+  const previousCircularLinkString = `/circulars/${circularId - 1}${
+    version ? `/${version}` : ''
+  }`
+  const nextCircularLinkString = `/circulars/${circularId + 1}${
+    version ? `/${version}` : ''
+  }`
   return (
     <>
       <ButtonGroup>
@@ -142,6 +148,26 @@ export default function () {
       <h1 className="margin-bottom-0">GCN Circular {circularId}</h1>
       <FrontMatter {...frontMatter} />
       <Body className="margin-y-2">{body}</Body>
+      <ButtonGroup className="display-flex flex-row flex-align-center flex-justify-center">
+        <Link to={`${previousCircularLinkString}`} className="usa-button">
+          <div className="position-relative">
+            <Icon.ArrowBack
+              role="presentation"
+              className="position-absolute top-0 left-0"
+            />
+          </div>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Previous Circular
+        </Link>
+        <Link to={`${nextCircularLinkString}`} className="usa-button">
+          <div className="position-relative">
+            <Icon.ArrowForward
+              role="presentation"
+              className="position-absolute top-0 left-0"
+            />
+          </div>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Next Circular
+        </Link>
+      </ButtonGroup>
     </>
   )
 }

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -224,10 +224,9 @@ export async function get(
 ): Promise<Circular> {
   const circularVersions = await getDynamoDBVersionAutoIncrement(circularId)
   const result = await circularVersions.get(version)
-  if (!result)
-    throw new Response(null, {
-      status: 404,
-    })
+  if (!result) {
+    throw redirect('/circulars')
+  }
   return result as Circular
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
Adds navigation buttons inside specific circular pages to navigate to previous and next circulars. If attempting to navigate to a circular that does not exist, users will be returned to the main circulars page.

# Related Issue(s)
Resolves #2226 

# Testing
Testing for basic navigation:
1. Navigate to a specific circular
2. Scroll to bottom of page
3. Click 'Next Circular' or 'Previous Circular' buttons
4. Page for next or previous circular should load

Testing for navigation to a nonexistent circular:
1. Navigate to the most recent circular
2. Click 'Next Circular'
3. Main Circulars page should load
4. Navigate to oldest circular
5. Click 'Previous Circular'
6. Main Circulars page should load
