### PR TITLE
Updates schema docs to clarify unevaluatedProperties use

### DIFF
--- a/app/routes/docs.notices.schema.mdx
+++ b/app/routes/docs.notices.schema.mdx
@@ -53,6 +53,7 @@ Here is a basic schema file, `sample.schema.json`, and an example file, `sample.
             },
           ],
           properties: {
+            $schema: true,
             example_field_1: {
               type: 'string',
               description: 'A custom field that can hold text',
@@ -121,7 +122,7 @@ List of core schema to include fields from. [Browse the core schema](/docs/schem
 
 #### `properties`
 
-Optional mapping of custom, mission-specific fields. Field names should use [snake_case](https://en.wikipedia.org/wiki/Snake_case). Each entry should at least have a description and a type. See the [list of available data types](https://json-schema.org/understanding-json-schema/reference/type.html).
+Mapping of custom, mission-specific fields. The first property, `'$schema: true'`, must be included when using `'unevaluatedProperties': false`, otherwise the inclusion of the `$schema` property in your example files will cause validation to fail. Field names should use [snake_case](https://en.wikipedia.org/wiki/Snake_case). Each entry should at least have a description and a type. See the [list of available data types](https://json-schema.org/understanding-json-schema/reference/type.html).
 
 ## Extended Example
 

--- a/app/routes/docs.notices.schema.mdx
+++ b/app/routes/docs.notices.schema.mdx
@@ -53,7 +53,7 @@ Here is a basic schema file, `sample.schema.json`, and an example file, `sample.
             },
           ],
           properties: {
-            $schema: true,
+            $schema: { type: 'string', format: 'uri' },
             example_field_1: {
               type: 'string',
               description: 'A custom field that can hold text',
@@ -122,7 +122,7 @@ List of core schema to include fields from. [Browse the core schema](/docs/schem
 
 #### `properties`
 
-Mapping of custom, mission-specific fields. The first property, `'$schema: true'`, must be included when using `'unevaluatedProperties': false`, otherwise the inclusion of the `$schema` property in your example files will cause validation to fail. Field names should use [snake_case](https://en.wikipedia.org/wiki/Snake_case). Each entry should at least have a description and a type. See the [list of available data types](https://json-schema.org/understanding-json-schema/reference/type.html).
+Mapping of custom, mission-specific fields. The first property, `'$schema: { type: "string", format: "uri" }'`, must be included when using `'unevaluatedProperties': false`, otherwise the inclusion of the `$schema` property in your example files will cause validation to fail. Field names should use [snake_case](https://en.wikipedia.org/wiki/Snake_case). Each entry should at least have a description and a type. See the [list of available data types](https://json-schema.org/understanding-json-schema/reference/type.html).
 
 ## Extended Example
 
@@ -150,7 +150,7 @@ We recommend exploring our [schema browser](/docs/schema/stable/gcn/notices) and
             { $ref: '../../core/AdditionalInfo.schema.json' },
           ],
           properties: {
-            $schema: true,
+            $schema: { type: 'string', format: 'uri' },
             follow_up_event: {
               type: 'string',
               description:


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description

The listed example included `'unevaluatedProperties':false` but did not include the `'$schema': true` property. Any schema that copied this format would fail validation.  

This updates the docs to be more explicit about how they are tied together
