### PR TITLE
Husky hooks no longer need to be run with npx

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+lint-staged


### PR DESCRIPTION
See https://github.com/typicode/husky/releases/tag/v9.1.0.