### PR TITLE
add doc link on Circular correction form

### DIFF
--- a/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
+++ b/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
@@ -158,6 +158,15 @@ export function CircularEditForm({
   return (
     <AstroDataContext.Provider value={{ rel: 'noopener', target: '_blank' }}>
       <h1>{headerText} GCN Circular</h1>
+      {intent === 'correction' && (
+        <p className="usa-paragraph">
+          See{' '}
+          <Link to="/docs/circulars/corrections">
+            documentation on Circulars moderation
+          </Link>{' '}
+          for more information on corrections.
+        </p>
+      )}
       <Form method="POST" action={`/circulars${formSearchString}`}>
         <input type="hidden" name="intent" value={intent} />
         {circularId !== undefined && (


### PR DESCRIPTION
# Description
We need to add a link to the docs about circular corrections. This work just adds a link to the form when the intent is to correct. 

# Related Issue(s)
Resolves #2222 

# Testing

<img width="1043" alt="Screenshot 2024-06-12 at 10 04 34 AM" src="https://github.com/nasa-gcn/gcn.nasa.gov/assets/6545874/db73c091-eb9d-4553-86c5-3b5d08e976b0">


I ran it locally, see image above. I made sure to check the edit path as well to ensure that it was not visible and didn't mess up styles when it doesn't show up.
