### PR TITLE
Permit requests that come via the CDN, reject all others

### DIFF
--- a/app/routes/docs.contributing.configuration/route.mdx
+++ b/app/routes/docs.contributing.configuration/route.mdx
@@ -81,6 +81,19 @@ account for GCN production by registering the email address
       <Default>Hard-coded constant</Default>
     </tr>
     <tr>
+      <Key>`CDN_SECRET`</Key>
+      <Description>
+        Secret key that must be present in the `X-CDN-Secret` request header of
+        all requests to prove that the request came via the content delivery
+        network rather than directly to the origin. Should be a long, random
+        string
+      </Description>
+      <Default>
+        Requests are permitted regardless of the value of the `X-CDN-Secret`
+        header
+      </Default>
+    </tr>
+    <tr>
       <Key>`COGNITO_USER_POOL_ID`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`</Key>
       <Description>
         OpenID Connect identity provider configuration for [AWS

--- a/server.ts
+++ b/server.ts
@@ -1,4 +1,4 @@
-import { createRequestHandler } from '@remix-run/architect'
+import { type RequestHandler, createRequestHandler } from '@remix-run/architect'
 import * as build from '@remix-run/dev/server-build'
 import { installGlobals } from '@remix-run/node'
 import sourceMapSupport from 'source-map-support'
@@ -6,7 +6,17 @@ import sourceMapSupport from 'source-map-support'
 sourceMapSupport.install()
 installGlobals()
 
-export const handler = createRequestHandler({
+const remixHandler = createRequestHandler({
   build,
   mode: process.env.NODE_ENV,
 })
+
+const { CDN_SECRET } = process.env
+
+export const handler: RequestHandler = (event, ...args) => {
+  if (CDN_SECRET && event.headers['x-cdn-secret'] !== CDN_SECRET)
+    // FIXME: this shouldn't need to be a promise.
+    // See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69466
+    return Promise.resolve({ statusCode: 502 })
+  return remixHandler(event, ...args)
+}


### PR DESCRIPTION
Allow only requests that come via our content delivery network (CDN), AWS CloudFront. For all other requests, return a 502 error. This prevents direct requests to our origin.

By intent or mistake, if an actor managed to make requests directly to our origin, it could cause unwanted cloud expenses due to unnecessary processing by our origin.

Our Lambdas now have an environment variable called `CDN_SECRET` which should be set to a long, random string. We will configure CloudFront to add the header `X-CDN-Secret` to all requests to our origin. If the environment variable is set and the header does not match, then we reject the request and return an HTTP 502 response.

The AWS CloudFormation documentation [suggests such custom headers as a method to identify requests that come from CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html#add-origin-custom-headers-use-cases). We chose this solution as a sensible balance of security and simplicity. Here are some other possible approaches:

- Instead of adding the check here in the Remix server entry point, we could put the check in a new Lambda that is configured as an [API Gateway authorizer](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html). This would have the advantage that the request would be blocked even before making it to Remix. However, it would have the disadvantage of adding latency due to the additional Lambda's startup time.

- We could have turned on AWS IAM authorization for our API Gateway and written a Lamdba@Edge function for CloudFormation to sign requests to our origin using the configured IAM role, [as described in this blog post](https://medium.com/@dario_26152/restrict-access-to-lambda-functionurl-to-cloudfront-using-aws-iam-988583834705). However this would also add some Lambda startup time, not to mention complexity.
