### PR TITLE
Add more ESM-only packages

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -14,6 +14,7 @@ const isProduction = process.env.NODE_ENV === 'production'
 const esmOnlyModules = [
   '@nasa-gcn/remark-rehype-astro',
   'bail',
+  'before-after-hook',
   'bcp-47-match',
   'ccount',
   'character-entities',
@@ -31,8 +32,10 @@ const esmOnlyModules = [
   'trim-lines',
   'trough',
   'unified',
+  'universal-user-agent',
   'web-namespaces',
   'zwitch',
+  /^@octokit/,
   /^hast/,
   /^mdast/,
   /^micromark/,


### PR DESCRIPTION
PR #2395 added some more ESM-only modules, breaking local development. Add them to the list of ESM-only modules which must always be bundled.
