### PR TITLE
EP: Add schema related links

### DIFF
--- a/app/routes/missions.einstein-probe/route.mdx
+++ b/app/routes/missions.einstein-probe/route.mdx
@@ -38,7 +38,7 @@ Einstein Probe distributes alerts for the detection of gamma-ray transients. The
 The [GCN schema](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) and
 example [JSON message](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.example.json) files are available to use for [Einstein Probe Schema](/schema/stable/gcn/notices/einstein_probe). See the [Schema Browser](/docs/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) for more information on the properties defined in the schema.
 
-Detailed Description and Examples of EP Notices are available at [GCN Schema GitHub](https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/einstein_probe/wxt).
+Detailed description and examples of EP Notices are available in the [GCN Schema GitHub project](https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/einstein_probe/wxt).
 
 <div className="overflow-table">
 

--- a/app/routes/missions.einstein-probe/route.mdx
+++ b/app/routes/missions.einstein-probe/route.mdx
@@ -38,7 +38,7 @@ Einstein Probe distributes alerts for the detection of gamma-ray transients. The
 The [GCN schema](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) and
 example [JSON message](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.example.json) files are available to use for [Einstein Probe Schema](/schema/stable/gcn/notices/einstein_probe). See the [Schema Browser](/docs/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) for more information on the properties defined in the schema.
 
-[Detailed Description and Examples](https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/einstein_probe/wxt)
+Detailed Description and Examples of EP Notices can be found at [GCN Schema GitHub](https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/einstein_probe/wxt).
 
 <div className="overflow-table">
 

--- a/app/routes/missions.einstein-probe/route.mdx
+++ b/app/routes/missions.einstein-probe/route.mdx
@@ -38,7 +38,7 @@ Einstein Probe distributes alerts for the detection of gamma-ray transients. The
 The [GCN schema](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) and
 example [JSON message](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.example.json) files are available to use for [Einstein Probe Schema](/schema/stable/gcn/notices/einstein_probe). See the [Schema Browser](/docs/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) for more information on the properties defined in the schema.
 
-Detailed Description and Examples of EP Notices can be found at [GCN Schema GitHub](https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/einstein_probe/wxt).
+Detailed Description and Examples of EP Notices are available at [GCN Schema GitHub](https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/einstein_probe/wxt).
 
 <div className="overflow-table">
 

--- a/app/routes/missions.einstein-probe/route.mdx
+++ b/app/routes/missions.einstein-probe/route.mdx
@@ -33,6 +33,13 @@ The [Einstein Probe (EP)](https://ep.bao.ac.cn/ep/) is a mission of the Chinese 
 
 **JSON-Serialized GCN Notices Types in GCN Kafka:**
 
+Einstein Probe distributes alerts and localizations detections of gamma-ray transients. These notices are published on the GCN Kafka topic `gcn.notices.einstein_probe.wxt.alert`.
+
+The [GCN schema](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) and
+example [JSON message](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.example.json) files are available to use. See the [Schema Browser](/docs/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) for more information on the properties defined in the schema.
+
+[Detailed Description and Examples](https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/einstein_probe/wxt)
+
 <div className="overflow-table">
 
 | Type                                   | Contents                               | Latency |

--- a/app/routes/missions.einstein-probe/route.mdx
+++ b/app/routes/missions.einstein-probe/route.mdx
@@ -33,7 +33,7 @@ The [Einstein Probe (EP)](https://ep.bao.ac.cn/ep/) is a mission of the Chinese 
 
 **JSON-Serialized GCN Notices Types in GCN Kafka:**
 
-Einstein Probe distributes alerts and localizations detections of gamma-ray transients. These notices are published on the GCN Kafka topic `gcn.notices.einstein_probe.wxt.alert`.
+Einstein Probe distributes alerts for the detection of gamma-ray transients. These notices are published on the GCN Kafka topic `gcn.notices.einstein_probe.wxt.alert`.
 
 The [GCN schema](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) and
 example [JSON message](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.example.json) files are available to use for [Einstein Probe Schema](/schema/stable/gcn/notices/einstein_probe). See the [Schema Browser](/docs/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) for more information on the properties defined in the schema.

--- a/app/routes/missions.einstein-probe/route.mdx
+++ b/app/routes/missions.einstein-probe/route.mdx
@@ -36,7 +36,7 @@ The [Einstein Probe (EP)](https://ep.bao.ac.cn/ep/) is a mission of the Chinese 
 Einstein Probe distributes alerts and localizations detections of gamma-ray transients. These notices are published on the GCN Kafka topic `gcn.notices.einstein_probe.wxt.alert`.
 
 The [GCN schema](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) and
-example [JSON message](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.example.json) files are available to use. See the [Schema Browser](/docs/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) for more information on the properties defined in the schema.
+example [JSON message](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.example.json) files are available to use for [Einstein Probe Schema](/schema/stable/gcn/notices/einstein_probe). See the [Schema Browser](/docs/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) for more information on the properties defined in the schema.
 
 [Detailed Description and Examples](https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/einstein_probe/wxt)
 


### PR DESCRIPTION
# Description
EP mission page doesn't contain useful schema links.

# Related Issue(s)
Fix [#2359](https://github.com/nasa-gcn/gcn.nasa.gov/issues/2359)

P.S. Before merging this PR, schema should be updated to new version,
as EP alert.schema.example.json has changed to alert.example.json and need to be updated in Schema Browser.

