### PR TITLE
Debounce peer endorsement combo box

### DIFF
--- a/app/routes/user.endorsements/route.tsx
+++ b/app/routes/user.endorsements/route.tsx
@@ -17,8 +17,11 @@ import {
   TextInput,
 } from '@trussworks/react-uswds'
 import classnames from 'classnames'
-import { useCombobox } from 'downshift'
-import type { UseComboboxProps } from 'downshift'
+import {
+  type UseComboboxProps,
+  type UseComboboxStateChange,
+  useCombobox,
+} from 'downshift'
 import {
   forwardRef,
   useEffect,
@@ -26,7 +29,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import { useResizeObserver } from 'usehooks-ts'
+import { useDebounceCallback, useResizeObserver } from 'usehooks-ts'
 
 import { formatAuthor } from '../circulars/circulars.lib'
 import type {
@@ -385,6 +388,21 @@ const EndorserComboBox = forwardRef<
     setItems(fetcher.data?.submitters ?? [])
   }, [fetcher.data])
 
+  const onInputValueChange = useDebounceCallback(
+    ({ inputValue, isOpen }: UseComboboxStateChange<EndorsementUser>) => {
+      if (inputValue && isOpen) {
+        const data = new FormData()
+        data.set('filter', inputValue.split(' ')[0])
+        data.set('intent', 'filter')
+        fetcher.submit(data, { method: 'POST' })
+      } else {
+        setItems([])
+      }
+    },
+    500,
+    { trailing: true }
+  )
+
   const {
     reset,
     isOpen,
@@ -396,16 +414,7 @@ const EndorserComboBox = forwardRef<
     getToggleButtonProps,
   } = useCombobox<EndorsementUser>({
     items,
-    onInputValueChange({ inputValue, isOpen }) {
-      if (inputValue && isOpen) {
-        const data = new FormData()
-        data.set('filter', inputValue.split(' ')[0])
-        data.set('intent', 'filter')
-        fetcher.submit(data, { method: 'POST' })
-      } else {
-        setItems([])
-      }
-    },
+    onInputValueChange,
     itemToString(item) {
       return item ? formatAuthor(item) : ''
     },


### PR DESCRIPTION
# Description

If you typed rapidly, then the page would crash. In CloudWatch, we would see this error:

```
ERROR	TooManyRequestsException: Too many requests
    at de_TooManyRequestsExceptionRes (/var/runtime/node_modules/@aws-sdk/client-cognito-identity-provider/dist-cjs/index.js:4141:21)
    at de_CommandError (/var/runtime/node_modules/@aws-sdk/client-cognito-identity-provider/dist-cjs/index.js:3777:19)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at /var/runtime/node_modules/@aws-sdk/node_modules/@smithy/middleware-serde/dist-cjs/index.js:35:20
    at /var/runtime/node_modules/@aws-sdk/node_modules/@smithy/core/dist-cjs/index.js:165:18
    at /var/runtime/node_modules/@aws-sdk/node_modules/@smithy/middleware-retry/dist-cjs/index.js:320:38
    at /var/runtime/node_modules/@aws-sdk/middleware-logger/dist-cjs/index.js:33:22
    at makePagedClientRequest (/var/runtime/node_modules/@aws-sdk/node_modules/@smithy/core/dist-cjs/index.js:430:10)
    at paginateOperation (/var/runtime/node_modules/@aws-sdk/node_modules/@smithy/core/dist-cjs/index.js:443:16)
    at n8e (/var/task/index.cjs:900:1448) {
  '$fault': 'client',
  '$metadata': {
    httpStatusCode: 400,
    requestId: '...',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 3,
    totalRetryDelay: 1047
  },
  __type: 'TooManyRequestsException'
}
```

Debounce the combo box input handler to avoid rapid requests.

# Related Issue(s)
Fixes #2385.

# Testing
I've tested this locally, but we really need to deploy it in order to see if this fixes it because the error partly depends upon making real requests to Cognito.