### PR TITLE
Use native fetch instead of Node.js polyfill

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -4,7 +4,7 @@ import { installGlobals } from '@remix-run/node'
 import sourceMapSupport from 'source-map-support'
 
 sourceMapSupport.install()
-installGlobals()
+installGlobals({ nativeFetch: true })
 
 export const handler = createRequestHandler({
   build,


### PR DESCRIPTION
As of Remix 2.9.0, Remix supports using the native fetch() added in Node.js 20 instead of a polyfill.