### PR TITLE
Set noopener, not noreferrer

### DIFF
--- a/app/components/nested-checkboxes/NestedCheckboxes.tsx
+++ b/app/components/nested-checkboxes/NestedCheckboxes.tsx
@@ -85,7 +85,7 @@ function NestedCheckboxNode({
                 className="usa-link"
                 to={link}
                 target="_blank"
-                rel={isExternal ? 'noreferrer' : undefined}
+                rel={isExternal ? 'noopener' : undefined}
                 onClick={(e) => {
                   e.stopPropagation()
                 }}


### PR DESCRIPTION
Noopener prevents the newly opened page from interacting with the old one via JavaScript. Noreferrer prevents sending any tracking data. I am concerned about the former, not the latter.