### PR TITLE
Disable arc.does default handling of CDN

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -150,6 +150,7 @@ architecture arm64
 memory 256
 timeout 30
 hydrate false
+cdn false
 
 @search
 instanceType t3.small.search


### PR DESCRIPTION
After updating Architect in #2256, the deployments are failing (see https://github.com/nasa-gcn/gcn.nasa.gov/actions/runs/8972650379/job/24641211105) with error messages like this:

```
⚬ Deploy Invalidating API Gateway CDN distribution cache
deploy failed! @aws-lite/client: CloudFront.CreateInvalidation: User: arn:aws:sts::781939454830:assumed-role/mcp-GCN-Github-OIDC-Role/GitHubActions is not authorized to perform: cloudfront:CreateInvalidation on resource: arn:aws:cloudfront::781939454830:distribution/E1SU7TV7U07IS9 because no identity-based policy allows the cloudfront:CreateInvalidation action
```

Apparently, Architect has for some time supported creating a CloudFront CDN via an undocumented `@cdn` pragma which is [only mentioned in the Architect changelog](https://github.com/architect/architect/blob/main/changelog.md#635-2020-04-18). Even if you don't explicitly enable the Architect-managed CDN, it may attempt to helpfully detect any manually created CDNs and helpfully invalidate them for you.

We don't need that invalidation because we fingerprint all of our assets to make sure that the filenames are unique whenever assets change. And the deployment fails because we have not given the IAM role that we use for the deployment permissions to invalidate CloudFront distributions.

I am not entirely sure if this is the right syntax for disabling the feature. This might require a few trial-and-error attempts.