### PR TITLE
Circulars: retain URL search parameters when switching versions of a circular

### DIFF
--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -157,6 +157,7 @@ function CircularsHistory({
 }) {
   const ref = useRef<HTMLDivElement>(null)
   const [showContent, setShowContent] = useState(false)
+  const searchString = useSearchString()
   useOnClickOutside(ref, () => {
     setShowContent(false)
   })
@@ -184,7 +185,7 @@ function CircularsHistory({
                 <div key={version}>
                   <Link
                     onClick={() => setShowContent(!showContent)}
-                    to={`/circulars/${circular}/${version}`}
+                    to={`/circulars/${circular}/${version}${searchString}`}
                   >
                     Version {version}
                   </Link>


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
This changes the Circulars version selector so that it also includes the URL search parameters included at the time of navigation to the circular. 

# Related Issue(s)
Resolves #2443 

# Testing
1. Initiate a search 
2. Navigate to a circular that has multiple versions (example: [Circular 34776](https://gcn.nasa.gov/circulars/34776))
3. Select an older version of the circular
4. When the page reloads, the URL should still contain the search parameters
5. Pressing the return button on the page should also result in the original search output being loaded (see #967)
