### PR TITLE
Circulars: preserve search parameters when navigating to referenced circulars

### DIFF
--- a/app/routes/circulars.$circularId.($version)/AstroData.components.tsx
+++ b/app/routes/circulars.$circularId.($version)/AstroData.components.tsx
@@ -9,6 +9,7 @@ import { type LoaderFunction } from '@remix-run/node'
 import { type useLoaderData } from '@remix-run/react'
 
 import { AstroDataLinkWithTooltip } from './AstroDataContext'
+import { useSearchString } from '~/lib/utils'
 import { type loader as arxivTooltipLoader } from '~/routes/api.tooltip.arxiv.$'
 import { type loader as circularTooltipLoader } from '~/routes/api.tooltip.circular.$'
 import { type loader as doiTooltipLoader } from '~/routes/api.tooltip.doi.$'
@@ -29,9 +30,10 @@ export function GcnCircular({
   children,
   value,
 }: JSX.IntrinsicElements['data']) {
+  const searchString = useSearchString()
   return (
     <AstroDataLinkWithTooltip
-      to={`/circulars/${value}`}
+      to={`/circulars/${value}${searchString}`}
       fetch={() =>
         fetchTooltipData<typeof circularTooltipLoader>('circular', value)
       }


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
This modifies automatic hyperlinks to other Circulars by adding the current search parameters to the URL. This allows for the search to persist when navigating to a referenced Circular.

# Related Issue(s)
Resolves #2390 

# Testing
1. Initiate a search in the circular archive
2. Select a result that references a second circular
3. Click on hyperlink to the second circular
4. Navigate back to the Circular archive by pressing the back button while on the second circular's page
5. The search parameters from the initial search should still be present.
