### PR TITLE
Circulars - Lucene search documentation

### DIFF
--- a/app/routes/docs.circulars.advanced-search.mdx
+++ b/app/routes/docs.circulars.advanced-search.mdx
@@ -20,16 +20,16 @@ Searches can be performed by specifying the field and search term. The syntax fo
 
 The following fields are supported: `subject`, `body`, and `submitter`.
 
-By default, a query that does not contain lucene syntax will attempt to match the query against all 3 fields. For example, the query `SWIFT` will match any circular that contains the word 'SWIFT' in the subject, body, or submitter fields, whereas the query `subject:"SWIFT"` will only match circulars where the subject contains the word 'SWIFT'.
+By default, a query that does not contain lucene syntax will attempt to match the query against all 3 fields. For example, the query `Swift` will match any circular that contains the word 'Swift' in the subject, body, or submitter fields, whereas the query `subject:"Swift"` will only match circulars where the subject contains the word 'Swift'.
 
 ## Compound Queries
 
 These separate field queries can be combined using additional keywords to form compound queries. The following keywords are supported:
 
-- `AND`: The AND operator requires that both conditions are met. For example, `subject:"SWIFT" AND body:"GRB"` will match circulars where the subject contains 'SWIFT' and the body contains 'GRB'.
-- `OR`: The OR operator requires that at least one condition is met. For example, `subject:"SWIFT" OR body:"GRB"` will match circulars where the subject contains 'SWIFT' or the body contains 'GRB'.
+- `AND`: The AND operator requires that both conditions are met. For example, `subject:"Swift" AND body:"GRB"` will match circulars where the subject contains 'Swift' and the body contains 'GRB'.
+- `OR`: The OR operator requires that at least one condition is met. For example, `subject:"Swift" OR body:"GRB"` will match circulars where the subject contains 'Swift' or the body contains 'GRB'.
 
-By default, the AND operator is used if no operator is specified. For example, `subject:"SWIFT" body:"GRB"` is equivalent to `subject:"SWIFT" AND body:"GRB"`.
+By default, the AND operator is used if no operator is specified. For example, `subject:"Swift" body:"GRB"` is equivalent to `subject:"Swift" AND body:"GRB"`.
 
 ## Wildcards
 
@@ -40,10 +40,10 @@ Wildcards can be used to match a patterned search term to a field, such as searc
 
 ## Examples
 
-- `SWIFT`: Matches circulars where the subject, body, or submitter contains 'SWIFT'.
-- `subject:"SWIFT"`: Matches circulars where the subject contains 'SWIFT'.
-- `body:"SWIFT"`: Matches circulars where the body contains 'SWIFT'.
-- `subject:"SWIFT" AND body:"GRB"`: Matches circulars where the subject contains 'SWIFT' and the body contains 'GRB'.
-- `subject:"SWIFT" OR body:"GRB"`: Matches circulars where the subject contains 'SWIFT' or the body contains 'GRB'.
+- `Swift`: Matches circulars where the subject, body, or submitter contains 'Swift'.
+- `subject:"Swift"`: Matches circulars where the subject contains 'Swift'.
+- `body:"Swift"`: Matches circulars where the body contains 'Swift'.
+- `subject:"Swift" AND body:"GRB"`: Matches circulars where the subject contains 'Swift' and the body contains 'GRB'.
+- `subject:"Swift" OR body:"GRB"`: Matches circulars where the subject contains 'Swift' or the body contains 'GRB'.
 - `subject:"GRB21*"`: Matches circulars where the subject contains 'GRB21' followed by any number of characters.
 - `subject:"GRB21?"`: Matches circulars where the subject contains 'GRB21' followed by a single character.

--- a/app/routes/docs.circulars.advanced-search.mdx
+++ b/app/routes/docs.circulars.advanced-search.mdx
@@ -1,6 +1,6 @@
 ---
 handle:
-  breadcrumb: Lucene Search
+  breadcrumb: Advanced Search
 ---
 
 import { feature } from '~/lib/env.server'
@@ -10,7 +10,7 @@ export function loader() {
   else throw new Response(null, { status: 404 })
 }
 
-# Lucene Search
+# Advanced Search
 
 The full-text search feature allows for searching keywords in a specific field of the circular. The search feature uses the [Lucene query syntax](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html) to specify the field and search term.
 

--- a/app/routes/docs.circulars.lucene.mdx
+++ b/app/routes/docs.circulars.lucene.mdx
@@ -1,0 +1,8 @@
+import { feature } from '~/lib/env.server'
+
+export function loader() {
+  if (feature('CIRCULARS_LUCENE')) return null
+  else throw new Response(null, { status: 404 })
+
+
+}

--- a/app/routes/docs.circulars.lucene.mdx
+++ b/app/routes/docs.circulars.lucene.mdx
@@ -12,10 +12,44 @@ export function loader() {
 
 # Lucene Search
 
-The Circulars Archive now has a full-text search feature that allows for specifying the field a search term should match. The search feature uses the [Lucene query syntax](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html) to specify the field and search term. The search feature supports the following fields:
+The full-text search feature allows for searching keywords in a specific field of the circular. The search feature uses the [Lucene query syntax](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html) to specify the field and search term. 
+
+## Searching by Field
+
+Searches can be performed by specifying the field and search term. The syntax for this is `field:"search term"`. For example, to search for circulars with the word 'SWIFT' in the subject field, the query would be `subject:"SWIFT"`.
+
+The following fields are supported:
 
 - Subject: `subject`
 - Body: `body`
 - Submitter: `submitter`
 
-By default, a query that does not contain lucene syntax will attempt to match the query against all 3 fields. For example, the query 'SWIFT' will match any circular that contains the word 'SWIFT' in the subject, body, or submitter fields, whereas the query 'subect:SWIFT' will only match circulars where the subject contains the word 'SWIFT'.
+By default, a query that does not contain lucene syntax will attempt to match the query against all 3 fields. For example, the query `SWIFT` will match any circular that contains the word 'SWIFT' in the subject, body, or submitter fields, whereas the query `subject:"SWIFT"` will only match circulars where the subject contains the word 'SWIFT'.
+
+## Compound Queries
+
+These separate field queries can be combined using additional keywords to form compound queries. The following keywords are supported:
+
+- `AND`: The AND operator requires that both conditions are met. For example, `subject:"SWIFT" AND body:"GRB"` will match circulars where the subject contains 'SWIFT' and the body contains 'GRB'.
+- `OR`: The OR operator requires that at least one condition is met. For example, `subject:"SWIFT" OR body:"GRB"` will match circulars where the subject contains 'SWIFT' or the body contains 'GRB'.
+
+By default, the AND operator is used if no operator is specified. For example, `subject:"SWIFT" body:"GRB"` is equivalent to `subject:"SWIFT" AND body:"GRB"`.
+
+## Wildcards
+
+Wildcards can be used to match a patterned search term to a field, such as searching for all Circulars related to GRBs detected in a given year by using the query `subject:"GRB21*"`. The following wildcards are supported:
+
+- `*`: Matches any number of characters.
+- `?`: Matches a single character.
+
+## Examples
+
+- `SWIFT`: Matches circulars where the subject, body, or submitter contains 'SWIFT'.
+- `subject:"SWIFT"`: Matches circulars where the subject contains 'SWIFT'.
+- `body:"SWIFT"`: Matches circulars where the body contains 'SWIFT'.
+- `subject:"SWIFT" AND body:"GRB"`: Matches circulars where the subject contains 'SWIFT' and the body contains 'GRB'.
+- `subject:"SWIFT" OR body:"GRB"`: Matches circulars where the subject contains 'SWIFT' or the body contains 'GRB'.
+- `subject:"GRB21*"`: Matches circulars where the subject contains 'GRB21' followed by any number of characters.
+- `subject:"GRB21?"`: Matches circulars where the subject contains 'GRB21' followed by a single character.
+
+

--- a/app/routes/docs.circulars.lucene.mdx
+++ b/app/routes/docs.circulars.lucene.mdx
@@ -12,7 +12,7 @@ export function loader() {
 
 # Lucene Search
 
-The full-text search feature allows for searching keywords in a specific field of the circular. The search feature uses the [Lucene query syntax](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html) to specify the field and search term. 
+The full-text search feature allows for searching keywords in a specific field of the circular. The search feature uses the [Lucene query syntax](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html) to specify the field and search term.
 
 ## Searching by Field
 
@@ -51,5 +51,3 @@ Wildcards can be used to match a patterned search term to a field, such as searc
 - `subject:"SWIFT" OR body:"GRB"`: Matches circulars where the subject contains 'SWIFT' or the body contains 'GRB'.
 - `subject:"GRB21*"`: Matches circulars where the subject contains 'GRB21' followed by any number of characters.
 - `subject:"GRB21?"`: Matches circulars where the subject contains 'GRB21' followed by a single character.
-
-

--- a/app/routes/docs.circulars.lucene.mdx
+++ b/app/routes/docs.circulars.lucene.mdx
@@ -16,7 +16,7 @@ The full-text search feature allows for searching keywords in a specific field o
 
 ## Searching by Field
 
-Searches can be performed by specifying the field and search term. The syntax for this is `field:"search term"`. For example, to search for circulars with the word 'SWIFT' in the subject field, the query would be `subject:"SWIFT"`.
+Searches can be performed by specifying the field and search term. The syntax for this is `field:"search term"`. For example, to search for circulars with the word 'Swift' in the subject field, the query would be `subject:"Swift"`.
 
 The following fields are supported:
 

--- a/app/routes/docs.circulars.lucene.mdx
+++ b/app/routes/docs.circulars.lucene.mdx
@@ -18,11 +18,7 @@ The full-text search feature allows for searching keywords in a specific field o
 
 Searches can be performed by specifying the field and search term. The syntax for this is `field:"search term"`. For example, to search for circulars with the word 'Swift' in the subject field, the query would be `subject:"Swift"`.
 
-The following fields are supported:
-
-- Subject: `subject`
-- Body: `body`
-- Submitter: `submitter`
+The following fields are supported: `subject`, `body`, and `submitter`.
 
 By default, a query that does not contain lucene syntax will attempt to match the query against all 3 fields. For example, the query `SWIFT` will match any circular that contains the word 'SWIFT' in the subject, body, or submitter fields, whereas the query `subject:"SWIFT"` will only match circulars where the subject contains the word 'SWIFT'.
 

--- a/app/routes/docs.circulars.lucene.mdx
+++ b/app/routes/docs.circulars.lucene.mdx
@@ -1,8 +1,21 @@
+---
+handle:
+  breadcrumb: Lucene Search
+---
+
 import { feature } from '~/lib/env.server'
 
 export function loader() {
   if (feature('CIRCULARS_LUCENE')) return null
   else throw new Response(null, { status: 404 })
-
-
 }
+
+# Lucene Search
+
+The Circulars Archive now has a full-text search feature that allows for specifying the field a search term should match. The search feature uses the [Lucene query syntax](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html) to specify the field and search term. The search feature supports the following fields:
+
+- Subject: `subject`
+- Body: `body`
+- Submitter: `submitter`
+
+By default, a query that does not contain lucene syntax will attempt to match the query against all 3 fields. For example, the query 'SWIFT' will match any circular that contains the word 'SWIFT' in the subject, body, or submitter fields, whereas the query 'subect:SWIFT' will only match circulars where the subject contains the word 'SWIFT'.

--- a/app/routes/docs.tsx
+++ b/app/routes/docs.tsx
@@ -9,6 +9,7 @@ import { Link, NavLink, Outlet } from '@remix-run/react'
 import { GridContainer } from '@trussworks/react-uswds'
 
 import { SideNav, SideNavSub } from '~/components/SideNav'
+import { useFeature } from '~/root'
 import type { BreadcrumbHandle } from '~/root/Title'
 
 export const handle: BreadcrumbHandle = {
@@ -53,6 +54,14 @@ export default function () {
                     <NavLink key="markdown" to="circulars/markdown">
                       Markdown
                     </NavLink>,
+                    useFeature('CIRCULARS_LUCENE') && (
+                      <NavLink
+                        key="advanced-search"
+                        to="circulars/advanced-search"
+                      >
+                        Advanced Search
+                      </NavLink>
+                    ),
                   ]}
                 />
               </>,


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
This adds basic documentation for the Lucene search, hidden behind a feature flag.

# Related Issue(s)

#2288, #2501 

# Testing
1. Add `CIRCULARS_LUCENE` feature flag to `.env` 
2. Navigate directly to http://localhost:3333/docs/circulars/lucene
3. Read Documentation

1. Remove `CIRCULARS_LUCENE` feature flag from `.env` 
2. Navigate directly to http://localhost:3333/docs/circulars/lucene
3. Page should not load
