### PR TITLE
Open Details for Notices Quickstart in New Tab

### DIFF
--- a/app/components/nested-checkboxes/NestedCheckboxes.tsx
+++ b/app/components/nested-checkboxes/NestedCheckboxes.tsx
@@ -84,7 +84,7 @@ function NestedCheckboxNode({
               <Link
                 className="usa-link"
                 to={link}
-                target={isExternal ? '_blank' : undefined}
+                target="_blank"
                 rel={isExternal ? 'noreferrer' : undefined}
                 onClick={(e) => {
                   e.stopPropagation()


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
Clicking a details link in the list of Notice types in the streaming quickstart will now open them in a new tab rather than opening them in the same tab. Currently, clicking the details for a Notice type will cause the selection of notices to be reset when navigating back to the quickstart guide.

# Related Issue(s)
Resolves #2225 

# Testing
On step 3 of the notices quickstart guide, click a details link. It should open in a new tab.
