### PR TITLE
Try another syntax for disabling the Architect CDN

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -150,7 +150,9 @@ architecture arm64
 memory 256
 timeout 30
 hydrate false
-cdn false
+
+@cdn
+false
 
 @search
 instanceType t3.small.search


### PR DESCRIPTION
This pragma is undocumented. This is another trial-and-error attempt to disable it.

See https://github.com/nasa-gcn/gcn.nasa.gov/pull/2261.