### PR TITLE
Install Node.js deps for both build platform and Lambda target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,9 @@ jobs:
         with:
           node-version: '20'
       - name: NPM Install
-        run: npm ci --os=linux --cpu=arm64
+        run: |
+          npm ci
+          npm i --os=linux --cpu=arm64
       - name: Build
         run: npm run build
       - name: Upload artifacts


### PR DESCRIPTION
We can't _only_ install Node.js deps for the Lambda target platform because the build platform itself contains some native code (e.g. rollup).