### PR TITLE
Revert "Bump @architect/architect from 10.16.3 to 11.0.12"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "usehooks-ts": "^3.0.2"
       },
       "devDependencies": {
-        "@architect/architect": "^11.0.12",
+        "@architect/architect": "^10.16.3",
         "@architect/plugin-lambda-invoker": "^1.2.0",
         "@architect/utils": "^3.1.9",
         "@aws-sdk/client-cognito-identity-provider": "^3.462.0",
@@ -160,20 +160,28 @@
       }
     },
     "node_modules/@architect/architect": {
-      "version": "11.0.12",
-      "resolved": "https://registry.npmjs.org/@architect/architect/-/architect-11.0.12.tgz",
-      "integrity": "sha512-uCb5yiFgH251v8WW5J7jfX6UkqoKRyQkOkTXgV/09NRat8qqUoKEgDQZ6OlPadp2YWe1FOwoULU2cPEMMB6wfQ==",
+      "version": "10.16.3",
+      "resolved": "https://registry.npmjs.org/@architect/architect/-/architect-10.16.3.tgz",
+      "integrity": "sha512-sa0+PTv/ZrdRwYwHfa3UhtFjQeWDCU3i0oQ1uZR85CN06itk+17/dPYGy4CAi6aw7zgb+nFpywvgXTVNaeQW9Q==",
       "dev": true,
       "dependencies": {
-        "@architect/create": "5.0.3",
-        "@architect/deploy": "5.0.7",
-        "@architect/destroy": "4.0.5",
-        "@architect/env": "4.0.5",
-        "@architect/hydrate": "4.0.6",
-        "@architect/inventory": "~4.0.5",
-        "@architect/logs": "5.0.5",
-        "@architect/sandbox": "6.0.5",
-        "@architect/utils": "~4.0.6",
+        "@architect/create": "4.2.4",
+        "@architect/deploy": "4.6.3",
+        "@architect/destroy": "3.0.13",
+        "@architect/env": "3.0.12",
+        "@architect/hydrate": "3.5.1",
+        "@architect/inventory": "~3.6.3",
+        "@architect/logs": "4.1.0",
+        "@architect/sandbox": "5.9.4",
+        "@architect/utils": "~3.1.9",
+        "@aws-sdk/client-apigatewaymanagementapi": "^3.362.0",
+        "@aws-sdk/client-dynamodb": "^3.362.0",
+        "@aws-sdk/client-s3": "^3.362.0",
+        "@aws-sdk/client-sns": "^3.362.0",
+        "@aws-sdk/client-sqs": "^3.362.0",
+        "@aws-sdk/client-ssm": "^3.362.0",
+        "@aws-sdk/lib-dynamodb": "^3.362.0",
+        "aws-sdk": "^2.1374.0",
         "chalk": "4.1.2",
         "update-notifier-cjs": "5.1.6"
       },
@@ -181,101 +189,52 @@
         "arc": "src/index.js"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@architect/architect/node_modules/@architect/utils": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@architect/utils/-/utils-4.0.6.tgz",
-      "integrity": "sha512-aa6gNNoHxgKpQrIFOa5zNW5fD10v46AE2VZNcjToxAvm//8itbIBoGw2wj8oF3gqHMKKkeLAtdO8K8tlKVN8ZA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-lite/client": "^0.21.1",
-        "chalk": "4.1.2",
-        "glob": "~10.3.12",
-        "path-sort": "~0.1.0",
-        "restore-cursor": "3.1.0",
-        "run-series": "~1.1.9",
-        "run-waterfall": "~1.1.7",
-        "sha": "~3.0.0"
-      },
-      "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/@architect/asap": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@architect/asap/-/asap-7.0.10.tgz",
-      "integrity": "sha512-oJjYDranGTCkp21bziF/fIxJfLTucitqg/ar5mmLPHyroNG3XF3SUIMvuNd1GNIe4oy40wvGEXvTToKYvUeOLA==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@architect/asap/-/asap-6.0.6.tgz",
+      "integrity": "sha512-5+KU/stxPhSZ7wpgaxi+fcIcdjDUbVBbrYc6A8ESFRqXOEx0+g8nVLO2+nQrCLcIyfuxUXwYF2GIkHeLKrUEdQ==",
       "dev": true,
-      "dependencies": {
-        "@aws-lite/client": "~0.21.1",
-        "@aws-lite/s3": "^0.1.21"
-      },
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/@architect/create": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@architect/create/-/create-5.0.3.tgz",
-      "integrity": "sha512-wLHLdZnArRR08HoEFCUtnvxSDjWexkhqrzK7NgeswjMMr5mK4y0zagarte0oaXSIhjCN+x79GWCkH49bKdsVBA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@architect/create/-/create-4.2.4.tgz",
+      "integrity": "sha512-jwi/Im0FaMUpLtpkxpOWew7uBsJJGHLvUCq5QGgYh2HSzmPzYoA9/5jPcVMV3VnvfiqDpv/Il1j+r1jo6C4tNw==",
       "dev": true,
       "dependencies": {
-        "@architect/inventory": "~4.0.5",
-        "@architect/utils": "~4.0.6",
+        "@architect/inventory": "~3.6.3",
+        "@architect/utils": "~3.1.9",
         "chalk": "4.1.2",
-        "lambda-runtimes": "~2.0.2",
+        "lambda-runtimes": "~1.1.6",
         "minimist": "~1.2.8"
       },
       "bin": {
         "arc-create": "src/cli.js"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@architect/create/node_modules/@architect/utils": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@architect/utils/-/utils-4.0.6.tgz",
-      "integrity": "sha512-aa6gNNoHxgKpQrIFOa5zNW5fD10v46AE2VZNcjToxAvm//8itbIBoGw2wj8oF3gqHMKKkeLAtdO8K8tlKVN8ZA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-lite/client": "^0.21.1",
-        "chalk": "4.1.2",
-        "glob": "~10.3.12",
-        "path-sort": "~0.1.0",
-        "restore-cursor": "3.1.0",
-        "run-series": "~1.1.9",
-        "run-waterfall": "~1.1.7",
-        "sha": "~3.0.0"
-      },
-      "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/@architect/deploy": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@architect/deploy/-/deploy-5.0.7.tgz",
-      "integrity": "sha512-Be3P363ottT53q3VEBQB/auAMLdpMWgPBg+n4LNftWDK2CmTBh9/zT/CQGTTVHdcK0s799q6nYGYdLDUdWOFsQ==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@architect/deploy/-/deploy-4.6.3.tgz",
+      "integrity": "sha512-G0tH61PzzFWKv21fU3cHxd4gjeMRMXk0EvRP/3pAfAYezdrhQJAkLv6DP8bp1WHsACKTR0P5ZDe5kxJkIkY+ig==",
       "dev": true,
       "dependencies": {
-        "@architect/create": "~5.0.3",
-        "@architect/hydrate": "~4.0.6",
-        "@architect/inventory": "~4.0.5",
-        "@architect/package": "~9.0.3",
-        "@architect/utils": "~4.0.6",
-        "@aws-lite/apigatewayv2": "^0.0.4",
-        "@aws-lite/client": "^0.21.1",
-        "@aws-lite/cloudformation": "^0.0.5",
-        "@aws-lite/cloudfront": "^0.0.8",
-        "@aws-lite/lambda": "^0.0.5",
-        "@aws-lite/s3": "^0.1.21",
-        "@aws-lite/ssm": "^0.2.3",
+        "@architect/create": "~4.2.3",
+        "@architect/hydrate": "~3.5.0",
+        "@architect/inventory": "~3.6.2",
+        "@architect/package": "~8.5.2",
+        "@architect/utils": "~3.1.9",
         "chalk": "4.1.2",
-        "fs-extra": "~11.2.0",
+        "fs-extra": "~11.1.1",
         "get-folder-size": "2.0.1",
-        "glob": "~10.3.12",
+        "glob": "~10.3.10",
         "mime-types": "~2.1.35",
         "minimist": "~1.2.8",
         "path-sort": "~0.1.0",
@@ -289,32 +248,13 @@
         "arc-deploy": "src/cli/index.js"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@architect/deploy/node_modules/@architect/utils": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@architect/utils/-/utils-4.0.6.tgz",
-      "integrity": "sha512-aa6gNNoHxgKpQrIFOa5zNW5fD10v46AE2VZNcjToxAvm//8itbIBoGw2wj8oF3gqHMKKkeLAtdO8K8tlKVN8ZA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-lite/client": "^0.21.1",
-        "chalk": "4.1.2",
-        "glob": "~10.3.12",
-        "path-sort": "~0.1.0",
-        "restore-cursor": "3.1.0",
-        "run-series": "~1.1.9",
-        "run-waterfall": "~1.1.7",
-        "sha": "~3.0.0"
-      },
-      "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/@architect/deploy/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -326,18 +266,14 @@
       }
     },
     "node_modules/@architect/destroy": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@architect/destroy/-/destroy-4.0.5.tgz",
-      "integrity": "sha512-qZtH6NZmNb1iUTdLq1ayCkOaPUf6PjvGoMAGrorhmf7VxGc8M43sSGE4v+OOfUrKdhKxrcY+lEdcdP2KZXSfSQ==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@architect/destroy/-/destroy-3.0.13.tgz",
+      "integrity": "sha512-P5h7WVGx7hPo5PeOOHA0F5EomHIRjGHHj9ExgSpKkIOo+X+r27AWNWDxk2hgfp5BPVfw2PEbuW1ARy6DZR5UHg==",
       "dev": true,
       "dependencies": {
-        "@architect/inventory": "~4.0.5",
-        "@architect/utils": "~4.0.6",
-        "@aws-lite/client": "^0.21.1",
-        "@aws-lite/cloudformation": "^0.0.5",
-        "@aws-lite/cloudwatch-logs": "^0.0.4",
-        "@aws-lite/s3": "^0.1.21",
-        "@aws-lite/ssm": "^0.2.3",
+        "@architect/inventory": "~3.6.0",
+        "@architect/utils": "~3.1.9",
+        "aws-sdk": "^2.1363.0",
         "minimist": "~1.2.8",
         "run-parallel": "~1.2.0",
         "run-waterfall": "~1.1.7"
@@ -346,41 +282,21 @@
         "arc-destroy": "src/cli.js"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@architect/destroy/node_modules/@architect/utils": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@architect/utils/-/utils-4.0.6.tgz",
-      "integrity": "sha512-aa6gNNoHxgKpQrIFOa5zNW5fD10v46AE2VZNcjToxAvm//8itbIBoGw2wj8oF3gqHMKKkeLAtdO8K8tlKVN8ZA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-lite/client": "^0.21.1",
-        "chalk": "4.1.2",
-        "glob": "~10.3.12",
-        "path-sort": "~0.1.0",
-        "restore-cursor": "3.1.0",
-        "run-series": "~1.1.9",
-        "run-waterfall": "~1.1.7",
-        "sha": "~3.0.0"
-      },
-      "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/@architect/env": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@architect/env/-/env-4.0.5.tgz",
-      "integrity": "sha512-WltaHMwT6/At9kqtYgIEkN+RpHTYo6vWsdOQP/shr80m9pCStHNZW0YaVAjHbbBOPMOMyaAGizE1gcwaDXzT6Q==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@architect/env/-/env-3.0.12.tgz",
+      "integrity": "sha512-8m8+PJWPsjeOQcJ4aWoay87I+TPg977gJ9M9qoRYf87nRyaw1UcmZncOEjz2ZOTCjrl8WdBuETXbAA5dE5OJEA==",
       "dev": true,
       "dependencies": {
-        "@architect/inventory": "~4.0.5",
-        "@architect/parser": "~7.0.1",
-        "@architect/utils": "~4.0.6",
-        "@aws-lite/client": "^0.21.1",
-        "@aws-lite/ssm": "^0.2.3",
+        "@architect/inventory": "~3.6.0",
+        "@architect/parser": "~6.0.3",
+        "@architect/utils": "~3.1.9",
+        "aws-sdk": "^2.1363.0",
         "chalk": "4.1.2",
-        "dotenv": "~16.4.5",
+        "dotenv": "~16.3.1",
         "minimist": "~1.2.8",
         "run-series": "~1.1.9",
         "run-waterfall": "~1.1.7",
@@ -390,26 +306,19 @@
         "arc-env": "src/cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
-    "node_modules/@architect/env/node_modules/@architect/utils": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@architect/utils/-/utils-4.0.6.tgz",
-      "integrity": "sha512-aa6gNNoHxgKpQrIFOa5zNW5fD10v46AE2VZNcjToxAvm//8itbIBoGw2wj8oF3gqHMKKkeLAtdO8K8tlKVN8ZA==",
+    "node_modules/@architect/env/node_modules/dotenv": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.2.tgz",
+      "integrity": "sha512-HTlk5nmhkm8F6JcdXvHIzaorzCoziNQT9mGxLPVXW8wJF1TiGSL60ZGB4gHWabHOaMmWmhvk2/lPHfnBiT78AQ==",
       "dev": true,
-      "dependencies": {
-        "@aws-lite/client": "^0.21.1",
-        "chalk": "4.1.2",
-        "glob": "~10.3.12",
-        "path-sort": "~0.1.0",
-        "restore-cursor": "3.1.0",
-        "run-series": "~1.1.9",
-        "run-waterfall": "~1.1.7",
-        "sha": "~3.0.0"
-      },
       "engines": {
-        "node": ">=16"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/@architect/functions": {
@@ -430,18 +339,18 @@
       }
     },
     "node_modules/@architect/hydrate": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@architect/hydrate/-/hydrate-4.0.6.tgz",
-      "integrity": "sha512-ZAJxtZ8bp32hTn6ATa/mqFk2KTLrqyagjmWF9fjyGayxKjSVGBrZvYNA8N23K/uqAK2BN1M6cWmNS2j6W4vTBQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@architect/hydrate/-/hydrate-3.5.1.tgz",
+      "integrity": "sha512-UiyoKRhEsPz8NnBuLbx0tGmkW3RkQKy5Kcdo0/lhrfvckgcd+91KRXrj+JxTjCQEOIDQzKo80hQJZc+Up+sqpA==",
       "dev": true,
       "dependencies": {
-        "@architect/inventory": "~4.0.5",
-        "@architect/utils": "~4.0.6",
+        "@architect/inventory": "~3.6.2",
+        "@architect/utils": "~3.1.9",
         "acorn-loose": "~8.4.0",
         "chalk": "4.1.2",
         "cpr": "~3.0.1",
         "esquery": "~1.5.0",
-        "glob": "~10.3.12",
+        "glob": "~10.3.10",
         "minimist": "~1.2.8",
         "run-series": "~1.1.9",
         "symlink-or-copy": "~1.3.1"
@@ -450,75 +359,33 @@
         "arc-hydrate": "src/cli.js"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@architect/hydrate/node_modules/@architect/utils": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@architect/utils/-/utils-4.0.6.tgz",
-      "integrity": "sha512-aa6gNNoHxgKpQrIFOa5zNW5fD10v46AE2VZNcjToxAvm//8itbIBoGw2wj8oF3gqHMKKkeLAtdO8K8tlKVN8ZA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-lite/client": "^0.21.1",
-        "chalk": "4.1.2",
-        "glob": "~10.3.12",
-        "path-sort": "~0.1.0",
-        "restore-cursor": "3.1.0",
-        "run-series": "~1.1.9",
-        "run-waterfall": "~1.1.7",
-        "sha": "~3.0.0"
-      },
-      "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/@architect/inventory": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@architect/inventory/-/inventory-4.0.5.tgz",
-      "integrity": "sha512-lDmH3iOejxWDLolI8tFuLgaqgT1ANuB4TrS3qHno43v+Tx+EEi5Nw6HWJ8LJ6onuStpzNWTMJtSssaJgJUSHrQ==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@architect/inventory/-/inventory-3.6.5.tgz",
+      "integrity": "sha512-A+xJYnn/3oWUmKLnEUPfVh2zGsTFOUq3V8PxYhZM6VomsvFAHqt5rITjRhM9M7TQ8D0dj1cvYhuctE0Ipfr23g==",
       "dev": true,
       "dependencies": {
-        "@architect/asap": "~7.0.10",
-        "@architect/parser": "~7.0.1",
-        "@architect/utils": "~4.0.6",
-        "@aws-lite/client": "^0.21.1",
-        "@aws-lite/ssm": "^0.2.3",
-        "lambda-runtimes": "~2.0.2"
+        "@architect/asap": "~6.0.4",
+        "@architect/parser": "~6.0.3",
+        "@architect/utils": "~3.1.9",
+        "lambda-runtimes": "~1.1.6"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@architect/inventory/node_modules/@architect/utils": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@architect/utils/-/utils-4.0.6.tgz",
-      "integrity": "sha512-aa6gNNoHxgKpQrIFOa5zNW5fD10v46AE2VZNcjToxAvm//8itbIBoGw2wj8oF3gqHMKKkeLAtdO8K8tlKVN8ZA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-lite/client": "^0.21.1",
-        "chalk": "4.1.2",
-        "glob": "~10.3.12",
-        "path-sort": "~0.1.0",
-        "restore-cursor": "3.1.0",
-        "run-series": "~1.1.9",
-        "run-waterfall": "~1.1.7",
-        "sha": "~3.0.0"
-      },
-      "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/@architect/logs": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@architect/logs/-/logs-5.0.5.tgz",
-      "integrity": "sha512-NEro6KnvKIRvavvcGHKw6ziJ5SrP0FpTXhiDAYnLLGgh6qJ1zXqxyKrgCYAu5oI5lNoccZomVoYv3ooaDUDqMQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@architect/logs/-/logs-4.1.0.tgz",
+      "integrity": "sha512-NF8JY2BRsI71aWROq7eCS6lMMt7JbfF76HXIgUqBpmtTPGHgJJMChJf4RRwPJsTK1zv8WBvWITiWImjwDystCg==",
       "dev": true,
       "dependencies": {
-        "@architect/inventory": "~4.0.5",
-        "@architect/utils": "~4.0.6",
-        "@aws-lite/client": "^0.21.1",
-        "@aws-lite/cloudformation": "^0.0.5",
-        "@aws-lite/cloudwatch-logs": "^0.0.4",
+        "@architect/inventory": "~3.6.0",
+        "@architect/utils": "~3.1.9",
+        "aws-sdk": "^2.1363.0",
         "chalk": "4.1.2",
         "minimist": "~1.2.8",
         "run-parallel": "~1.2.0",
@@ -529,67 +396,29 @@
         "arc-logs": "src/cli.js"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@architect/logs/node_modules/@architect/utils": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@architect/utils/-/utils-4.0.6.tgz",
-      "integrity": "sha512-aa6gNNoHxgKpQrIFOa5zNW5fD10v46AE2VZNcjToxAvm//8itbIBoGw2wj8oF3gqHMKKkeLAtdO8K8tlKVN8ZA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-lite/client": "^0.21.1",
-        "chalk": "4.1.2",
-        "glob": "~10.3.12",
-        "path-sort": "~0.1.0",
-        "restore-cursor": "3.1.0",
-        "run-series": "~1.1.9",
-        "run-waterfall": "~1.1.7",
-        "sha": "~3.0.0"
-      },
-      "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/@architect/package": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@architect/package/-/package-9.0.3.tgz",
-      "integrity": "sha512-k21bX5xmGfGLr9wPy+TweN8OaMscf4nPYeVotf35rzdhCfnEBax3Tyi3GY8v0WyJ2jgxPzu7CrsgnhG8goIxag==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@architect/package/-/package-8.5.2.tgz",
+      "integrity": "sha512-I3y8Tn7AkVx3qOs/uehIunJviQv+ekEegj5hsjM8TIywZWOb8YGIBLCicms5BHacZTslQZOe0DcrzetYfJm/sQ==",
       "dev": true,
       "dependencies": {
-        "@architect/inventory": "~4.0.5",
-        "@architect/utils": "~4.0.6"
+        "@architect/inventory": "~3.6.0",
+        "@architect/utils": "~3.1.9"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@architect/package/node_modules/@architect/utils": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@architect/utils/-/utils-4.0.6.tgz",
-      "integrity": "sha512-aa6gNNoHxgKpQrIFOa5zNW5fD10v46AE2VZNcjToxAvm//8itbIBoGw2wj8oF3gqHMKKkeLAtdO8K8tlKVN8ZA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-lite/client": "^0.21.1",
-        "chalk": "4.1.2",
-        "glob": "~10.3.12",
-        "path-sort": "~0.1.0",
-        "restore-cursor": "3.1.0",
-        "run-series": "~1.1.9",
-        "run-waterfall": "~1.1.7",
-        "sha": "~3.0.0"
-      },
-      "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/@architect/parser": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@architect/parser/-/parser-7.0.1.tgz",
-      "integrity": "sha512-T4Rr/eQbtg/gPvS4HcXR7zYxLJ3gEh6pSKj0s/Y1IrvJY9QG4BDAVZgE7AYGfzqymwIF0pUI2mQ91CLi2CTnQw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@architect/parser/-/parser-6.0.3.tgz",
+      "integrity": "sha512-g03zlsXO0YBVMDFbXHRL3JpVpru4kUeaQIe53tNhs1C9+fMguNCSWq1tNSmwqhBYq43O/R3hleg8VSOI0NFwgA==",
       "dev": true,
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/@architect/plugin-lambda-invoker": {
@@ -607,62 +436,98 @@
       }
     },
     "node_modules/@architect/sandbox": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@architect/sandbox/-/sandbox-6.0.5.tgz",
-      "integrity": "sha512-VJcFxVhSbrhisTMqq2ukbj4NlN18eJgYYqEMnCk9UAdIyHBBoEAP4YmroyFCHv7CsutFUMhjDQP9+9deQje+6w==",
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/@architect/sandbox/-/sandbox-5.9.4.tgz",
+      "integrity": "sha512-BA19H/4ykch4asxsZ3tGT6Xma1hqyBwjwHIr3+kyPs9hLx2cEraBW7/7sU+HPWX6Ftq/5w+vsuQxBY3y6TjBhg==",
       "dev": true,
       "dependencies": {
-        "@architect/asap": "~7.0.10",
-        "@architect/create": "~5.0.3",
-        "@architect/hydrate": "~4.0.6",
-        "@architect/inventory": "~4.0.5",
-        "@architect/utils": "~4.0.6",
-        "@aws-lite/client": "^0.21.1",
-        "@aws-lite/dynamodb": "^0.3.4",
+        "@architect/asap": "~6.0.4",
+        "@architect/create": "~4.2.4",
+        "@architect/hydrate": "~3.5.1",
+        "@architect/inventory": "~3.6.3",
+        "@architect/utils": "~3.1.9",
+        "@aws-sdk/client-apigatewaymanagementapi": "^3.316.0",
+        "@aws-sdk/client-dynamodb": "^3.316.0",
+        "@aws-sdk/client-s3": "^3.316.0",
+        "@aws-sdk/client-sns": "^3.316.0",
+        "@aws-sdk/client-sqs": "^3.316.0",
+        "@aws-sdk/client-ssm": "^3.316.0",
+        "@aws-sdk/lib-dynamodb": "^3.316.0",
+        "@aws-sdk/node-http-handler": "^3.360.0",
         "@begin/hashid": "~1.0.0",
+        "aws-sdk": "^2.1363.0",
         "chalk": "4.1.2",
-        "chokidar": "~3.6.0",
+        "chokidar": "~3.5.3",
         "depstatus": "~1.1.1",
         "dynalite": "~3.2.2",
         "finalhandler": "~1.2.0",
-        "glob": "~10.3.12",
+        "glob": "~10.3.10",
         "http-proxy": "~1.18.1",
-        "lambda-runtimes": "~2.0.2",
+        "lambda-runtimes": "~1.1.6",
         "minimist": "~1.2.8",
         "router": "~1.3.8",
         "run-parallel": "~1.2.0",
         "run-series": "~1.1.9",
         "send": "~0.18.0",
         "server-destroy": "~1.0.1",
-        "tmp": "~0.2.3",
+        "tmp": "~0.2.1",
         "tree-kill": "~1.2.2",
         "update-notifier-cjs": "~5.1.6",
-        "ws": "~8.17.0"
+        "ws": "~8.14.2"
       },
       "bin": {
         "sandbox": "src/cli/cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
-    "node_modules/@architect/sandbox/node_modules/@architect/utils": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@architect/utils/-/utils-4.0.6.tgz",
-      "integrity": "sha512-aa6gNNoHxgKpQrIFOa5zNW5fD10v46AE2VZNcjToxAvm//8itbIBoGw2wj8oF3gqHMKKkeLAtdO8K8tlKVN8ZA==",
+    "node_modules/@architect/sandbox/node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
-        "@aws-lite/client": "^0.21.1",
-        "chalk": "4.1.2",
-        "glob": "~10.3.12",
-        "path-sort": "~0.1.0",
-        "restore-cursor": "3.1.0",
-        "run-series": "~1.1.9",
-        "run-waterfall": "~1.1.7",
-        "sha": "~3.0.0"
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/@architect/sandbox/node_modules/ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@architect/utils": {
@@ -863,89 +728,429 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@aws-lite/apigatewayv2": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@aws-lite/apigatewayv2/-/apigatewayv2-0.0.4.tgz",
-      "integrity": "sha512-e6kzA7oIJcEN6RiSlfWTunS6RpK3DadCLNPpBZCdFfH1Bz1GYr15rkkWItIaEO6e21VWZPYAzTRSqBRcZfgbfw==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@aws-lite/client": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@aws-lite/client/-/client-0.21.1.tgz",
-      "integrity": "sha512-RdKLDUIVZBtYSzjD1hPwSwbR+ZSwY7988emG0o5dptED6hSuvCTDYUha+NiFBKo5MALw5qapLUp0xYO9JejFYg==",
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi": {
+      "version": "3.569.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.569.0.tgz",
+      "integrity": "sha512-mJocxGmx2GuY5LF/61+AONXY2bLm+1XU9uF3HrX8fl920L09dZu2E+odb/y4rjZK4Ws2/BuvK3ItlO0N87VJ2g==",
       "dev": true,
       "dependencies": {
-        "aws4": "^1.12.0",
-        "ini": "^4.1.2"
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.569.0",
+        "@aws-sdk/client-sts": "3.569.0",
+        "@aws-sdk/core": "3.567.0",
+        "@aws-sdk/credential-provider-node": "3.569.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.567.0",
+        "@aws-sdk/region-config-resolver": "3.567.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.567.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-lite/cloudformation": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@aws-lite/cloudformation/-/cloudformation-0.0.5.tgz",
-      "integrity": "sha512-x0//MSCl3ntV0RKQcyYLIe6dzzCbjdAKEh1ftzkXp5dK7f+li7iZXhP3YhrVUaVWmEyjX8FLiIsDX0dRIODEYA==",
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/client-sso": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.568.0.tgz",
+      "integrity": "sha512-LSD7k0ZBQNWouTN5dYpUkeestoQ+r5u6cp6o+FATKeiFQET85RNA3xJ4WPnOI5rBC1PETKhQXvF44863P3hCaQ==",
       "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.567.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.567.0",
+        "@aws-sdk/region-config-resolver": "3.567.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.567.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-lite/cloudfront": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@aws-lite/cloudfront/-/cloudfront-0.0.8.tgz",
-      "integrity": "sha512-RdBFr7sHoGnLf/QLp8j1AlgAnLNtj9rAnmbkkvUwqrmaTZ0iLnWekeLe44YnknaQQjzscsGdAOjiNuPLds/BFw==",
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/client-sts": {
+      "version": "3.569.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.569.0.tgz",
+      "integrity": "sha512-3AyipQ2zHszkcTr8n1Sp7CiMUi28aMf1vOhEo0KKi0DWGo1Z1qJEpWeRP363KG0n9/8U3p1IkXGz5FRbpXZxIw==",
       "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.569.0",
+        "@aws-sdk/core": "3.567.0",
+        "@aws-sdk/credential-provider-node": "3.569.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.567.0",
+        "@aws-sdk/region-config-resolver": "3.567.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.567.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-lite/cloudwatch-logs": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@aws-lite/cloudwatch-logs/-/cloudwatch-logs-0.0.4.tgz",
-      "integrity": "sha512-4tQx0WBKhXrSCtpCcqsDWf+lr5Q6g+Xc2wepiuTKYtd3MXmfSTfbEr1AokaXHgHomGg9z08sAlNdGwnxYePspg==",
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.568.0.tgz",
+      "integrity": "sha512-MVTQoZwPnP1Ev5A7LG+KzeU6sCB8BcGkZeDT1z1V5Wt7GPq0MgFQTSSjhImnB9jqRSZkl1079Bt3PbO6lfIS8g==",
       "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-lite/dynamodb": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@aws-lite/dynamodb/-/dynamodb-0.3.4.tgz",
-      "integrity": "sha512-G+1jSGtRNE6Z5A1YFaqBeRHkF666EndAGc2/hiCYj+YvaBGwBZqeCL8azwRSsnkAPHGGvk07CthQxOwvPK/QJw==",
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.568.0.tgz",
+      "integrity": "sha512-m5DUN9mpto5DhEvo6w3+8SS6q932ja37rTNvpPqWJIaWhj7OorAwVirSaJQAQB/M8+XCUIrUonxytphZB28qGQ==",
       "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-process": "3.568.0",
+        "@aws-sdk/credential-provider-sso": "3.568.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.568.0"
       }
     },
-    "node_modules/@aws-lite/lambda": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@aws-lite/lambda/-/lambda-0.0.5.tgz",
-      "integrity": "sha512-2mNibCwhGU9qAhhqpDIqXdJRR8yKEspoYpycZN/BoOZolHaFZnItqomcF6ZifeZPF6bDfBHVuEu9cX9OU1IXVg==",
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.569.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.569.0.tgz",
+      "integrity": "sha512-7jH4X2qlPU3PszZP1zvHJorhLARbU1tXvp8ngBe8ArXBrkFpl/dQ2Y/IRAICPm/pyC1IEt8L/CvKp+dz7v/eRw==",
       "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-http": "3.568.0",
+        "@aws-sdk/credential-provider-ini": "3.568.0",
+        "@aws-sdk/credential-provider-process": "3.568.0",
+        "@aws-sdk/credential-provider-sso": "3.568.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-lite/s3": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@aws-lite/s3/-/s3-0.1.21.tgz",
-      "integrity": "sha512-71C3TwYLaH2+heEZIMMWNEFYnngOCeaRwFcAZ6Wnc98450KOnMqekK4IVsLZJUNW4//AJYS+sLcyMFcHFsF/RA==",
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.568.0.tgz",
+      "integrity": "sha512-r01zbXbanP17D+bQUb7mD8Iu2SuayrrYZ0Slgvx32qgz47msocV9EPCSwI4Hkw2ZtEPCeLQR4XCqFJB1D9P50w==",
       "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-lite/ssm": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@aws-lite/ssm/-/ssm-0.2.3.tgz",
-      "integrity": "sha512-pywo0EBU6LnLWicXHlWX7dSz3odJN7hK3pgtudSs5XFGONrcVKy4k0Zc+x85fixIf3/ZZAdB66ctT3D5li3Xpw==",
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.568.0.tgz",
+      "integrity": "sha512-+TA77NWOEXMUcfLoOuim6xiyXFg1GqHj55ggI1goTKGVvdHYZ+rhxZbwjI29+ewzPt/qcItDJcvhrjOrg9lCag==",
       "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.568.0",
+        "@aws-sdk/token-providers": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.568.0.tgz",
+      "integrity": "sha512-ZJSmTmoIdg6WqAULjYzaJ3XcbgBzVy36lir6Y0UBMRGaxDgos1AARuX6EcYzXOl+ksLvxt/xMQ+3aYh1LWfKSw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.568.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.567.0.tgz",
+      "integrity": "sha512-zQHHj2N3in9duKghH7AuRNrOMLnKhW6lnmb7dznou068DJtDr76w475sHp2TF0XELsOGENbbBsOlN/S5QBFBVQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.568.0.tgz",
+      "integrity": "sha512-BinH72RG7K3DHHC1/tCulocFv+ZlQ9SrPF9zYT0T1OT95JXuHhB7fH8gEABrc6DAtOdJJh2fgxQjPy5tzPtsrA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.567.0.tgz",
+      "integrity": "sha512-rFk3QhdT4IL6O/UWHmNdjJiURutBCy+ogGqaNHf/RELxgXH3KmYorLwCe0eFb5hq8f6vr3zl4/iH7YtsUOuo1w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.567.0.tgz",
+      "integrity": "sha512-a7DBGMRBLWJU3BqrQjOtKS4/RcCh/BhhKqwjCE0FEhhm6A/GGuAs/DcBGOl6Y8Wfsby3vejSlppTLH/qtV1E9w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.567.0.tgz",
+      "integrity": "sha512-VMDyYi5Dh2NydDiIARZ19DwMfbyq0llS736cp47qopmO6wzdeul7WRTx8NKfEYN0/AwEaqmTW0ohx58jSB1lYg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/token-providers": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.568.0.tgz",
+      "integrity": "sha512-mCQElYzY5N2JlXB7LyjOoLvRN/JiSV+E9szLwhYN3dleTUCMbGqWb7RiAR2V3fO+mz8f9kR7DThTExKJbKogKw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.568.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/types": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.567.0.tgz",
+      "integrity": "sha512-WVhot3qmi0BKL9ZKnUqsvCd++4RF2DsJIG32NlRaml1FT9KaqSzNv0RXeA6k/kYwiiNT7y3YWu3Lbzy7c6vG9g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.567.0.tgz",
+      "integrity": "sha512-cqP0uXtZ7m7hRysf3fRyJwcY1jCgQTpJy7BHB5VpsE7DXlXHD5+Ur5L42CY7UrRPrB6lc6YGFqaAOs5ghMcLyA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.568.0.tgz",
+      "integrity": "sha512-NVoZoLnKF+eXPBvXg+KqixgJkPSrerR6Gqmbjwqbv14Ini+0KNKB0/MXas1mDGvvEgtNkHI/Cb9zlJ3KXpti2A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
@@ -1233,6 +1438,858 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns": {
+      "version": "3.569.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.569.0.tgz",
+      "integrity": "sha512-RTzjfEYAmOff92H8WmODHXQffspGqCKPIPjfjRYIjQ1MD7bzn0NukkB88G77zHej791o3cIjtb/5pZp2fe0bYw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.569.0",
+        "@aws-sdk/client-sts": "3.569.0",
+        "@aws-sdk/core": "3.567.0",
+        "@aws-sdk/credential-provider-node": "3.569.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.567.0",
+        "@aws-sdk/region-config-resolver": "3.567.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.567.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sso": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.568.0.tgz",
+      "integrity": "sha512-LSD7k0ZBQNWouTN5dYpUkeestoQ+r5u6cp6o+FATKeiFQET85RNA3xJ4WPnOI5rBC1PETKhQXvF44863P3hCaQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.567.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.567.0",
+        "@aws-sdk/region-config-resolver": "3.567.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.567.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sts": {
+      "version": "3.569.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.569.0.tgz",
+      "integrity": "sha512-3AyipQ2zHszkcTr8n1Sp7CiMUi28aMf1vOhEo0KKi0DWGo1Z1qJEpWeRP363KG0n9/8U3p1IkXGz5FRbpXZxIw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.569.0",
+        "@aws-sdk/core": "3.567.0",
+        "@aws-sdk/credential-provider-node": "3.569.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.567.0",
+        "@aws-sdk/region-config-resolver": "3.567.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.567.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.568.0.tgz",
+      "integrity": "sha512-MVTQoZwPnP1Ev5A7LG+KzeU6sCB8BcGkZeDT1z1V5Wt7GPq0MgFQTSSjhImnB9jqRSZkl1079Bt3PbO6lfIS8g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.568.0.tgz",
+      "integrity": "sha512-m5DUN9mpto5DhEvo6w3+8SS6q932ja37rTNvpPqWJIaWhj7OorAwVirSaJQAQB/M8+XCUIrUonxytphZB28qGQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-process": "3.568.0",
+        "@aws-sdk/credential-provider-sso": "3.568.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.568.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.569.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.569.0.tgz",
+      "integrity": "sha512-7jH4X2qlPU3PszZP1zvHJorhLARbU1tXvp8ngBe8ArXBrkFpl/dQ2Y/IRAICPm/pyC1IEt8L/CvKp+dz7v/eRw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-http": "3.568.0",
+        "@aws-sdk/credential-provider-ini": "3.568.0",
+        "@aws-sdk/credential-provider-process": "3.568.0",
+        "@aws-sdk/credential-provider-sso": "3.568.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.568.0.tgz",
+      "integrity": "sha512-r01zbXbanP17D+bQUb7mD8Iu2SuayrrYZ0Slgvx32qgz47msocV9EPCSwI4Hkw2ZtEPCeLQR4XCqFJB1D9P50w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.568.0.tgz",
+      "integrity": "sha512-+TA77NWOEXMUcfLoOuim6xiyXFg1GqHj55ggI1goTKGVvdHYZ+rhxZbwjI29+ewzPt/qcItDJcvhrjOrg9lCag==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.568.0",
+        "@aws-sdk/token-providers": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.568.0.tgz",
+      "integrity": "sha512-ZJSmTmoIdg6WqAULjYzaJ3XcbgBzVy36lir6Y0UBMRGaxDgos1AARuX6EcYzXOl+ksLvxt/xMQ+3aYh1LWfKSw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.568.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.567.0.tgz",
+      "integrity": "sha512-zQHHj2N3in9duKghH7AuRNrOMLnKhW6lnmb7dznou068DJtDr76w475sHp2TF0XELsOGENbbBsOlN/S5QBFBVQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.568.0.tgz",
+      "integrity": "sha512-BinH72RG7K3DHHC1/tCulocFv+ZlQ9SrPF9zYT0T1OT95JXuHhB7fH8gEABrc6DAtOdJJh2fgxQjPy5tzPtsrA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.567.0.tgz",
+      "integrity": "sha512-rFk3QhdT4IL6O/UWHmNdjJiURutBCy+ogGqaNHf/RELxgXH3KmYorLwCe0eFb5hq8f6vr3zl4/iH7YtsUOuo1w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.567.0.tgz",
+      "integrity": "sha512-a7DBGMRBLWJU3BqrQjOtKS4/RcCh/BhhKqwjCE0FEhhm6A/GGuAs/DcBGOl6Y8Wfsby3vejSlppTLH/qtV1E9w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.567.0.tgz",
+      "integrity": "sha512-VMDyYi5Dh2NydDiIARZ19DwMfbyq0llS736cp47qopmO6wzdeul7WRTx8NKfEYN0/AwEaqmTW0ohx58jSB1lYg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/token-providers": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.568.0.tgz",
+      "integrity": "sha512-mCQElYzY5N2JlXB7LyjOoLvRN/JiSV+E9szLwhYN3dleTUCMbGqWb7RiAR2V3fO+mz8f9kR7DThTExKJbKogKw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.568.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/types": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.567.0.tgz",
+      "integrity": "sha512-WVhot3qmi0BKL9ZKnUqsvCd++4RF2DsJIG32NlRaml1FT9KaqSzNv0RXeA6k/kYwiiNT7y3YWu3Lbzy7c6vG9g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.567.0.tgz",
+      "integrity": "sha512-cqP0uXtZ7m7hRysf3fRyJwcY1jCgQTpJy7BHB5VpsE7DXlXHD5+Ur5L42CY7UrRPrB6lc6YGFqaAOs5ghMcLyA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.568.0.tgz",
+      "integrity": "sha512-NVoZoLnKF+eXPBvXg+KqixgJkPSrerR6Gqmbjwqbv14Ini+0KNKB0/MXas1mDGvvEgtNkHI/Cb9zlJ3KXpti2A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.569.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.569.0.tgz",
+      "integrity": "sha512-9w2vIFm91J1M9iAcdmvXJ1h2XN+7sCekNvLol3RF8ZG9+kiS9vivFLZ2vSYVSRWlj2oh+BQ9f1Pir32uD3W7CQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.569.0",
+        "@aws-sdk/client-sts": "3.569.0",
+        "@aws-sdk/core": "3.567.0",
+        "@aws-sdk/credential-provider-node": "3.569.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.569.0",
+        "@aws-sdk/middleware-user-agent": "3.567.0",
+        "@aws-sdk/region-config-resolver": "3.567.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.567.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/md5-js": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.568.0.tgz",
+      "integrity": "sha512-LSD7k0ZBQNWouTN5dYpUkeestoQ+r5u6cp6o+FATKeiFQET85RNA3xJ4WPnOI5rBC1PETKhQXvF44863P3hCaQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.567.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.567.0",
+        "@aws-sdk/region-config-resolver": "3.567.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.567.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sts": {
+      "version": "3.569.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.569.0.tgz",
+      "integrity": "sha512-3AyipQ2zHszkcTr8n1Sp7CiMUi28aMf1vOhEo0KKi0DWGo1Z1qJEpWeRP363KG0n9/8U3p1IkXGz5FRbpXZxIw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.569.0",
+        "@aws-sdk/core": "3.567.0",
+        "@aws-sdk/credential-provider-node": "3.569.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.567.0",
+        "@aws-sdk/region-config-resolver": "3.567.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.567.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.568.0.tgz",
+      "integrity": "sha512-MVTQoZwPnP1Ev5A7LG+KzeU6sCB8BcGkZeDT1z1V5Wt7GPq0MgFQTSSjhImnB9jqRSZkl1079Bt3PbO6lfIS8g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.568.0.tgz",
+      "integrity": "sha512-m5DUN9mpto5DhEvo6w3+8SS6q932ja37rTNvpPqWJIaWhj7OorAwVirSaJQAQB/M8+XCUIrUonxytphZB28qGQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-process": "3.568.0",
+        "@aws-sdk/credential-provider-sso": "3.568.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.568.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.569.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.569.0.tgz",
+      "integrity": "sha512-7jH4X2qlPU3PszZP1zvHJorhLARbU1tXvp8ngBe8ArXBrkFpl/dQ2Y/IRAICPm/pyC1IEt8L/CvKp+dz7v/eRw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-http": "3.568.0",
+        "@aws-sdk/credential-provider-ini": "3.568.0",
+        "@aws-sdk/credential-provider-process": "3.568.0",
+        "@aws-sdk/credential-provider-sso": "3.568.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.568.0.tgz",
+      "integrity": "sha512-r01zbXbanP17D+bQUb7mD8Iu2SuayrrYZ0Slgvx32qgz47msocV9EPCSwI4Hkw2ZtEPCeLQR4XCqFJB1D9P50w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.568.0.tgz",
+      "integrity": "sha512-+TA77NWOEXMUcfLoOuim6xiyXFg1GqHj55ggI1goTKGVvdHYZ+rhxZbwjI29+ewzPt/qcItDJcvhrjOrg9lCag==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.568.0",
+        "@aws-sdk/token-providers": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.568.0.tgz",
+      "integrity": "sha512-ZJSmTmoIdg6WqAULjYzaJ3XcbgBzVy36lir6Y0UBMRGaxDgos1AARuX6EcYzXOl+ksLvxt/xMQ+3aYh1LWfKSw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.568.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.567.0.tgz",
+      "integrity": "sha512-zQHHj2N3in9duKghH7AuRNrOMLnKhW6lnmb7dznou068DJtDr76w475sHp2TF0XELsOGENbbBsOlN/S5QBFBVQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.568.0.tgz",
+      "integrity": "sha512-BinH72RG7K3DHHC1/tCulocFv+ZlQ9SrPF9zYT0T1OT95JXuHhB7fH8gEABrc6DAtOdJJh2fgxQjPy5tzPtsrA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.567.0.tgz",
+      "integrity": "sha512-rFk3QhdT4IL6O/UWHmNdjJiURutBCy+ogGqaNHf/RELxgXH3KmYorLwCe0eFb5hq8f6vr3zl4/iH7YtsUOuo1w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.567.0.tgz",
+      "integrity": "sha512-a7DBGMRBLWJU3BqrQjOtKS4/RcCh/BhhKqwjCE0FEhhm6A/GGuAs/DcBGOl6Y8Wfsby3vejSlppTLH/qtV1E9w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.567.0.tgz",
+      "integrity": "sha512-VMDyYi5Dh2NydDiIARZ19DwMfbyq0llS736cp47qopmO6wzdeul7WRTx8NKfEYN0/AwEaqmTW0ohx58jSB1lYg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/token-providers": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.568.0.tgz",
+      "integrity": "sha512-mCQElYzY5N2JlXB7LyjOoLvRN/JiSV+E9szLwhYN3dleTUCMbGqWb7RiAR2V3fO+mz8f9kR7DThTExKJbKogKw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.568.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/types": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.567.0.tgz",
+      "integrity": "sha512-WVhot3qmi0BKL9ZKnUqsvCd++4RF2DsJIG32NlRaml1FT9KaqSzNv0RXeA6k/kYwiiNT7y3YWu3Lbzy7c6vG9g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.567.0.tgz",
+      "integrity": "sha512-cqP0uXtZ7m7hRysf3fRyJwcY1jCgQTpJy7BHB5VpsE7DXlXHD5+Ur5L42CY7UrRPrB6lc6YGFqaAOs5ghMcLyA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.568.0.tgz",
+      "integrity": "sha512-NVoZoLnKF+eXPBvXg+KqixgJkPSrerR6Gqmbjwqbv14Ini+0KNKB0/MXas1mDGvvEgtNkHI/Cb9zlJ3KXpti2A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
@@ -2587,6 +3644,36 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.569.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.569.0.tgz",
+      "integrity": "sha512-KT3KlMmOApfOiMM0CdlO9RYCsjw7CmCpA3Fg2Jbe/+ywQNROMNthfgILqKq3ri7uTmWgo4yR4iaaTiRlrBfpAg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@aws-sdk/types": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-signing": {
       "version": "3.496.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
@@ -2626,6 +3713,100 @@
         "@aws-sdk/util-endpoints": "3.496.0",
         "@smithy/protocol-http": "^3.1.1",
         "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.374.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.374.0.tgz",
+      "integrity": "sha512-v1Z6m0wwkf65/tKuhwrtPRqVoOtNkDTRn2MBMtxCwEw+8V8Q+YRFqVgGN+J1n53ktE0G5OYVBux/NHiAjJHReQ==",
+      "deprecated": "This package has moved to @smithy/node-http-handler",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-http-handler": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/node-http-handler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz",
+      "integrity": "sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^1.1.0",
+        "@smithy/protocol-http": "^1.2.0",
+        "@smithy/querystring-builder": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/protocol-http": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+      "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/querystring-builder": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
+      "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^1.2.0",
+        "@smithy/util-uri-escape": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@smithy/util-uri-escape": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
+      "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+      "dev": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4938,87 +6119,6 @@
       "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==",
       "dev": true
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
-      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.6.tgz",
@@ -5030,278 +6130,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -7385,48 +8213,6 @@
         "web-streams-polyfill": "^3.1.1"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.0.tgz",
-      "integrity": "sha512-jwXtxYbRt1V+CdQSy6Z+uZti7JF5irRKF8hlKfEnF/xJpcNGuuiZMBvuoYM+x9sr9iWGnzrlM0+9hvQ1kgkf1w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.0.tgz",
-      "integrity": "sha512-fI9nduZhCccjzlsA/OuAwtFGWocxA4gqXGTLvOyiF8d+8o0fZUeSztixkYjcGq1fGZY3Tkq4yRvHPFxU+jdZ9Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.0.tgz",
-      "integrity": "sha512-BcnSPRM76/cD2gQC+rQNGBN6GStBs2pl/FpweW8JYuz5J/IEa0Fr4AtrPv766DB/6b2MZ/AfSIOSGw3nEIP8SA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.0.tgz",
@@ -7438,160 +8224,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.0.tgz",
-      "integrity": "sha512-ygrGVhQP47mRh0AAD0zl6QqCbNsf0eTo+vgwkY6LunBcg0f2Jv365GXlDUECIyoXp1kKwL5WW6rsO429DBY/bA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.0.tgz",
-      "integrity": "sha512-x+uJ6MAYRlHGe9wi4HQjxpaKHPM3d3JjqqCkeC5gpnnI6OWovLdXTpfa8trjxPLnWKyBsSi5kne+146GAxFt4A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.0.tgz",
-      "integrity": "sha512-nrRw8ZTQKg6+Lttwqo6a2VxR9tOroa2m91XbdQ2sUUzHoedXlsyvY1fN4xWdqz8PKmf4orDwejxXHjh7YBGUCA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.0.tgz",
-      "integrity": "sha512-xV0d5jDb4aFu84XKr+lcUJ9y3qpIWhttO3Qev97z8DKLXR62LC3cXT/bMZXrjLF9X+P5oSmJTzAhqwUbY96PnA==",
-      "cpu": [
-        "ppc64le"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.0.tgz",
-      "integrity": "sha512-SDDhBQwZX6LPRoPYjAZWyL27LbcBo7WdBFWJi5PI9RPCzU8ijzkQn7tt8NXiXRiFMJCVpkuMkBf4OxSxVMizAw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.0.tgz",
-      "integrity": "sha512-RxB/qez8zIDshNJDufYlTT0ZTVut5eCpAZ3bdXDU9yTxBzui3KhbGjROK2OYTTor7alM7XBhssgoO3CZ0XD3qA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.0.tgz",
-      "integrity": "sha512-C6y6z2eCNCfhZxT9u+jAM2Fup89ZjiG5pIzZIDycs1IwESviLxwkQcFRGLjnDrP+PT+v5i4YFvlcfAs+LnreXg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.0.tgz",
-      "integrity": "sha512-i0QwbHYfnOMYsBEyjxcwGu5SMIi9sImDVjDg087hpzXqhBSosxkE7gyIYFHgfFl4mr7RrXksIBZ4DoLoP4FhJg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.0.tgz",
-      "integrity": "sha512-Fq52EYb0riNHLBTAcL0cun+rRwyZ10S9vKzhGKKgeD+XbwunszSY0rVMco5KbOsTlwovP2rTOkiII/fQ4ih/zQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.0.tgz",
-      "integrity": "sha512-e/PBHxPdJ00O9p5Ui43+vixSgVf4NlLsmV6QneGERJ3lnjIua/kim6PRFe3iDueT1rQcgSkYP8ZBBXa/h4iPvw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.0.tgz",
-      "integrity": "sha512-aGg7iToJjdklmxlUlJh/PaPNa4PmqHfyRMLunbL3eaMO0gp656+q1zOKkpJ/CVe9CryJv6tAN1HDoR8cNGzkag==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "peer": true
     },
@@ -7876,13 +8508,13 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.1.1.tgz",
-      "integrity": "sha512-L3MbIYBIdLlT+MWTYrdVSv/dow1+6iZ1Ad7xS0OHxTTs17d753ZcpOV4Ro7M7tRAVWML/sg2IAp/zzCb6aAttg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.2.0.tgz",
+      "integrity": "sha512-M26XTtt9IIusVMOWEAhIvFIr9jYj4ISPPGJROqw6vXngO3IYJCnVVSMFn4Tx1rUTG5BiKJNg9u2nxmBiZC5IlQ==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/middleware-content-length": {
@@ -12575,342 +13207,6 @@
         "esbuild": "^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0 || ^0.19.0"
       }
     },
-    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.6.tgz",
-      "integrity": "sha512-bSC9YVUjADDy1gae8RrioINU6e1lCkg3VGVwm0QQ2E1CWcC4gnMce9+B6RpxuSsrsXsk1yojn7sp1fnG8erE2g==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.6.tgz",
-      "integrity": "sha512-YnYSCceN/dUzUr5kdtUzB+wZprCafuD89Hs0Aqv9QSdwhYQybhXTaSTcrl6X/aWThn1a/j0eEpUBGOE7269REg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.6.tgz",
-      "integrity": "sha512-MVcYcgSO7pfu/x34uX9u2QIZHmXAB7dEiLQC5bBl5Ryqtpj9lT2sg3gNDEsrPEmimSJW2FXIaxqSQ501YLDsZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.6.tgz",
-      "integrity": "sha512-bsDRvlbKMQMt6Wl08nHtFz++yoZHsyTOxnjfB2Q95gato+Yi4WnRl13oC2/PJJA9yLCoRv9gqT/EYX0/zDsyMA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.6.tgz",
-      "integrity": "sha512-EnUwjRc1inT4ccZh4pB3v1cIhohE2S4YXlt1OvI7sw/+pD+dIE4smwekZlEPIwY6PhU6oDWwITrQQm5S2/iZgg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.6.tgz",
-      "integrity": "sha512-Uh3HLWGzH6FwpviUcLMKPCbZUAFzv67Wj5MTwK6jn89b576SR2IbEp+tqUHTr8DIl0iDmBAf51MVaP7pw6PY5Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.6.tgz",
-      "integrity": "sha512-7YdGiurNt7lqO0Bf/U9/arrPWPqdPqcV6JCZda4LZgEn+PTQ5SMEI4MGR52Bfn3+d6bNEGcWFzlIxiQdS48YUw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.6.tgz",
-      "integrity": "sha512-bUR58IFOMJX523aDVozswnlp5yry7+0cRLCXDsxnUeQYJik1DukMY+apBsLOZJblpH+K7ox7YrKrHmJoWqVR9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.6.tgz",
-      "integrity": "sha512-ujp8uoQCM9FRcbDfkqECoARsLnLfCUhKARTP56TFPog8ie9JG83D5GVKjQ6yVrEVdMie1djH86fm98eY3quQkQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.6.tgz",
-      "integrity": "sha512-y2NX1+X/Nt+izj9bLoiaYB9YXT/LoaQFYvCkVD77G/4F+/yuVXYCWz4SE9yr5CBMbOxOfBcy/xFL4LlOeNlzYQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.6.tgz",
-      "integrity": "sha512-09AXKB1HDOzXD+j3FdXCiL/MWmZP0Ex9eR8DLMBVcHorrWJxWmY8Nms2Nm41iRM64WVx7bA/JVHMv081iP2kUA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.6.tgz",
-      "integrity": "sha512-AmLhMzkM8JuqTIOhxnX4ubh0XWJIznEynRnZAVdA2mMKE6FAfwT2TWKTwdqMG+qEaeyDPtfNoZRpJbD4ZBv0Tg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.6.tgz",
-      "integrity": "sha512-Y4Ri62PfavhLQhFbqucysHOmRamlTVK10zPWlqjNbj2XMea+BOs4w6ASKwQwAiqf9ZqcY9Ab7NOU4wIgpxwoSQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.6.tgz",
-      "integrity": "sha512-SPUiz4fDbnNEm3JSdUW8pBJ/vkop3M1YwZAVwvdwlFLoJwKEZ9L98l3tzeyMzq27CyepDQ3Qgoba44StgbiN5Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.6.tgz",
-      "integrity": "sha512-a3yHLmOodHrzuNgdpB7peFGPx1iJ2x6m+uDvhP2CKdr2CwOaqEFMeSqYAHU7hG+RjCq8r2NFujcd/YsEsFgTGw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.6.tgz",
-      "integrity": "sha512-EanJqcU/4uZIBreTrnbnre2DXgXSa+Gjap7ifRfllpmyAU7YMvaXmljdArptTHmjrkkKm9BK6GH5D5Yo+p6y5A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.6.tgz",
-      "integrity": "sha512-xaxeSunhQRsTNGFanoOkkLtnmMn5QbA0qBhNet/XLVsc+OVkpIWPHcr3zTW2gxVU5YOHFbIHR9ODuaUdNza2Vw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.6.tgz",
-      "integrity": "sha512-gnMnMPg5pfMkZvhHee21KbKdc6W3GR8/JuE0Da1kjwpK6oiFU3nqfHuVPgUX2rsOx9N2SadSQTIYV1CIjYG+xw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.6.tgz",
-      "integrity": "sha512-G95n7vP1UnGJPsVdKXllAJPtqjMvFYbN20e8RK8LVLhlTiSOH1sd7+Gt7rm70xiG+I5tM58nYgwWrLs6I1jHqg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.6.tgz",
-      "integrity": "sha512-96yEFzLhq5bv9jJo5JhTs1gI+1cKQ83cUpyxHuGqXVwQtY5Eq54ZEsKs8veKtiKwlrNimtckHEkj4mRh4pPjsg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.6.tgz",
-      "integrity": "sha512-n6d8MOyUrNp6G4VSpRcgjs5xj4A91svJSaiwLIDWVWEsZtpN5FA9NlBbZHDmAJc2e8e6SF4tkBD3HAvPF+7igA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -14712,15 +15008,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/global-dirs/node_modules/ini": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -15681,12 +15968,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-      "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
       "dev": true,
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">=10"
       }
     },
     "node_modules/inline-style-parser": {
@@ -17961,9 +18248,9 @@
       }
     },
     "node_modules/lambda-runtimes": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lambda-runtimes/-/lambda-runtimes-2.0.2.tgz",
-      "integrity": "sha512-pGILm2NHRLtQr1f3E3Kbidou8H9bUFoAxB4pUNAv4NOnw+X4N3MQkoWjNY5f7JS+KJQjsr4mpFuCCqrH6wHf+Q==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/lambda-runtimes/-/lambda-runtimes-1.1.7.tgz",
+      "integrity": "sha512-VLQOAOsQMOv62LDC/lpZsaWZJFWWDrBUqsboIDwBIQ4KE212zakj4yqT8nIlPxtit+lWcER2ysrYAxR0ipnEug==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -25986,74 +26273,6 @@
         }
       }
     },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
-      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
-      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
-      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
-      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/vite/node_modules/@esbuild/darwin-x64": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
@@ -26065,295 +26284,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
-      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
-      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
-      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
-      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
-      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
-      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
-      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
-      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
-      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
-      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
-      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
-      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
-      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
-      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "usehooks-ts": "^3.0.2"
   },
   "devDependencies": {
-    "@architect/architect": "^11.0.12",
+    "@architect/architect": "^10.16.3",
     "@architect/plugin-lambda-invoker": "^1.2.0",
     "@architect/utils": "^3.1.9",
     "@aws-sdk/client-cognito-identity-provider": "^3.462.0",


### PR DESCRIPTION
This reverts commit cee27bd50c2275a712bc0d7103c271dff1b1e537.

The Architect update broke our deployment.
See https://github.com/architect/architect/issues/1483.