### PR TITLE
Circulars - Add Documentation for the Circulars Archive Search Functionality

### DIFF
--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -15,9 +15,9 @@ Upon successful submission and distribution, a GCN Circular is assigned a number
 
 ## Searching the Archive
 
-Following the migration of the GCN Circulars archive from the GCN Classic Circulars archive, a search functionality was added to enable users to search the archive by keyword. The Circulars archive uses [OpenSearch](https://opensearch.org) to index the subject, body, and submitter of all Circulars in the archive. Upon initiating a query, the search feature will return all Circulars that match the query in any of these fields. By default, the results will be returned in reverse chronological order, but users can also choose to sort the results by relevance. At the bottom of the archive page, users can navigate through the search results using the pagination controls and specify the number of results to display per page.
+The Circulars archive includes a search functionality to enable you to find specific Circulars via keyword. This search tool indexes the subject, body, and submitter of all Circulars in the archive. Upon initiating a query, the search feature will return all Circulars that match the query in any of these fields. By default, the results will be returned in reverse chronological order, but you can also choose to sort the results by relevance. You can navigate through the search results using pagination controls and specify the number of results to display per page.
 
-Additionally, users can filter search results by the date of their submission. This is accomplished selecting the dropdown button immediately to the right of the search bar. From there, users can either select from a number of predefined time ranges (e.g., "Last Hour", "Last Day", etc.) or specify a custom date range, which can either be set as a start date, an end date, or both. All search filters can be cleared by clicking the x button inside of the search bar.
+Additionally, you can filter search results by the date of their submission. This is accomplished selecting the dropdown button labeled "Filter by date". From there, you can either select from a number of predefined time ranges (e.g., "Last Hour", "Last Day", etc.) or specify a custom date range, which can either be set as a start date, an end date, or both. All search filters can be cleared by clicking the 'x' button inside of the search bar.
 
 ## Citing GCN Circulars
 

--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -15,9 +15,9 @@ Upon successful submission and distribution, a GCN Circular is assigned a number
 
 ## Searching the Archive
 
-The Circulars archive includes a search functionality to enable you to find specific Circulars via keyword. This search tool indexes the subject, body, and submitter of all Circulars in the archive. Upon initiating a query, the search feature will return all Circulars that match the query in any of these fields. By default, the results will be returned in reverse chronological order, but you can also choose to sort the results by relevance. You can navigate through the search results using pagination controls and specify the number of results to display per page.
+You can search the Circulars Archive by keyword. This search tool indexes the subject, body, and submitter of all Circulars. Upon initiating a query, the search tool will return all Circulars that match the query in any of these fields. By default, results will be returned in reverse chronological order, but you can also choose to sort the results by relevance. You can navigate through the search results using pagination controls and specify the number of results to display per page. By default, 100 results are displayed per page.
 
-Additionally, you can filter search results by the date of their submission. This is accomplished selecting the dropdown button labeled "Filter by date". From there, you can either select from a number of predefined time ranges (e.g., "Last Hour", "Last Day", etc.) or specify a custom date range, which can either be set as a start date, an end date, or both. All search filters can be cleared by clicking the 'x' button inside of the search bar.
+Additionally, you can filter search results by the date of their submission. Select the dropdown button labeled "Filter by date". From there, you can either select from a number of predefined time ranges (e.g., "Last Hour", "Last Day", etc.) or specify a custom date range, which can either be set as a start date, an end date, or both. All search filters can be cleared by clicking the 'x' button in the search bar.
 
 ## Citing GCN Circulars
 

--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -15,7 +15,7 @@ Upon successful submission and distribution, a GCN Circular is assigned a number
 
 ## Searching the Archive
 
-You can search the Circulars Archive by keyword. This search tool indexes the subject, body, and submitter of all Circulars. Upon initiating a query, the search tool will return all Circulars that match the query in any of these fields. By default, results will be returned in reverse chronological order, but you can also choose to sort the results by relevance. You can navigate through the search results using pagination controls and specify the number of results to display per page. By default, 100 results are displayed per page.
+You can search the Circulars Archive by keywords or phrases in the subject, body, and submitter fields. By default, results will be returned in reverse chronological order, but you can also choose to sort the results by relevance. You can navigate through the search results using pagination controls and specify the number of results to display per page. By default, 100 results are displayed per page.
 
 Additionally, you can filter search results by the date of their submission. Select the dropdown button labeled "Filter by date". From there, you can either select from a number of predefined time ranges (e.g., "Last Hour", "Last Day", etc.) or specify a custom date range, which can either be set as a start date, an end date, or both. All search filters can be cleared by clicking the 'x' button in the search bar.
 

--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -13,6 +13,12 @@ Upon successful submission and distribution, a GCN Circular is assigned a number
   Go to GCN Circulars Archive
 </Link>
 
+## Searching the Archive
+
+Following the migration of the GCN Circulars archive from the GCN Classic Circulars archive, a search functionality was added to enable users to search the archive by keyword. The Circulars archive uses [OpenSearch](https://opensearch.org) to index the subject, body, and submitter of all Circulars in the archive. Upon initiating a query, the search feature will return all Circulars that match the query in any of these fields. By default, the results will be returned in reverse chronological order, but users can also choose to sort the results by relevance. At the bottom of the archive page, users can navigate through the search results using the pagination controls and specify the number of results to display per page.
+
+Additionally, users can filter search results by the date of their submission. This is accomplished selecting the dropdown button immediately to the right of the search bar. From there, users can either select from a number of predefined time ranges (e.g., "Last Hour", "Last Day", etc.) or specify a custom date range, which can either be set as a start date, an end date, or both. All search filters can be cleared by clicking the x button inside of the search bar.
+
 ## Citing GCN Circulars
 
 The [SAO/NASA Astrophysics Data System (ADS)](https://ui.adsabs.harvard.edu) ingests and indexes all GCN Circulars. You can use ADS to get bibliographic records for GCN Circulars to cite them in a publication.

--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -17,7 +17,7 @@ Upon successful submission and distribution, a GCN Circular is assigned a number
 
 You can search the Circulars Archive by keywords or phrases in the subject, body, and submitter fields. By default, results will be returned in reverse chronological order, but you can also choose to sort the results by relevance. You can navigate through the search results using pagination controls and specify the number of results to display per page. By default, 100 results are displayed per page.
 
-Additionally, you can filter search results by the date of their submission. Select the dropdown button labeled "Filter by date". From there, you can either select from a number of predefined time ranges (e.g., "Last Hour", "Last Day", etc.) or specify a custom date range, which can either be set as a start date, an end date, or both. All search filters can be cleared by clicking the 'x' button in the search bar.
+You can also filter search results by submission date. Select the dropdown button labeled "Filter by date". From there, you can either select from a number of predefined time ranges (e.g., "Last Hour", "Last Day", etc.) or specify a custom date range, which can either be set as a start date, an end date, or both. All search filters can be cleared by clicking the 'x' button in the search bar.
 
 ## Citing GCN Circulars
 


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
this adds basic search documentation for the current search paradigm. This does not make reference to lucene queries, which are still hidden behind a feature flag.

# Related Issue(s)
Resolves #2501 

# Testing
1. Navigate to http://localhost:3333/docs/circulars/archive
2. There should be a new section called "Searching the Archive"
