### PR TITLE
Fix rate limiting due to improperly debounced auto complete

### DIFF
--- a/app/routes/user.endorsements/route.tsx
+++ b/app/routes/user.endorsements/route.tsx
@@ -22,14 +22,16 @@ import {
   type UseComboboxStateChange,
   useCombobox,
 } from 'downshift'
+import debounce from 'lodash/debounce'
 import {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useRef,
   useState,
 } from 'react'
-import { useDebounceCallback, useResizeObserver } from 'usehooks-ts'
+import { useResizeObserver } from 'usehooks-ts'
 
 import { formatAuthor } from '../circulars/circulars.lib'
 import type {
@@ -392,19 +394,23 @@ const EndorserComboBox = forwardRef<
     setItems(fetcher.data?.submitters ?? [])
   }, [fetcher.data])
 
-  const onInputValueChange = useDebounceCallback(
-    ({ inputValue, isOpen }: UseComboboxStateChange<EndorsementUser>) => {
-      if (inputValue && isOpen) {
-        const data = new FormData()
-        data.set('filter', inputValue.split(' ')[0])
-        data.set('intent', 'filter')
-        fetcher.submit(data, { method: 'POST' })
-      } else {
-        setItems([])
-      }
-    },
-    500,
-    { trailing: true }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const onInputValueChange = useCallback(
+    debounce(
+      ({ inputValue, isOpen }: UseComboboxStateChange<EndorsementUser>) => {
+        if (inputValue && isOpen) {
+          const data = new FormData()
+          data.set('filter', inputValue.split(' ')[0])
+          data.set('intent', 'filter')
+          fetcher.submit(data, { method: 'POST' })
+        } else {
+          setItems([])
+        }
+      },
+      500,
+      { trailing: true }
+    ),
+    []
   )
 
   const {


### PR DESCRIPTION
In this context, the `useDebouncedCallback` hook is not working. Although it delays the execution of the callback until `wait` seconds of inactivity have passed, it does not decrease the _number_ of executions --- it just bunches them all together at once. As a result, we exceed the Cognito rate limit and the page crashes.

Instead, use the Lodash `debounce` method directly. In my local sandbox environment, I observe that this approach does result in properly debounced invocations of the callback.