### PR TITLE
Reset Circulars search results on empty query

### DIFF
--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -151,7 +151,7 @@ export default function () {
   searchParams.delete('index')
 
   const limit = searchParams.get('limit') || '100'
-  const query = searchParams.get('query') || undefined
+  const query = searchParams.get('query') || ''
   const startDate = searchParams.get('startDate') || undefined
   const endDate = searchParams.get('endDate') || undefined
   const sort = searchParams.get('sort') || 'circularID'
@@ -187,6 +187,7 @@ export default function () {
       )}
       <ButtonGroup className="position-sticky top-0 bg-white margin-bottom-1 padding-top-1 z-300">
         <Form
+          preventScrollReset
           className="display-inline-block usa-search usa-search--small"
           role="search"
           id={formId}
@@ -204,7 +205,7 @@ export default function () {
             aria-describedby="searchHint"
             onChange={({ target: { form, value } }) => {
               setInputQuery(value)
-              if (!value) submit(form)
+              if (!value) submit(form, { preventScrollReset: true })
             }}
           />
           <Button type="submit">


### PR DESCRIPTION
The intended behavior of the search box on the Circulars archive page is:

- Hide the list of results and number of results when the user starts typing search terms.
- Display the list of results and number of results when the user submits the form.
- If the user does not submit the form, but wipes out the search terms either by deleting the text in the search box or by clicking the 'x', then show the Circulars (without filtering by search terms) once again.

This behavior broke when we added filtering by date. Fix it, and also prevent the scroll position from jumping when submitting or resetting the form.

Fixes #1110. Closes #2279.