### PR TITLE
Fix broken link in doc on consuming notices

### DIFF
--- a/app/routes/docs.notices.consuming.mdx
+++ b/app/routes/docs.notices.consuming.mdx
@@ -20,7 +20,7 @@ Subscriptions to notices via Kafka provides pipelines and robotic telescopes a r
 
 See our [Start Streaming GCN Notices quick start guide](/quickstart) for a step-by-step walkthrough to begin streaming alerts now.
 
-See our [Kafka client setup](/client) for more details about configuring your client to receive Notices, and the lightweight wrappers in [Python](https://github.com/nasa-gcn/gcn-kafka-python), [Node.js](https://github.com/nasa-gcn/gcn-kafka-js), C, and C#.
+See our [Kafka client setup](/docs/client) for more details about configuring your client to receive Notices, and the lightweight wrappers in [Python](https://github.com/nasa-gcn/gcn-kafka-python), [Node.js](https://github.com/nasa-gcn/gcn-kafka-js), C, and C#.
 
 ## Receiving Notices via Email
 


### PR DESCRIPTION
# Description
I found a broken link in the docs on consuming notices. This PR corrects it.

# Related Issue(s)
Closes #2477 