### PR TITLE
Allow for testing of different roles in playwright config

### DIFF
--- a/__playwright__/admin.setup.ts
+++ b/__playwright__/admin.setup.ts
@@ -1,0 +1,18 @@
+import { expect, test as setup } from '@playwright/test'
+
+const authFile = '__playwright__/.auth/adminUser.json'
+
+const testAdminUsername = 'admin'
+const testAdminPassword = 'TEST_PASSWORD'
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/login')
+  await page.getByPlaceholder('Enter any login').fill(testAdminUsername)
+  await page.getByPlaceholder('and password').fill(testAdminPassword)
+  await page.getByRole('button', { name: 'Sign-in' }).click()
+  await page.waitForURL('/')
+  await expect(
+    page.getByRole('button', { name: 'admin@example.com' })
+  ).toBeVisible()
+  await page.context().storageState({ path: authFile })
+})

--- a/__playwright__/admin/admin.spec.ts
+++ b/__playwright__/admin/admin.spec.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('Example Admin Test Suite', () => {
+  test('has title', async ({ page }) => {
+    await page.goto('/')
+
+    // Expect a title "to contain" a substring.
+    await expect(page).toHaveTitle('GCN - General Coordinates Network')
+  })
+})

--- a/__playwright__/auth.setup.ts
+++ b/__playwright__/auth.setup.ts
@@ -6,9 +6,6 @@ const testUsername = 'TEST_USERNAME'
 const testPassword = 'TEST_PASSWORD'
 
 setup('authenticate', async ({ page }) => {
-  // Perform authentication steps. Replace these actions with your own.
-  if (!testUsername || !testPassword)
-    throw new Error('Please define test account info')
   await page.goto('/login')
   await page.getByPlaceholder('Enter any login').fill(testUsername)
   await page.getByPlaceholder('and password').fill(testPassword)

--- a/__playwright__/circulars/edit.spec.ts
+++ b/__playwright__/circulars/edit.spec.ts
@@ -54,26 +54,27 @@ test.describe('Circulars edit page', () => {
     )
   })
 
-  test('submits expected values', async ({ page }) => {
+  test('submits expected values', async ({ page, browserName }) => {
     test.slow()
+    const testSubject = `${editTestsCircular.subject} - ${browserName}`
     await page.goto(`/circulars/edit/${editTestsCircular.circularId}`)
     await page.locator('#submitter').fill(editTestsCircular.submitter)
     await page
       .getByTestId('date-picker-external-input')
       .fill(editTestsCircular.date)
     await page.getByTestId('combo-box-input').fill(editTestsCircular.time)
-    await page.locator('#subject').fill(editTestsCircular.subject)
+    await page.locator('#subject').fill(testSubject)
     await page.getByTestId('textarea').fill(editTestsCircular.body)
     await page.getByRole('button', { name: 'Update' }).click({ timeout: 10000 })
     await page.waitForURL('/circulars?index')
     await expect(
       page.getByRole('link', {
-        name: editTestsCircular.subject,
+        name: testSubject,
       })
     ).toBeVisible()
     await page
       .getByRole('link', {
-        name: editTestsCircular.subject,
+        name: testSubject,
       })
       .click({ timeout: 10000 })
   })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,32 @@ import { defineConfig, devices } from '@playwright/test'
  */
 // require('dotenv').config();
 
+const deviceList = ['Desktop Firefox', 'Desktop Chrome', 'Desktop Safari']
+
+const adminTests = deviceList.map((device) => {
+  return {
+    name: `Admin tests: ${device}`,
+    use: {
+      ...devices[device],
+      storageState: '__playwright__/.auth/adminUser.json',
+    },
+    testMatch: 'admin.spec.ts',
+    dependencies: ['adminSetup'],
+  }
+})
+
+const circularsTests = deviceList.map((device) => {
+  return {
+    name: `Circulars Tests: ${device}`,
+    use: {
+      ...devices[device],
+      storageState: '__playwright__/.auth/user.json',
+    },
+    testMatch: 'circulars/*',
+    dependencies: ['setup'],
+  }
+})
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -32,53 +58,10 @@ export default defineConfig({
 
   /* Configure projects for major browsers */
   projects: [
-    { name: 'setup', testMatch: /.*\.setup\.ts/ },
-    {
-      name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome'],
-        storageState: '__playwright__/.auth/user.json',
-      },
-      dependencies: ['setup'],
-    },
-
-    {
-      name: 'firefox',
-      use: {
-        ...devices['Desktop Firefox'],
-        storageState: '__playwright__/.auth/user.json',
-      },
-      dependencies: ['setup'],
-    },
-
-    {
-      name: 'webkit',
-      use: {
-        ...devices['Desktop Safari'],
-        storageState: '__playwright__/.auth/user.json',
-      },
-      dependencies: ['setup'],
-    },
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
+    { name: 'setup', testMatch: 'auth.setup.ts' },
+    { name: 'adminSetup', testMatch: 'admin.setup.ts' },
+    ...adminTests,
+    ...circularsTests,
   ],
 
   /* Run your local dev server before starting the tests */

--- a/src/plugins/sandboxOidcIdp.js
+++ b/src/plugins/sandboxOidcIdp.js
@@ -30,6 +30,27 @@ export const set = {
   },
 }
 
+const localSandboxProfiles = {
+  admin: {
+    sub: '1234abcd-1234-abcd-1234-abcd1234abcd',
+    email: 'admin@example.com',
+    'cognito:username': 'admin@example.com',
+    'cognito:groups': ['gcn.nasa.gov/gcn-admin'],
+    identities: [{ providerName: 'Local Sandbox' }],
+  },
+  default: {
+    sub: '1234abcd-1234-abcd-1234-abcd1234abcd',
+    email: 'user@example.com',
+    'cognito:username': 'user@example.com',
+    'cognito:groups': [
+      'gcn.nasa.gov/kafka-public-consumer',
+      'gcn.nasa.gov/circular-submitter',
+      'gcn.nasa.gov/circular-moderator',
+    ],
+    identities: [{ providerName: 'Local Sandbox' }],
+  },
+}
+
 export const sandbox = {
   async start() {
     if (!process.env.ARC_OIDC_IDP_PORT) return
@@ -42,17 +63,7 @@ export const sandbox = {
         return {
           accountId: id,
           claims() {
-            return {
-              sub: id,
-              email: 'user@example.com',
-              'cognito:username': id,
-              'cognito:groups': [
-                'gcn.nasa.gov/kafka-public-consumer',
-                'gcn.nasa.gov/circular-submitter',
-                'gcn.nasa.gov/circular-moderator',
-              ],
-              identities: [{ providerName: 'Local Sandbox' }],
-            }
+            return localSandboxProfiles[id] ?? localSandboxProfiles['default']
           },
         }
       },


### PR DESCRIPTION
# Description
- Updates the Playwright config to show how we can create projects to run with different roles (i.e. circular submitters, moderators, admins, etc.)
- Updates the sandbox to allow us to define profiles for different use cases and includes an example admin role
