### PR TITLE
Close Kafka connection on SIGINT or SIGTERM, not beforeExit

### DIFF
--- a/app/lib/kafka.server.ts
+++ b/app/lib/kafka.server.ts
@@ -51,11 +51,13 @@ if (process.env.ARC_SANDBOX) {
     async () => {
       const producer = kafka.producer()
       await producer.connect()
-      process.once('beforeExit', async () => {
-        console.log('Disconnecting from Kafka')
-        await producer.disconnect()
-        console.log('Disconnected from Kafka')
-      })
+      ;['SIGINT', 'SIGTERM'].forEach((event) =>
+        process.once(event, async () => {
+          console.log('Disconnecting from Kafka')
+          await producer.disconnect()
+          console.log('Disconnected from Kafka')
+        })
+      )
       return producer
     },
     { promise: true }


### PR DESCRIPTION
The beforeExit event occurs when the runtime has drained the event loop and has no more work to perform, and is about to exit.

However the purpose of this signal handler is to disconnect the Kafka client which is holding some unsettled promises, which prevent beforeExit from ever being called.

Instead, handle SIGINT and SIGTERM events directly.