### PR TITLE
Schema Name Correction

### DIFF
--- a/app/routes/missions.burstcube/route.mdx
+++ b/app/routes/missions.burstcube/route.mdx
@@ -54,8 +54,8 @@ example [JSON message](/schema/stable/gcn/notices/burstcube/alert.example.json) 
 
 | Type             | Contents                 | Latency |
 | ---------------- | ------------------------ | ------- |
-| `Alert`          | Detection of a burst     | 5 min   |
-| `Alert` (update) | Localization HEALPix map | 15 min  |
+| `alert`          | Detection of a burst     | 5 min   |
+| `alert` (update) | Localization HEALPix map | 15 min  |
 
 </div>
 


### PR DESCRIPTION
# Description
The schema name convention is small case, and was corrected at gcn schema (https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/burstcube). 
While it isn't updated at Mission Page (https://gcn.nasa.gov/missions/burstcube).

