### PR TITLE
Install aarch64 Node.js deps in correct deployment job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: '20'
       - name: NPM Install
-        run: npm ci
+        run: npm ci --os=linux --cpu=arm64
       - name: Build
         run: npm run build
       - name: Upload artifacts
@@ -55,7 +55,7 @@ jobs:
         with:
           node-version: '20'
       - name: NPM Install
-        run: npm ci --os=linux --cpu=arm64
+        run: npm ci
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
We need to install aarch64 Node.js deps in the CI job that creates the Lambda deployment bundles.
