### PR TITLE
Update esbuild target to node20

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -19,7 +19,7 @@ const options = {
   outExtension: { '.js': '.cjs' },
   external: ['@aws-sdk/*', 'aws-sdk'],
   platform: 'node',
-  target: ['node18'],
+  target: ['node20'],
   minify: !dev,
   sourcemap: dev,
 }


### PR DESCRIPTION
This is the minimum version of Node.js that we support, and it is also the version on which we deploy on AWS Lambda.