### PR TITLE
Add SVOM JSON Notices to Quickstart UI

### DIFF
--- a/app/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes.tsx
+++ b/app/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes.tsx
@@ -196,6 +196,7 @@ const JsonNoticeTypes: { [key: string]: string[] } = {
   LVK: ['igwn.gwalert'],
   Swift: ['gcn.notices.swift.bat.guano'],
   'Einstein Probe': ['gcn.notices.einstein_probe.wxt.alert'],
+  SVOM: ['gcn.notices.svom'],
 }
 
 const JsonNoticeTypeLinks: { [key: string]: string | undefined } = {
@@ -204,6 +205,7 @@ const JsonNoticeTypeLinks: { [key: string]: string | undefined } = {
   LVK: 'https://emfollow.docs.ligo.org/userguide/tutorial/receiving/gcn.html#receiving-and-parsing-notices',
   Swift: '/missions/swift',
   'Einstein Probe': '/missions/einstein-probe',
+  SVOM: '/missions/svom',
 }
 
 interface NoticeTypeCheckboxProps {

--- a/app/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes.tsx
+++ b/app/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react'
 import type { NoticeFormat } from '../NoticeFormat'
 import { NestedCheckboxes } from '../nested-checkboxes/NestedCheckboxes'
 import { triggerRate } from './rates'
+import { useFeature } from '~/root'
 
 const minRate = 1 / 7
 
@@ -196,7 +197,6 @@ const JsonNoticeTypes: { [key: string]: string[] } = {
   LVK: ['igwn.gwalert'],
   Swift: ['gcn.notices.swift.bat.guano'],
   'Einstein Probe': ['gcn.notices.einstein_probe.wxt.alert'],
-  SVOM: ['gcn.notices.svom'],
 }
 
 const JsonNoticeTypeLinks: { [key: string]: string | undefined } = {
@@ -205,7 +205,6 @@ const JsonNoticeTypeLinks: { [key: string]: string | undefined } = {
   LVK: 'https://emfollow.docs.ligo.org/userguide/tutorial/receiving/gcn.html#receiving-and-parsing-notices',
   Swift: '/missions/swift',
   'Einstein Probe': '/missions/einstein-probe',
-  SVOM: '/missions/svom',
 }
 
 interface NoticeTypeCheckboxProps {
@@ -222,6 +221,11 @@ export function NoticeTypeCheckboxes({
   const [userSelected, setUserSelected] = useState(new Set<string>())
   const [selectedCounter, setSelectedCounter] = useState(0)
   const [alertEstimate, setAlertEstimate] = useState(0)
+
+  if (useFeature('SVOM_QUICKSTART')) {
+    JsonNoticeTypes.SVOM = ['gcn.notices.svom']
+    JsonNoticeTypeLinks.SVOM = '/missions/svom'
+  }
 
   const counterfunction = (childRef: HTMLInputElement) => {
     if (childRef.checked) {

--- a/app/components/NoticeTypeCheckboxes/rates.ts
+++ b/app/components/NoticeTypeCheckboxes/rates.ts
@@ -274,4 +274,5 @@ export const triggerRate: Record<string, number> = {
   'gcn.notices.swift.bat.guano': 0.0,
   'igwn.gwalert': 90.42857142857143,
   'gcn.notices.einstein_probe.wxt.alert': 0.27,
+  'gcn.notices.svom': 0,
 }


### PR DESCRIPTION
adds SVOM as an option to the quickstart/ need to hide behind feature flag still

<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
This adds SVOM to the quickstart notices

# Related Issue(s)
Resolves #2274 

# Testing
1. Navigate to step 3 of the notices quickstart (customize alerts)
2. Select the JSON notice format
3. SVOM should be available (though the details link will be a dead link due to #2175 not being merged)
