### PR TITLE
add text tag stripper

### DIFF
--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright © 2024 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { stripTags } from '~/lib/utils'
+
+describe('stripTags', () => {
+  const textBody = '<NUMPAGES>123</NUMPAGES>'
+  const htmlText = 'ab <div>cd</div> ef'
+  const partialTag = '<script something nefarious here'
+
+  test('handles unique tags', () => {
+    expect(stripTags(textBody)).toBe('123')
+  })
+  test('handles normal html tags', () => {
+    expect(stripTags(htmlText)).toBe('ab cd ef')
+  })
+  test('handles partial html tags', () => {
+    expect(stripTags(partialTag)).toBe('')
+  })
+})

--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright © 2024 United States Government as represented by the
+ * Copyright © 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -6,6 +6,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { useSearchParams } from '@remix-run/react'
+import { stripHtml } from 'string-strip-html'
+
+export function stripTags(text: string) {
+  return stripHtml(text).result
+}
 
 export function formatAndNoticeTypeToTopic(
   noticeFormat: string,

--- a/app/routes/api.tooltip.doi.$.ts
+++ b/app/routes/api.tooltip.doi.$.ts
@@ -11,6 +11,7 @@ import invariant from 'tiny-invariant'
 
 import { getEnvOrDieInProduction } from '~/lib/env.server'
 import { publicStaticShortTermCacheControlHeaders } from '~/lib/headers.server'
+import { stripTags } from '~/lib/utils'
 
 const adsTokenTooltip = getEnvOrDieInProduction('ADS_TOKEN_TOOLTIP')
 
@@ -53,7 +54,7 @@ export async function loader({ params: { '*': value } }: LoaderFunctionArgs) {
 
   // Some articles' records contain markup like `<NUMPAGES>14</NUMPAGES> pp.`
   // Strip out such tags.
-  pub = pub.replaceAll(/<[^>]+>/g, '')
+  pub = stripTags(pub)
 
   // Abbreviate some common publishing terms
   pub = pub.replaceAll(' Volume ', ' Vol. ')

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "remark-rehype": "^10.1.0",
         "source-map-support": "^0.5.21",
         "spin-delay": "^2.0.0",
-        "string-strip-html": "^13.4.8",
+        "string-strip-html": "8.5.0",
         "tar-stream": "^3.1.6",
         "tiny-invariant": "^1.3.3",
         "ts-dedent": "^2.2.0",
@@ -9561,15 +9561,8 @@
     "node_modules/@types/lodash": {
       "version": "4.14.199",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
-      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg=="
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
+      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==",
+      "dev": true
     },
     "node_modules/@types/lucene": {
       "version": "2.1.7",
@@ -11799,17 +11792,6 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/codsen-utils": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/codsen-utils/-/codsen-utils-1.6.4.tgz",
-      "integrity": "sha512-PDyvQ5f2PValmqZZIJATimcokDt4JjIev8cKbZgEOoZm+U1IJDYuLeTcxZPQdep99R/X0RIlQ6ReQgPOVnPbNw==",
-      "dependencies": {
-        "rfdc": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=14.18.0"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -16179,21 +16161,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/html-entities": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
-      "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/mdevils"
-        },
-        {
-          "type": "patreon",
-          "url": "https://patreon.com/mdevils"
-        }
-      ]
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -19342,11 +19309,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -23114,52 +23076,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/ranges-apply": {
-      "version": "7.0.16",
-      "resolved": "https://registry.npmjs.org/ranges-apply/-/ranges-apply-7.0.16.tgz",
-      "integrity": "sha512-4rGJHOyA7qatiMDg3vcETkc/TVBPU86/xZRTXff6o7a2neYLmj0EXUUAlhLVuiWAzTPHDPHOQxtk8EDrIF4ohg==",
-      "dependencies": {
-        "ranges-merge": "^9.0.15",
-        "tiny-invariant": "^1.3.3"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/ranges-merge": {
-      "version": "9.0.15",
-      "resolved": "https://registry.npmjs.org/ranges-merge/-/ranges-merge-9.0.15.tgz",
-      "integrity": "sha512-hvt4hx0FKIaVfjd1oKx0poL57ljxdL2KHC6bXBrAdsx2iCsH+x7nO/5J0k2veM/isnOcFZKp0ZKkiCjCtzy74Q==",
-      "dependencies": {
-        "ranges-push": "^7.0.15",
-        "ranges-sort": "^6.0.11"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/ranges-push": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/ranges-push/-/ranges-push-7.0.15.tgz",
-      "integrity": "sha512-gXpBYQ5Umf3uG6jkJnw5ddok2Xfo5p22rAJBLrqzNKa7qkj3q5AOCoxfRPXEHUVaJutfXc9K9eGXdIzdyQKPkw==",
-      "dependencies": {
-        "codsen-utils": "^1.6.4",
-        "ranges-sort": "^6.0.11",
-        "string-collapse-leading-whitespace": "^7.0.7",
-        "string-trim-spaces-only": "^5.0.10"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/ranges-sort": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/ranges-sort/-/ranges-sort-6.0.11.tgz",
-      "integrity": "sha512-fhNEG0vGi7bESitNNqNBAfYPdl2efB+1paFlI8BQDCNkruERKuuhG8LkQClDIVqUJLkrmKuOSPQ3xZHqVnVo3Q==",
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
     "node_modules/raw-body": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
@@ -24237,7 +24153,8 @@
     "node_modules/rfdc": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
-      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg=="
+      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
+      "dev": true
     },
     "node_modules/rimraf": {
       "version": "5.0.0",
@@ -25144,31 +25061,11 @@
         "node": ">=0.6.19"
       }
     },
-    "node_modules/string-collapse-leading-whitespace": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/string-collapse-leading-whitespace/-/string-collapse-leading-whitespace-7.0.7.tgz",
-      "integrity": "sha512-jF9eynJoE6ezTCdYI8Qb02/ij/DlU9ItG93Dty4SWfJeLFrotOr+wH9IRiWHTqO3mjCyqBWEiU3uSTIbxYbAEQ==",
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
     "node_modules/string-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
       "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
       "dev": true
-    },
-    "node_modules/string-left-right": {
-      "version": "6.0.17",
-      "resolved": "https://registry.npmjs.org/string-left-right/-/string-left-right-6.0.17.tgz",
-      "integrity": "sha512-nuyIV4D4ivnwT64E0TudmCRg52NfkumuEUilyoOrHb/Z2wEOF5I+9SI6P+veFKqWKZfGpAs6OqKe4nAjujARyw==",
-      "dependencies": {
-        "codsen-utils": "^1.6.4",
-        "rfdc": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -25184,28 +25081,11 @@
       }
     },
     "node_modules/string-strip-html": {
-      "version": "13.4.8",
-      "resolved": "https://registry.npmjs.org/string-strip-html/-/string-strip-html-13.4.8.tgz",
-      "integrity": "sha512-vlcRAtx5DN6zXGUx3EYGFg0/JOQWM65mqLgDaBHviQPP+ovUFzqZ30iQ+674JHWr9wNgnzFGxx9TGipPZMnZXg==",
-      "dependencies": {
-        "@types/lodash-es": "^4.17.12",
-        "codsen-utils": "^1.6.4",
-        "html-entities": "^2.5.2",
-        "lodash-es": "^4.17.21",
-        "ranges-apply": "^7.0.16",
-        "ranges-push": "^7.0.15",
-        "string-left-right": "^6.0.17"
-      },
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/string-strip-html/-/string-strip-html-8.5.0.tgz",
+      "integrity": "sha512-5ICsK1B1j0A3AF1d45m0sqQCcmi1Q+t1QpF+b794LO5FTHV+ITkGR5C+UCDJQZgs5LMuRruqr6j48PxQVIurJQ==",
       "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/string-trim-spaces-only": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/string-trim-spaces-only/-/string-trim-spaces-only-5.0.10.tgz",
-      "integrity": "sha512-MhmjE5jNqb1Ylo+BARPRlsdChGLrnPpAUWrT1VOxo9WhWwKVUU6CbZTfjwKaQPYTGS/wsX/4Zek88FM2rEb5iA==",
-      "engines": {
-        "node": ">=14.18.0"
+        "node": ">=14"
       }
     },
     "node_modules/string-width": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "remark-rehype": "^10.1.0",
         "source-map-support": "^0.5.21",
         "spin-delay": "^2.0.0",
+        "string-strip-html": "^13.4.8",
         "tar-stream": "^3.1.6",
         "tiny-invariant": "^1.3.3",
         "ts-dedent": "^2.2.0",
@@ -126,7 +127,7 @@
         "yarn": "^1.22.21"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20 <22"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -9560,8 +9561,15 @@
     "node_modules/@types/lodash": {
       "version": "4.14.199",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
-      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==",
-      "dev": true
+      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg=="
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/lucene": {
       "version": "2.1.7",
@@ -11791,6 +11799,17 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/codsen-utils": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/codsen-utils/-/codsen-utils-1.6.4.tgz",
+      "integrity": "sha512-PDyvQ5f2PValmqZZIJATimcokDt4JjIev8cKbZgEOoZm+U1IJDYuLeTcxZPQdep99R/X0RIlQ6ReQgPOVnPbNw==",
+      "dependencies": {
+        "rfdc": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -16160,6 +16179,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
+      "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ]
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -19308,6 +19342,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -23075,6 +23114,52 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ranges-apply": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/ranges-apply/-/ranges-apply-7.0.16.tgz",
+      "integrity": "sha512-4rGJHOyA7qatiMDg3vcETkc/TVBPU86/xZRTXff6o7a2neYLmj0EXUUAlhLVuiWAzTPHDPHOQxtk8EDrIF4ohg==",
+      "dependencies": {
+        "ranges-merge": "^9.0.15",
+        "tiny-invariant": "^1.3.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/ranges-merge": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/ranges-merge/-/ranges-merge-9.0.15.tgz",
+      "integrity": "sha512-hvt4hx0FKIaVfjd1oKx0poL57ljxdL2KHC6bXBrAdsx2iCsH+x7nO/5J0k2veM/isnOcFZKp0ZKkiCjCtzy74Q==",
+      "dependencies": {
+        "ranges-push": "^7.0.15",
+        "ranges-sort": "^6.0.11"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/ranges-push": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/ranges-push/-/ranges-push-7.0.15.tgz",
+      "integrity": "sha512-gXpBYQ5Umf3uG6jkJnw5ddok2Xfo5p22rAJBLrqzNKa7qkj3q5AOCoxfRPXEHUVaJutfXc9K9eGXdIzdyQKPkw==",
+      "dependencies": {
+        "codsen-utils": "^1.6.4",
+        "ranges-sort": "^6.0.11",
+        "string-collapse-leading-whitespace": "^7.0.7",
+        "string-trim-spaces-only": "^5.0.10"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/ranges-sort": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/ranges-sort/-/ranges-sort-6.0.11.tgz",
+      "integrity": "sha512-fhNEG0vGi7bESitNNqNBAfYPdl2efB+1paFlI8BQDCNkruERKuuhG8LkQClDIVqUJLkrmKuOSPQ3xZHqVnVo3Q==",
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/raw-body": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
@@ -24152,8 +24237,7 @@
     "node_modules/rfdc": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
-      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
-      "dev": true
+      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg=="
     },
     "node_modules/rimraf": {
       "version": "5.0.0",
@@ -25060,11 +25144,31 @@
         "node": ">=0.6.19"
       }
     },
+    "node_modules/string-collapse-leading-whitespace": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/string-collapse-leading-whitespace/-/string-collapse-leading-whitespace-7.0.7.tgz",
+      "integrity": "sha512-jF9eynJoE6ezTCdYI8Qb02/ij/DlU9ItG93Dty4SWfJeLFrotOr+wH9IRiWHTqO3mjCyqBWEiU3uSTIbxYbAEQ==",
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/string-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
       "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
       "dev": true
+    },
+    "node_modules/string-left-right": {
+      "version": "6.0.17",
+      "resolved": "https://registry.npmjs.org/string-left-right/-/string-left-right-6.0.17.tgz",
+      "integrity": "sha512-nuyIV4D4ivnwT64E0TudmCRg52NfkumuEUilyoOrHb/Z2wEOF5I+9SI6P+veFKqWKZfGpAs6OqKe4nAjujARyw==",
+      "dependencies": {
+        "codsen-utils": "^1.6.4",
+        "rfdc": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -25077,6 +25181,31 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/string-strip-html": {
+      "version": "13.4.8",
+      "resolved": "https://registry.npmjs.org/string-strip-html/-/string-strip-html-13.4.8.tgz",
+      "integrity": "sha512-vlcRAtx5DN6zXGUx3EYGFg0/JOQWM65mqLgDaBHviQPP+ovUFzqZ30iQ+674JHWr9wNgnzFGxx9TGipPZMnZXg==",
+      "dependencies": {
+        "@types/lodash-es": "^4.17.12",
+        "codsen-utils": "^1.6.4",
+        "html-entities": "^2.5.2",
+        "lodash-es": "^4.17.21",
+        "ranges-apply": "^7.0.16",
+        "ranges-push": "^7.0.15",
+        "string-left-right": "^6.0.17"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/string-trim-spaces-only": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/string-trim-spaces-only/-/string-trim-spaces-only-5.0.10.tgz",
+      "integrity": "sha512-MhmjE5jNqb1Ylo+BARPRlsdChGLrnPpAUWrT1VOxo9WhWwKVUU6CbZTfjwKaQPYTGS/wsX/4Zek88FM2rEb5iA==",
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "remark-rehype": "^10.1.0",
     "source-map-support": "^0.5.21",
     "spin-delay": "^2.0.0",
+    "string-strip-html": "^13.4.8",
     "tar-stream": "^3.1.6",
     "tiny-invariant": "^1.3.3",
     "ts-dedent": "^2.2.0",
@@ -240,10 +241,12 @@
       "<rootDir>/__playwright__"
     ],
     "transform": {
-      "^.+\\.svg$": "jest-transform-stub"
+      "^.+\\.svg$": "jest-transform-stub",
+      "^.+\\.(ts|js)$": "ts-jest"
     },
     "transformIgnorePatterns": [
-      "/node_modules/openid-client/"
+      "<rootDir>/node_modules/openid-client/",
+      "<rootDir>/node_modules/string-strip-html/$"
     ]
   },
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "remark-rehype": "^10.1.0",
     "source-map-support": "^0.5.21",
     "spin-delay": "^2.0.0",
-    "string-strip-html": "^13.4.8",
+    "string-strip-html": "8.5.0",
     "tar-stream": "^3.1.6",
     "tiny-invariant": "^1.3.3",
     "ts-dedent": "^2.2.0",
@@ -241,12 +241,10 @@
       "<rootDir>/__playwright__"
     ],
     "transform": {
-      "^.+\\.svg$": "jest-transform-stub",
-      "^.+\\.(ts|js)$": "ts-jest"
+      "^.+\\.svg$": "jest-transform-stub"
     },
     "transformIgnorePatterns": [
-      "<rootDir>/node_modules/openid-client/",
-      "<rootDir>/node_modules/string-strip-html/$"
+      "<rootDir>/node_modules/openid-client/"
     ]
   },
   "browserslist": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -87,6 +87,6 @@ export default defineConfig({
     url: 'http://localhost:3333',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
-    // timeout: 120 * 1000, // 120 Seconds timeout on webServer
+    timeout: 120 * 1000, // 120 Seconds timeout on webServer
   },
 })


### PR DESCRIPTION
# Description
This adds a package for stripping tags from text. It also alters the jest configuration to avoid an import issue with jest.
<img width="1705" alt="Screenshot 2024-05-01 at 2 11 09 PM" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/6545874/5031cf8a-c352-4609-9ec7-b50ca6692133">

# Related Issue(s)
Resolves #2221 

# Testing
I added the function in a way so as to make it testable to show that it works for our intended cases.
<img width="812" alt="Screenshot 2024-05-01 at 2 05 08 PM" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/6545874/afa21911-2cf0-442e-8dda-6092ef12ad8b">

