### PR TITLE
Updates the change request functions to automatically close the corresponding zendesk ticket

### DIFF
--- a/app/lib/zendesk.server.ts
+++ b/app/lib/zendesk.server.ts
@@ -72,5 +72,4 @@ export async function closeZendeskTicket(ticketId: number) {
     console.error(response)
     throw new Error(`Request failed with status ${response.status}`)
   }
-  return await response.json()
 }

--- a/app/lib/zendesk.server.ts
+++ b/app/lib/zendesk.server.ts
@@ -43,6 +43,34 @@ export async function postZendeskRequest(request: ZendeskRequest) {
 
   if (!response.ok) {
     console.error(response)
-    throw new Error(`Reqeust failed with status ${response.status}`)
+    throw new Error(`Request failed with status ${response.status}`)
   }
+  return await response.json()
+}
+
+export async function closeZendeskTicket(ticketId: number) {
+  const response = await fetch(
+    `https://nasa-gcn.zendesk.com/api/v2/tickets/${ticketId}.json`,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        ...getBasicAuthHeaders(
+          `${getEnvOrDie('ZENDESK_TOKEN_EMAIL')}/token`,
+          getEnvOrDie('ZENDESK_TOKEN')
+        ),
+      },
+      body: JSON.stringify({
+        ticket: {
+          status: 'solved',
+        },
+      }),
+    }
+  )
+
+  if (!response.ok) {
+    console.error(response)
+    throw new Error(`Request failed with status ${response.status}`)
+  }
+  return await response.json()
 }

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -111,7 +111,9 @@ export async function action({ request }: ActionFunctionArgs) {
       if (!createdOnDate || !createdOn)
         throw new Response(null, { status: 400 })
 
-      const {request: {id: zendeskTicketId}} = await postZendeskRequest({
+      const {
+        request: { id: zendeskTicketId },
+      } = await postZendeskRequest({
         requester: { name: user.name, email: user.email },
         subject: `Change Request for Circular ${circularId}`,
         comment: {

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -111,7 +111,7 @@ export async function action({ request }: ActionFunctionArgs) {
       if (!createdOnDate || !createdOn)
         throw new Response(null, { status: 400 })
 
-      const zendeskResponse = await postZendeskRequest({
+      const {request: {id: zendeskTicketId}} = await postZendeskRequest({
         requester: { name: user.name, email: user.email },
         subject: `Change Request for Circular ${circularId}`,
         comment: {
@@ -125,7 +125,7 @@ export async function action({ request }: ActionFunctionArgs) {
           ...props,
           submitter,
           createdOn,
-          zendeskTicketId: zendeskResponse.request.id,
+          zendeskTicketId,
         },
         user
       )

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -110,22 +110,25 @@ export async function action({ request }: ActionFunctionArgs) {
 
       if (!createdOnDate || !createdOn)
         throw new Response(null, { status: 400 })
-      await createChangeRequest(
-        {
-          circularId: parseFloat(circularId),
-          ...props,
-          submitter,
-          createdOn,
-        },
-        user
-      )
-      await postZendeskRequest({
+
+      const zendeskResponse = await postZendeskRequest({
         requester: { name: user.name, email: user.email },
         subject: `Change Request for Circular ${circularId}`,
         comment: {
           body: `${user.name} has requested an edit. Review at ${origin}/circulars`,
         },
       })
+
+      await createChangeRequest(
+        {
+          circularId: parseFloat(circularId),
+          ...props,
+          submitter,
+          createdOn,
+          zendeskTicketId: zendeskResponse.request.id,
+        },
+        user
+      )
       newCircular = null
       break
     case 'edit':

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -39,6 +39,7 @@ export interface CircularChangeRequest extends CircularMetadata {
   format: CircularFormat
   submitter: string
   createdOn: number
+  zendeskTicketId?: number
 }
 
 export interface CircularChangeRequestKeys {

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -39,7 +39,7 @@ export interface CircularChangeRequest extends CircularMetadata {
   format: CircularFormat
   submitter: string
   createdOn: number
-  zendeskTicketId?: number
+  zendeskTicketId: number
 }
 
 export interface CircularChangeRequestKeys {

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -466,8 +466,6 @@ export async function deleteChangeRequest(
   const changeRequest = await getChangeRequest(circularId, requestorSub)
   const requestorEmail = changeRequest.requestorEmail
   await deleteChangeRequestRaw(circularId, requestorSub)
-  if (changeRequest.zendeskTicketId)
-    await closeZendeskTicket(changeRequest.zendeskTicketId)
   await sendEmail({
     to: [requestorEmail],
     fromName: 'GCN Circulars',


### PR DESCRIPTION
# Description
Adds a function to the Zendesk server file to close tickets by Id, and calls the function in both the approve and reject paths

Also fixes a typo

# Testing
- As a circular submitter, create a change request
- Check zendesk to see that the ticket was created
- As a moderator either approve or reject the request
- Go back to Zendesk and see the ticket status updated to "solved"