### PR TITLE
adds synonyms moderation front end

### DIFF
--- a/__tests__/synonyms.server.ts
+++ b/__tests__/synonyms.server.ts
@@ -3,28 +3,65 @@ import type { AWSError, DynamoDB } from 'aws-sdk'
 import * as awsSDKMock from 'aws-sdk-mock'
 import crypto from 'crypto'
 
+import type { Circular } from '~/routes/circulars/circulars.lib'
 import { createSynonyms, putSynonyms } from '~/routes/synonyms/synonyms.server'
 
 jest.mock('@architect/functions')
 const synonymId = 'abcde-abcde-abcde-abcde-abcde'
+const exampleCirculars = [
+  {
+    Items: [
+      {
+        circularId: 1234556,
+        subject: 'subject 1',
+        body: 'very intelligent things',
+        eventId: 'eventId1',
+        createdOn: 12345567,
+        submitter: 'steve',
+      } as Circular,
+    ],
+  },
+  {
+    Items: [
+      {
+        circularId: 1230000,
+        subject: 'subject 2',
+        body: 'more intelligent things',
+        eventId: 'eventId2',
+        createdOn: 12345560,
+        submitter: 'steve',
+      } as Circular,
+    ],
+  },
+  { Items: [] },
+]
 
 describe('createSynonyms', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     const mockBatchWrite = jest.fn()
+    const mockQuery = jest.fn()
+
     const mockClient = {
       batchWrite: mockBatchWrite,
+      query: mockQuery,
     }
-    ;(tables as unknown as jest.Mock).mockResolvedValue({
+
+    ;(tables as unknown as jest.Mock).mockReturnValue({
       _doc: mockClient,
       name: () => {
         return 'synonyms'
+      },
+      circulars: {
+        query: mockQuery
+          .mockReturnValueOnce(exampleCirculars[0])
+          .mockReturnValueOnce(exampleCirculars[1]),
       },
     })
 
     jest.spyOn(crypto, 'randomUUID').mockReturnValue(synonymId)
   })
 
-  afterAll(() => {
+  afterEach(() => {
     jest.restoreAllMocks()
   })
 
@@ -48,12 +85,51 @@ describe('createSynonyms', () => {
 
     expect(result).toBe(synonymId)
   })
+
+  test('createSynonyms with nonexistent eventId throws Response 400', async () => {
+    const mockBatchWriteItem = jest.fn(
+      (
+        params: DynamoDB.DocumentClient.BatchWriteItemInput,
+        callback: (
+          err: AWSError | null,
+          data?: DynamoDB.DocumentClient.BatchWriteItemOutput
+        ) => void
+      ) => {
+        expect(params.RequestItems.synonyms).toBeDefined()
+        callback(null, {})
+      }
+    )
+    awsSDKMock.mock('DynamoDB', 'batchWriteItem', mockBatchWriteItem)
+
+    const synonymousEventIds = ['eventId1', 'nope']
+    try {
+      await createSynonyms(synonymousEventIds)
+    } catch (error) {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(error).toBeInstanceOf(Response)
+      const convertedError = error as Response
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(convertedError.status).toBe(400)
+      const errorMessage = await convertedError.text()
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(errorMessage).toBe('eventId does not exist')
+    }
+  })
 })
 
 describe('putSynonyms', () => {
   const mockBatchWrite = jest.fn()
+  const mockQuery = jest.fn()
 
   beforeAll(() => {
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue(synonymId)
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+    awsSDKMock.restore('DynamoDB')
+  })
+  test('putSynonyms should not write to DynamoDB if no additions or subtractions', async () => {
     const mockClient = {
       batchWrite: mockBatchWrite,
     }
@@ -63,15 +139,6 @@ describe('putSynonyms', () => {
         return 'synonyms'
       },
     })
-
-    jest.spyOn(crypto, 'randomUUID').mockReturnValue(synonymId)
-  })
-
-  afterAll(() => {
-    jest.restoreAllMocks()
-    awsSDKMock.restore('DynamoDB')
-  })
-  test('putSynonyms should not write to DynamoDB if no additions or subtractions', async () => {
     awsSDKMock.mock('DynamoDB.DocumentClient', 'batchWrite', mockBatchWrite)
 
     await putSynonyms({ synonymId })
@@ -79,7 +146,53 @@ describe('putSynonyms', () => {
     expect(mockBatchWrite).not.toHaveBeenCalled()
   })
 
+  test('putSynonyms should throw 400 response if there are invalid additions', async () => {
+    const mockClient = {
+      batchWrite: mockBatchWrite,
+      query: mockQuery,
+    }
+
+    ;(tables as unknown as jest.Mock).mockReturnValue({
+      _doc: mockClient,
+      name: () => {
+        return 'synonyms'
+      },
+      circulars: {
+        query: mockQuery.mockReturnValueOnce(exampleCirculars[2]),
+      },
+    })
+    awsSDKMock.mock('DynamoDB.DocumentClient', 'batchWrite', mockBatchWrite)
+    try {
+      await putSynonyms({ synonymId, additions: ["doesn't exist"] })
+    } catch (error) {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(error).toBeInstanceOf(Response)
+      const convertedError = error as Response
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(convertedError.status).toBe(400)
+      const errorMessage = await convertedError.text()
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(errorMessage).toBe('eventId does not exist')
+    }
+  })
+
   test('putSynonyms should write to DynamoDB if there are additions', async () => {
+    const mockClient = {
+      batchWrite: mockBatchWrite,
+      query: mockQuery,
+    }
+
+    ;(tables as unknown as jest.Mock).mockReturnValue({
+      _doc: mockClient,
+      name: () => {
+        return 'synonyms'
+      },
+      circulars: {
+        query: mockQuery
+          .mockReturnValueOnce(exampleCirculars[0])
+          .mockReturnValueOnce(exampleCirculars[1]),
+      },
+    })
     awsSDKMock.mock('DynamoDB.DocumentClient', 'batchWrite', mockBatchWrite)
     const additions = ['eventId1', 'eventId2']
     await putSynonyms({ synonymId, additions })
@@ -109,6 +222,15 @@ describe('putSynonyms', () => {
   })
 
   test('putSynonyms should write to DynamoDB if there are subtractions', async () => {
+    const mockClient = {
+      batchWrite: mockBatchWrite,
+    }
+    ;(tables as unknown as jest.Mock).mockResolvedValue({
+      _doc: mockClient,
+      name: () => {
+        return 'synonyms'
+      },
+    })
     awsSDKMock.mock('DynamoDB.DocumentClient', 'batchWrite', mockBatchWrite)
 
     const subtractions = ['eventId3', 'eventId4']
@@ -126,6 +248,22 @@ describe('putSynonyms', () => {
   })
 
   test('putSynonyms should write to DynamoDB if there are additions and subtractions', async () => {
+    const mockClient = {
+      batchWrite: mockBatchWrite,
+      query: mockQuery,
+    }
+
+    ;(tables as unknown as jest.Mock).mockReturnValue({
+      _doc: mockClient,
+      name: () => {
+        return 'synonyms'
+      },
+      circulars: {
+        query: mockQuery
+          .mockReturnValueOnce(exampleCirculars[0])
+          .mockReturnValueOnce(exampleCirculars[1]),
+      },
+    })
     awsSDKMock.mock('DynamoDB.DocumentClient', 'batchWrite', mockBatchWrite)
 
     const additions = ['eventId1', 'eventId2']

--- a/app/components/pagination/GCNPagination.tsx
+++ b/app/components/pagination/GCNPagination.tsx
@@ -35,7 +35,7 @@ function getPageLink({
   return searchString && `?${searchString}`
 }
 
-export default function ({
+export default function GCNPagination({
   page,
   totalPages,
   ...queryStringProps

--- a/app/components/pagination/Pagination.tsx
+++ b/app/components/pagination/Pagination.tsx
@@ -35,7 +35,7 @@ function getPageLink({
   return searchString && `?${searchString}`
 }
 
-export default function GCNPagination({
+export default function Pagination({
   page,
   totalPages,
   ...queryStringProps

--- a/app/components/pagination/PaginationSelectionFooter.tsx
+++ b/app/components/pagination/PaginationSelectionFooter.tsx
@@ -1,0 +1,61 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { useSubmit } from '@remix-run/react'
+import { Select } from '@trussworks/react-uswds'
+
+import GCNPagination from './GCNPagination'
+
+export default function PaginationSelectionFooter({
+  page,
+  totalPages,
+  limit,
+  query,
+  form,
+}: {
+  page: number
+  totalPages: number
+  limit?: number
+  query?: string
+  form: string
+}) {
+  const submit = useSubmit()
+  return (
+    <div className="display-flex flex-row flex-wrap">
+      <div className="display-flex flex-align-self-center margin-right-2 width-auto">
+        <div>
+          <Select
+            id="limit"
+            title="Number of results per page"
+            className="width-auto height-5 padding-y-0 margin-y-0"
+            name="limit"
+            defaultValue="100"
+            form={form}
+            onChange={({ target: { form } }) => {
+              submit(form)
+            }}
+          >
+            <option value="10">10 / page</option>
+            <option value="20">20 / page</option>
+            <option value="50">50 / page</option>
+            <option value="100">100 / page</option>
+          </Select>
+        </div>
+      </div>
+      <div className="display-flex flex-fill">
+        {totalPages > 1 && (
+          <GCNPagination
+            query={query}
+            page={page}
+            limit={limit}
+            totalPages={totalPages}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/components/pagination/PaginationSelectionFooter.tsx
+++ b/app/components/pagination/PaginationSelectionFooter.tsx
@@ -8,7 +8,7 @@
 import { useSubmit } from '@remix-run/react'
 import { Select } from '@trussworks/react-uswds'
 
-import GCNPagination from './GCNPagination'
+import Pagination from './Pagination'
 
 export default function PaginationSelectionFooter({
   page,
@@ -48,7 +48,7 @@ export default function PaginationSelectionFooter({
       </div>
       <div className="display-flex flex-fill">
         {totalPages > 1 && (
-          <GCNPagination
+          <Pagination
             query={query}
             page={page}
             limit={limit}

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -14,14 +14,7 @@ import {
   useSearchParams,
   useSubmit,
 } from '@remix-run/react'
-import {
-  Alert,
-  Button,
-  Icon,
-  Label,
-  Select,
-  TextInput,
-} from '@trussworks/react-uswds'
+import { Alert, Button, Icon, Label, TextInput } from '@trussworks/react-uswds'
 import clamp from 'lodash/clamp'
 import { useId, useState } from 'react'
 
@@ -41,13 +34,13 @@ import {
   putVersion,
   search,
 } from '../circulars/circulars.server'
-import CircularPagination from './CircularPagination'
 import CircularsHeader from './CircularsHeader'
 import CircularsIndex from './CircularsIndex'
 import { DateSelector } from './DateSelectorMenu'
 import { SortSelector } from './SortSelectorButton'
 import Hint from '~/components/Hint'
 import { ToolbarButtonGroup } from '~/components/ToolbarButtonGroup'
+import PaginationSelectionFooter from '~/components/pagination/PaginationSelectionFooter'
 import { origin } from '~/lib/env.server'
 import { getFormDataString } from '~/lib/utils'
 import { postZendeskRequest } from '~/lib/zendesk.server'
@@ -281,40 +274,13 @@ export default function () {
             totalItems={totalItems}
             query={query}
           />
-          <div className="display-flex flex-row flex-wrap">
-            <div className="display-flex flex-align-self-center margin-right-2 width-auto">
-              <div>
-                <Select
-                  id="limit"
-                  title="Number of results per page"
-                  className="width-auto height-5 padding-y-0 margin-y-0"
-                  name="limit"
-                  defaultValue="100"
-                  form={formId}
-                  onChange={({ target: { form } }) => {
-                    submit(form)
-                  }}
-                >
-                  <option value="10">10 / page</option>
-                  <option value="20">20 / page</option>
-                  <option value="50">50 / page</option>
-                  <option value="100">100 / page</option>
-                </Select>
-              </div>
-            </div>
-            <div className="display-flex flex-fill">
-              {totalPages > 1 && (
-                <CircularPagination
-                  query={query}
-                  page={page}
-                  limit={parseInt(limit)}
-                  totalPages={totalPages}
-                  startDate={startDate}
-                  endDate={endDate}
-                />
-              )}
-            </div>
-          </div>
+          <PaginationSelectionFooter
+            query={query}
+            page={page}
+            limit={parseInt(limit)}
+            totalPages={totalPages}
+            form={formId}
+          />
         </>
       )}
     </>

--- a/app/routes/synonyms.$synonymId.tsx
+++ b/app/routes/synonyms.$synonymId.tsx
@@ -7,25 +7,62 @@
  */
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
 import { redirect } from '@remix-run/node'
-import { Form, Link, useLoaderData } from '@remix-run/react'
-import { Button, ButtonGroup, FormGroup, Icon } from '@trussworks/react-uswds'
-import { useState } from 'react'
-import invariant from 'tiny-invariant'
-
 import {
+  Form,
+  Link,
+  useFetcher,
+  useLoaderData,
+  useSubmit,
+} from '@remix-run/react'
+import type { ModalRef } from '@trussworks/react-uswds'
+import {
+  Button,
+  ButtonGroup,
+  CardBody,
+  FormGroup,
+  Grid,
+  Icon,
+  Modal,
+  ModalFooter,
+  ModalHeading,
+  ModalToggleButton,
+  TextInput,
+} from '@trussworks/react-uswds'
+import { useEffect, useRef, useState } from 'react'
+import invariant from 'tiny-invariant'
+import { useOnClickOutside } from 'usehooks-ts'
+
+import { getUser } from './_auth/user.server'
+import { moderatorGroup } from './circulars/circulars.server'
+import {
+  autoCompleteEventIds,
   deleteSynonyms,
   getSynonymsByUuid,
   putSynonyms,
 } from './synonyms/synonyms.server'
+import DetailsDropdownContent from '~/components/DetailsDropdownContent'
+import { ToolbarButtonGroup } from '~/components/ToolbarButtonGroup'
 import { getFormDataString } from '~/lib/utils'
 
-export async function loader({ params: { synonymId } }: LoaderFunctionArgs) {
+export async function loader({
+  request,
+  params: { synonymId },
+}: LoaderFunctionArgs) {
+  const user = await getUser(request)
+  if (!user?.groups.includes(moderatorGroup))
+    throw new Response(null, { status: 403 })
+
   invariant(synonymId)
   const synonyms = await getSynonymsByUuid(synonymId)
   const eventIds = synonyms.map((synonym) => synonym.eventId)
-
+  const url = new URL(request.url)
+  const query = url.searchParams.get('query')
+  const { options } = query
+    ? await autoCompleteEventIds({ query })
+    : { options: [] }
   return {
     eventIds,
+    options,
   }
 }
 
@@ -61,81 +98,103 @@ export async function action({
 }
 
 export default function () {
-  const { eventIds } = useLoaderData<typeof loader>()
+  const { eventIds, options } = useLoaderData<typeof loader>()
+  const uniqueOptions = Array.from(new Set(options)) as string[]
   const [deleteSynonyms, setDeleteSynonyms] = useState([] as string[])
   const [synonyms, setSynonyms] = useState(eventIds || [])
   const [addSynonyms, setAddSynonyms] = useState([] as string[])
-  const [newSynonym, setNewSynonym] = useState('')
+  const uniqueSynonyms = Array.from(new Set(synonyms)) as string[]
+  const [input, setInput] = useState('')
+  const modalRef = useRef<ModalRef>(null)
+  const ref = useRef<HTMLDivElement>(null)
+  const fetcher = useFetcher()
+  const submit = useSubmit()
+
+  const [showContent, setShowContent] = useState(false)
+  useOnClickOutside(ref, () => {
+    setShowContent(false)
+  })
+
+  useEffect(() => {
+    const delayDebounceFn = setTimeout(() => {
+      if (input.length >= 3)
+        submit({ query: input }, { preventScrollReset: true })
+    }, 3000)
+
+    return () => clearTimeout(delayDebounceFn)
+  }, [input, submit])
 
   return (
     <>
-      <ButtonGroup>
-        <h1>Synonym Group</h1>
-        <ButtonGroup className="margin-bottom-2">
-          <Link to="/synonyms" className="usa-button">
-            <div className="display-inline">
-              <Icon.ArrowBack
-                role="presentation"
-                className="position-relative"
-              />
-            </div>
-          </Link>
-          <Form method="POST">
-            <input type="hidden" name="intent" value="delete" />
-            <Button type="submit">
-              <Icon.Delete
-                role="presentation"
-                className="bottom-aligned margin-right-05"
-              />
-            </Button>
-          </Form>
-        </ButtonGroup>
-      </ButtonGroup>
-      <p>
-        Synonym groupings are limited to 25 synonymous event identifiers. If you
-        are adding an event identifier that is already part of a group, it will
-        be removed from the previous association and added to this group.
-      </p>
-      <Form>
-        <FormGroup>
-          <ButtonGroup>
-            <input
-              placeholder="event id"
-              value={newSynonym}
-              key="synonym"
-              onChange={(e) => {
-                setNewSynonym(e.currentTarget.value)
-              }}
+      <ToolbarButtonGroup className="flex-wrap">
+        <Link to="/synonyms" className="usa-button flex-align-stretch">
+          <div className="position-relative">
+            <Icon.ArrowBack
+              role="presentation"
+              className="position-absolute top-0 left-0"
             />
-            <Button
-              type="button"
-              onClick={(e) => {
-                if (!newSynonym) return
-                setDeleteSynonyms(
-                  deleteSynonyms.filter(function (item) {
-                    return item !== newSynonym
-                  })
-                )
-                const existingSynonyms = [...synonyms, newSynonym].filter(
-                  function (v, i, self) {
-                    return i == self.indexOf(v)
-                  }
-                )
-                setSynonyms(existingSynonyms)
-                const additionalSynonyms = [...addSynonyms, newSynonym].filter(
-                  function (v, i, self) {
-                    return i == self.indexOf(v)
-                  }
-                )
-                setAddSynonyms(additionalSynonyms)
-                setNewSynonym('')
-              }}
-            >
-              <Icon.Add role="presentation" /> Add
-            </Button>
-          </ButtonGroup>
-        </FormGroup>
-      </Form>
+          </div>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Back
+        </Link>
+        <ModalToggleButton modalRef={modalRef} opener type="button">
+          <Icon.Delete
+            role="presentation"
+            className="bottom-aligned margin-right-05"
+          />{' '}
+          Delete
+        </ModalToggleButton>
+      </ToolbarButtonGroup>
+      <h1>Synonym Group</h1>
+      <p>
+        If you are adding an event identifier that is already part of a group,
+        it will be removed from the previous association and added to this
+        group.
+      </p>
+      <Grid row>
+        <fetcher.Form method="get">
+          <TextInput
+            className="border-1px"
+            autoComplete="off"
+            type="search"
+            name="query"
+            value={input}
+            onChange={({ target: { form, value } }) => {
+              setInput(value)
+              setShowContent(true)
+              if (value.length >= 3) submit(form, { preventScrollReset: true })
+            }}
+            id="query-input"
+          />
+        </fetcher.Form>
+      </Grid>
+      {uniqueOptions.length && input && showContent ? (
+        <div ref={ref}>
+          <DetailsDropdownContent>
+            <CardBody>
+              {uniqueOptions.map((eventId: string) => (
+                <div
+                  key={eventId}
+                  className="hover:bg-primary-lighter"
+                  onClick={() => {
+                    setSynonyms([...synonyms, eventId])
+                    setAddSynonyms(
+                      Array.from(new Set([...addSynonyms, eventId]))
+                    )
+                    setDeleteSynonyms(
+                      deleteSynonyms.filter(function (item) {
+                        return item !== eventId
+                      })
+                    )
+                    setInput('')
+                  }}
+                >
+                  {eventId}
+                </div>
+              ))}
+            </CardBody>
+          </DetailsDropdownContent>
+        </div>
+      ) : null}
       <Form
         method="POST"
         onSubmit={() => {
@@ -148,7 +207,7 @@ export default function () {
           <input type="hidden" name="deleteSynonyms" value={deleteSynonyms} />
           <input type="hidden" name="addSynonyms" value={addSynonyms} />
           <ul className="usa-list usa-list--unstyled">
-            {synonyms?.map((synonym) => (
+            {uniqueSynonyms?.map((synonym) => (
               <li key={synonym}>
                 <ButtonGroup>
                   {synonym}
@@ -169,7 +228,7 @@ export default function () {
                       )
                     }}
                   >
-                    <Icon.Delete aria-label="Delete" />
+                    Remove
                   </Button>
                 </ButtonGroup>
               </li>
@@ -185,6 +244,44 @@ export default function () {
           </Button>
         </FormGroup>
       </Form>
+      <Modal
+        ref={modalRef}
+        id="example-modal-1"
+        aria-labelledby="modal-1-heading"
+        aria-describedby="modal-1-description"
+        renderToPortal={false}
+      >
+        <ModalHeading id="modal-1-heading">
+          Are you sure you want to continue?
+        </ModalHeading>
+        <div className="usa-prose">
+          <p id="modal-1-description">
+            You are about to permanently delete this Synonym Group.
+          </p>
+        </div>
+        <ModalFooter>
+          <ButtonGroup>
+            <Form method="POST">
+              <input type="hidden" name="intent" value="delete" />
+              <Button type="submit" outline>
+                <Icon.Delete
+                  role="presentation"
+                  className="bottom-aligned margin-right-05"
+                />{' '}
+                Delete
+              </Button>
+            </Form>
+            <ModalToggleButton
+              modalRef={modalRef}
+              closer
+              unstyled
+              className="padding-105 text-center"
+            >
+              Go back
+            </ModalToggleButton>
+          </ButtonGroup>
+        </ModalFooter>
+      </Modal>
     </>
   )
 }

--- a/app/routes/synonyms.$synonymId.tsx
+++ b/app/routes/synonyms.$synonymId.tsx
@@ -76,17 +76,13 @@ export async function action({
   const intent = getFormDataString(data, 'intent')
 
   if (intent === 'edit') {
-    const additions =
-      getFormDataString(data, 'addSynonyms')?.split(',') || ([] as string[])
-    const filtered_additions = additions.filter((add) => add)
-    const subtractions =
-      getFormDataString(data, 'deleteSynonyms')?.split(',') || ([] as string[])
-    const filtered_subtractions = subtractions.filter((sub) => sub)
+    const additions = data.getAll('addSynonyms') as string[]
+    const subtractions = data.getAll('deleteSynonyms') as string[]
 
     await putSynonyms({
       synonymId,
-      additions: filtered_additions,
-      subtractions: filtered_subtractions,
+      additions,
+      subtractions,
     })
 
     return null
@@ -207,8 +203,24 @@ export default function () {
       >
         <input type="hidden" name="intent" value="edit" />
         <FormGroup>
-          <input type="hidden" name="deleteSynonyms" value={deleteSynonyms} />
-          <input type="hidden" name="addSynonyms" value={addSynonyms} />
+          {addSynonyms.map((synonym) => (
+            <input
+              key={synonym}
+              type="hidden"
+              name="addSynonyms"
+              value={synonym}
+              id={`add-${synonym}`}
+            />
+          ))}
+          {deleteSynonyms.map((synonym) => (
+            <input
+              key={synonym}
+              type="hidden"
+              name="deleteSynonyms"
+              value={synonym}
+              id={`delete-${synonym}`}
+            />
+          ))}
           <ul className="usa-list usa-list--unstyled">
             {uniqueSynonyms?.map((synonym) => (
               <li key={synonym}>

--- a/app/routes/synonyms.$synonymId.tsx
+++ b/app/routes/synonyms.$synonymId.tsx
@@ -60,6 +60,7 @@ export async function loader({
   const { options } = query
     ? await autoCompleteEventIds({ query })
     : { options: [] }
+
   return {
     eventIds,
     options,
@@ -81,11 +82,13 @@ export async function action({
     const subtractions =
       getFormDataString(data, 'deleteSynonyms')?.split(',') || ([] as string[])
     const filtered_subtractions = subtractions.filter((sub) => sub)
+
     await putSynonyms({
       synonymId,
       additions: filtered_additions,
       subtractions: filtered_subtractions,
     })
+
     return null
   } else if (intent === 'delete') {
     await deleteSynonyms(synonymId)
@@ -99,11 +102,11 @@ export async function action({
 
 export default function () {
   const { eventIds, options } = useLoaderData<typeof loader>()
-  const uniqueOptions = Array.from(new Set(options)) as string[]
-  const [deleteSynonyms, setDeleteSynonyms] = useState([] as string[])
-  const [synonyms, setSynonyms] = useState(eventIds || [])
-  const [addSynonyms, setAddSynonyms] = useState([] as string[])
-  const uniqueSynonyms = Array.from(new Set(synonyms)) as string[]
+  const uniqueOptions = Array.from(new Set(options))
+  const [deleteSynonyms, setDeleteSynonyms] = useState<string[]>([])
+  const [synonyms, setSynonyms] = useState<string[]>(eventIds || [])
+  const [addSynonyms, setAddSynonyms] = useState<string[]>([])
+  const uniqueSynonyms = Array.from(new Set(synonyms))
   const [input, setInput] = useState('')
   const modalRef = useRef<ModalRef>(null)
   const ref = useRef<HTMLDivElement>(null)
@@ -222,7 +225,7 @@ export default function () {
                         })
                       )
                       setAddSynonyms(
-                        synonyms.filter(function (item) {
+                        addSynonyms.filter(function (item) {
                           return item !== synonym
                         })
                       )
@@ -277,7 +280,7 @@ export default function () {
               unstyled
               className="padding-105 text-center"
             >
-              Go back
+              Cancel
             </ModalToggleButton>
           </ButtonGroup>
         </ModalFooter>

--- a/app/routes/synonyms._index.tsx
+++ b/app/routes/synonyms._index.tsx
@@ -23,6 +23,8 @@ import {
 } from '@trussworks/react-uswds'
 import { useId, useState } from 'react'
 
+import { getUser } from './_auth/user.server'
+import { moderatorGroup } from './circulars/circulars.server'
 import type { SynonymGroup } from './synonyms/synonyms.lib'
 import { searchSynonymsByEventId } from './synonyms/synonyms.server'
 import { ToolbarButtonGroup } from '~/components/ToolbarButtonGroup'
@@ -30,12 +32,17 @@ import PaginationSelectionFooter from '~/components/pagination/PaginationSelecti
 
 import searchImg from 'nasawds/src/img/usa-icons-bg/search--white.svg'
 
-export async function loader({ request: { url } }: LoaderFunctionArgs) {
-  const { searchParams } = new URL(url)
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await getUser(request)
+  if (!user?.groups.includes(moderatorGroup))
+    throw new Response(null, { status: 403 })
+
+  const { searchParams } = new URL(request.url)
   const query = searchParams.get('query') || undefined
   const limit = parseInt(searchParams.get('limit') || '100')
   const page = parseInt(searchParams.get('page') || '1')
   const synonyms = searchSynonymsByEventId({ page, eventId: query, limit })
+
   return synonyms
 }
 

--- a/app/routes/synonyms._index.tsx
+++ b/app/routes/synonyms._index.tsx
@@ -1,0 +1,122 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import {
+  Form,
+  Link,
+  useLoaderData,
+  useSearchParams,
+  useSubmit,
+} from '@remix-run/react'
+import {
+  Button,
+  Grid,
+  GridContainer,
+  Icon,
+  Label,
+  TextInput,
+} from '@trussworks/react-uswds'
+import { useId, useState } from 'react'
+
+import type { SynonymGroup } from './synonyms/synonyms.lib'
+import { searchSynonymsByEventId } from './synonyms/synonyms.server'
+import { ToolbarButtonGroup } from '~/components/ToolbarButtonGroup'
+import PaginationSelectionFooter from '~/components/pagination/PaginationSelectionFooter'
+
+import searchImg from 'nasawds/src/img/usa-icons-bg/search--white.svg'
+
+export async function loader({ request: { url } }: LoaderFunctionArgs) {
+  const { searchParams } = new URL(url)
+  const query = searchParams.get('query') || undefined
+  const limit = parseInt(searchParams.get('limit') || '100')
+  const page = parseInt(searchParams.get('page') || '1')
+  const synonyms = searchSynonymsByEventId({ page, eventId: query, limit })
+  return synonyms
+}
+
+function SynonymList({ synonyms }: { synonyms: SynonymGroup[] }) {
+  return (
+    <ul>
+      {synonyms.map((synonym) => {
+        return (
+          <li key={synonym.synonymId}>
+            <Link to={`/synonyms/${synonym.synonymId}`}>
+              {synonym.eventIds.join(', ')}
+            </Link>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+export default function () {
+  const { synonyms, page, totalPages } = useLoaderData<typeof loader>()
+  const submit = useSubmit()
+  const formId = useId()
+  const [searchParams] = useSearchParams()
+  const limit = searchParams.get('limit') || '100'
+  const query = searchParams.get('query') || ''
+
+  const [inputQuery, setInputQuery] = useState('')
+
+  return (
+    <>
+      <h1>Synonym Group Moderation</h1>
+      <GridContainer>
+        <Grid row>
+          <ToolbarButtonGroup className="position-sticky top-0 bg-white margin-bottom-1 padding-top-1 z-300">
+            <Form
+              preventScrollReset
+              className="display-inline-block usa-search usa-search--small"
+              role="search"
+              id={formId}
+            >
+              <Label srOnly htmlFor="query">
+                Search
+              </Label>
+              <TextInput
+                autoFocus
+                className="minw-15"
+                id="query"
+                name="query"
+                type="search"
+                defaultValue={inputQuery}
+                placeholder="Search"
+                aria-describedby="searchHint"
+                onChange={({ target: { form, value } }) => {
+                  setInputQuery(value)
+                  if (!value) submit(form, { preventScrollReset: true })
+                }}
+              />
+              <Button type="submit">
+                <img
+                  src={searchImg}
+                  className="usa-search__submit-icon"
+                  alt="Search"
+                />
+              </Button>
+            </Form>
+            <Link to="/synonyms/new">
+              <Button type="button" className="padding-y-1">
+                <Icon.Edit role="presentation" /> New
+              </Button>
+            </Link>
+          </ToolbarButtonGroup>
+        </Grid>
+      </GridContainer>
+      <SynonymList synonyms={synonyms} />
+      <PaginationSelectionFooter
+        query={query}
+        page={page}
+        totalPages={totalPages}
+        limit={parseInt(limit)}
+        form={formId}
+      />
+    </>
+  )
+}

--- a/app/routes/synonyms.new.tsx
+++ b/app/routes/synonyms.new.tsx
@@ -1,0 +1,155 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
+import {
+  Form,
+  redirect,
+  useFetcher,
+  useLoaderData,
+  useSubmit,
+} from '@remix-run/react'
+import {
+  Button,
+  ButtonGroup,
+  CardBody,
+  FormGroup,
+  Grid,
+  TextInput,
+} from '@trussworks/react-uswds'
+import { useEffect, useRef, useState } from 'react'
+import { useOnClickOutside } from 'usehooks-ts'
+
+import { getUser } from './_auth/user.server'
+import { moderatorGroup } from './circulars/circulars.server'
+import {
+  autoCompleteEventIds,
+  createSynonyms,
+} from './synonyms/synonyms.server'
+import DetailsDropdownContent from '~/components/DetailsDropdownContent'
+import { getFormDataString } from '~/lib/utils'
+
+export async function action({ request }: ActionFunctionArgs) {
+  const user = await getUser(request)
+  if (!user?.groups.includes(moderatorGroup))
+    throw new Response(null, { status: 403 })
+  const data = await request.formData()
+  const eventIds = getFormDataString(data, 'synonyms')?.split(',')
+  if (!eventIds) throw new Response(null, { status: 400 })
+  const synonymId = await createSynonyms(eventIds)
+  return redirect(`/synonyms/${synonymId}`)
+}
+
+export async function loader(args: LoaderFunctionArgs) {
+  const url = new URL(args.request.url)
+  const query = url.searchParams.get('query')
+  if (query) {
+    return await autoCompleteEventIds({ query })
+  }
+  return { options: [] }
+}
+
+export default function () {
+  const ref = useRef<HTMLDivElement>(null)
+  const fetcher = useFetcher()
+  const submit = useSubmit()
+
+  const [showContent, setShowContent] = useState(false)
+  useOnClickOutside(ref, () => {
+    setShowContent(false)
+  })
+  const [synonyms, setSynonyms] = useState([] as string[])
+  const uniqueSynonyms = Array.from(new Set(synonyms)) as string[]
+  const [input, setInput] = useState('')
+
+  const { options } = useLoaderData<typeof loader>()
+  const uniqueOptions = Array.from(new Set(options)) as string[]
+
+  useEffect(() => {
+    const delayDebounceFn = setTimeout(() => {
+      if (input.length >= 3)
+        submit({ query: input }, { preventScrollReset: true })
+    }, 3000)
+
+    return () => clearTimeout(delayDebounceFn)
+  }, [input, submit])
+
+  return (
+    <>
+      <h1>Create New Synonym Group</h1>
+      <Grid row>
+        <fetcher.Form method="get">
+          <TextInput
+            className="border-1px"
+            autoComplete="off"
+            type="search"
+            name="query"
+            value={input}
+            onChange={({ target: { form, value } }) => {
+              setInput(value)
+              setShowContent(true)
+              if (value.length >= 3) submit(form, { preventScrollReset: true })
+            }}
+            id="query-input"
+          />
+        </fetcher.Form>
+      </Grid>
+      {uniqueOptions.length && input && showContent ? (
+        <div ref={ref}>
+          <DetailsDropdownContent>
+            <CardBody>
+              {uniqueOptions.map((eventId: string) => (
+                <div
+                  key={eventId}
+                  className="hover:bg-primary-lighter"
+                  onClick={() => {
+                    setSynonyms([...synonyms, eventId])
+                    setInput('')
+                  }}
+                >
+                  {eventId}
+                </div>
+              ))}
+            </CardBody>
+          </DetailsDropdownContent>
+        </div>
+      ) : null}
+      <Form method="POST">
+        <FormGroup className="margin-left-1">
+          <input type="hidden" name="synonyms" value={uniqueSynonyms} />
+          <ul className="usa-list usa-list--unstyled">
+            {uniqueSynonyms?.map((synonym) => (
+              <li key={synonym}>
+                <ButtonGroup>
+                  {synonym}
+                  <Button
+                    className="usa-button--unstyled"
+                    type="button"
+                    onClick={() => {
+                      setSynonyms(
+                        synonyms.filter(function (item) {
+                          return item !== synonym
+                        })
+                      )
+                    }}
+                  >
+                    Remove
+                  </Button>
+                </ButtonGroup>
+              </li>
+            ))}
+          </ul>
+        </FormGroup>
+        <FormGroup>
+          <Button type="submit" disabled={!(synonyms.length > 1)}>
+            Create
+          </Button>
+        </FormGroup>
+      </Form>
+    </>
+  )
+}

--- a/app/routes/synonyms/route.tsx
+++ b/app/routes/synonyms/route.tsx
@@ -10,16 +10,13 @@ import { Outlet } from '@remix-run/react'
 import { GridContainer } from '@trussworks/react-uswds'
 
 import { getUser } from '../_auth/user.server'
+import { moderatorGroup } from '../circulars/circulars.server'
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const user = await getUser(request)
-  const isModerator = user?.groups.includes('gcn.nasa.gov/circular-moderator')
+  if (!user?.groups.includes(moderatorGroup))
+    throw new Response(null, { status: 403 })
 
-  if (!isModerator) {
-    throw new Response(null, {
-      status: 403,
-    })
-  }
   return null
 }
 


### PR DESCRIPTION
# Description
This is the front end for the moderation portion of synonyms (not the circular index grouped by synonyms, but the ability to create, put, delete the synonyms themselves). It is behind both a feature flag and a moderator check. The majority of the code is behind a feature flag and moderation gate, but I did create a component for pagination to reduce redundancy so I could reuse it for this work. In order to do that I had to update the circulars index page as well. That portion is NOT behind a feature flag.

# Related Issue(s)
Resolves #2116

# Testing
This is the moderation index with pagination. Links for each group are to the detail page
<img width="1229" alt="Screenshot 2024-08-13 at 4 34 31 PM" src="https://github.com/user-attachments/assets/fcdadf55-0ae5-44b1-a181-b59b02f359df">

This is the detail page for a synonym group. The button to save is disabled because no additional eventIds have been added. It is enabled when a new eventId is added.
<img width="1124" alt="Screenshot 2024-08-14 at 10 04 06 AM" src="https://github.com/user-attachments/assets/8c76dfbd-c7f7-4ad7-b3a9-3f849de15f27">

This is the error shown if you enter an eventId that doesn't exist.
<img width="1147" alt="Screenshot 2024-08-14 at 2 50 48 PM" src="https://github.com/user-attachments/assets/17649126-73d7-4d12-8a88-b88340e3f103">


This is the create view with no eventIds added.
<img width="1085" alt="Screenshot 2024-08-14 at 10 05 12 AM" src="https://github.com/user-attachments/assets/84de2efd-13e7-45ac-a670-dc8939fdb6b6">

This is the same view with eventIds added.
<img width="1061" alt="Screenshot 2024-08-14 at 10 05 44 AM" src="https://github.com/user-attachments/assets/32c8d8d7-8575-4875-bff0-9830c3aa6986">

This is the error shown when you try to create a synonym group with an invalid eventId
<img width="1163" alt="Screenshot 2024-08-14 at 2 37 14 PM" src="https://github.com/user-attachments/assets/cd918829-7fe4-454c-b3fc-2a8ec52a6146">

