### PR TITLE
Correct Minor Typo in Circulars Archive Documentation

### DIFF
--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -7,7 +7,7 @@ import { Link } from '@remix-run/react'
 
 # Circulars Archive
 
-Upon successful submission and distribution, a GCN Circulars is assigned a number and stored permanently in the [GCN Circulars archive](/circulars). The archive lists links to the full text of every GCN Circular in reverse chronological order. The archive has a full-text search feature that you can use to find all Circulars that contain a phrase or keyword.
+Upon successful submission and distribution, a GCN Circular is assigned a number and stored permanently in the [GCN Circulars archive](/circulars). The archive lists links to the full text of every GCN Circular in reverse chronological order. The archive has a full-text search feature that you can use to find all Circulars that contain a phrase or keyword.
 
 <Link to="/circulars" className="usa-button">
   Go to GCN Circulars Archive


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
\"Circulars\" should be singular in the first sentence of the Circulars Archive docs. 
![image](https://github.com/nasa-gcn/gcn.nasa.gov/assets/57914086/46d1690d-13cb-47de-ba85-a59a09dc4dc4)

# Related Issue(s)
n/a

# Testing
1. Navigate to the Documentation page
2. On the navigation pane on the left side of the page, select "Circulars"
3. In the expanded sub-menu, select "Archive"
4. Look at the first sentence of the first paragraph
5. "Upon successful submission and distribution, a GCN Circulars" should now be "Upon successful submission and distribution, a GCN Circular"
