### PR TITLE
Add direct dependency on esbuild

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,6 +104,7 @@
         "@types/tar-stream": "^3.1.1",
         "autoprefixer": "^10.4.20",
         "aws-sdk-mock": "^5.9.0",
+        "esbuild": "^0.17.6",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jest": "^27.9.0",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "@types/tar-stream": "^3.1.1",
     "autoprefixer": "^10.4.20",
     "aws-sdk-mock": "^5.9.0",
+    "esbuild": "^0.17.6",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jest": "^27.9.0",


### PR DESCRIPTION
We had an inderect dependency on esbuild because Remix depends on it, but we should have a direct dev dependency as well because our own build system calls esbuild itself.