### PR TITLE
Updates the change request form to populate with previously requested changes if they exist

### DIFF
--- a/app/lib/zendesk.server.ts
+++ b/app/lib/zendesk.server.ts
@@ -45,7 +45,13 @@ export async function postZendeskRequest(request: ZendeskRequest) {
     console.error(response)
     throw new Error(`Request failed with status ${response.status}`)
   }
-  return await response.json()
+
+  const responseJson = await response.json()
+  if (!responseJson.request.id) {
+    throw new Response(null, { status: 500 })
+  }
+
+  return responseJson.request.id
 }
 
 export async function closeZendeskTicket(ticketId: number) {

--- a/app/lib/zendesk.server.ts
+++ b/app/lib/zendesk.server.ts
@@ -49,7 +49,9 @@ export async function postZendeskRequest(request: ZendeskRequest) {
   const responseJson = await response.json()
   if (!responseJson.request.id) {
     console.error(responseJson)
-    throw new Error("ZenDesk request succeeded, but did not return a request ID")
+    throw new Error(
+      'ZenDesk request succeeded, but did not return a request ID'
+    )
   }
 
   return responseJson.request.id

--- a/app/lib/zendesk.server.ts
+++ b/app/lib/zendesk.server.ts
@@ -48,7 +48,8 @@ export async function postZendeskRequest(request: ZendeskRequest) {
 
   const responseJson = await response.json()
   if (!responseJson.request.id) {
-    throw new Response(null, { status: 500 })
+    console.error(responseJson)
+    throw new Error("ZenDesk request succeeded, but did not return a request ID")
   }
 
   return responseJson.request.id

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -112,14 +112,15 @@ export async function action({ request }: ActionFunctionArgs) {
       if (!createdOnDate || !createdOn)
         throw new Response(null, { status: 400 })
 
-      let zendeskTicketId
+      let zendeskTicketId: number | undefined
 
       try {
         zendeskTicketId = (
           await getChangeRequest(parseFloat(circularId), user.sub)
         ).zendeskTicketId
       } catch (error) {
-        console.info('No existing request found')
+        const err = error as Response
+        if (err.status !== 404) throw err
       }
 
       if (!zendeskTicketId) {
@@ -141,7 +142,7 @@ export async function action({ request }: ActionFunctionArgs) {
           ...props,
           submitter,
           createdOn,
-          zendeskTicketId: parseFloat(zendeskTicketId),
+          zendeskTicketId,
         },
         user
       )

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -118,9 +118,8 @@ export async function action({ request }: ActionFunctionArgs) {
         zendeskTicketId = (
           await getChangeRequest(parseFloat(circularId), user.sub)
         ).zendeskTicketId
-      } catch (error) {
-        const err = error as Response
-        if (err.status !== 404) throw err
+      } catch (err) {
+        if (!(err instanceof Response && err.status === 404)) throw err
       }
 
       if (!zendeskTicketId) {

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -132,6 +132,8 @@ export async function action({ request }: ActionFunctionArgs) {
         })
       }
 
+      if (!zendeskTicketId) throw new Response(null, { status: 500 })
+
       await createChangeRequest(
         {
           circularId: parseFloat(circularId),

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -123,15 +123,13 @@ export async function action({ request }: ActionFunctionArgs) {
       }
 
       if (!zendeskTicketId) {
-        ;({
-          request: { id: zendeskTicketId },
-        } = await postZendeskRequest({
+        zendeskTicketId = await postZendeskRequest({
           requester: { name: user.name, email: user.email },
           subject: `Change Request for Circular ${circularId}`,
           comment: {
             body: `${user.name} has requested an edit. Review at ${origin}/circulars`,
           },
-        }))
+        })
         if (!zendeskTicketId) throw new Response(null, { status: 500 })
       }
 

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -130,7 +130,6 @@ export async function action({ request }: ActionFunctionArgs) {
             body: `${user.name} has requested an edit. Review at ${origin}/circulars`,
           },
         })
-        if (!zendeskTicketId) throw new Response(null, { status: 500 })
       }
 
       await createChangeRequest(

--- a/app/routes/circulars.correction.$circularId.tsx
+++ b/app/routes/circulars.correction.$circularId.tsx
@@ -36,9 +36,8 @@ export async function loader({
   let existingRequest
   try {
     existingRequest = await getChangeRequest(parseFloat(circularId), user.sub)
-  } catch (error) {
-    const err = error as Response
-    if (err.status !== 404) throw err
+  } catch (err) {
+    if (!(err instanceof Response && err.status === 404)) throw err
   }
   const circular = existingRequest ?? (await get(parseFloat(circularId)))
   const defaultDateTime = new Date(circular.createdOn ?? 0).toISOString()

--- a/app/routes/circulars.correction.$circularId.tsx
+++ b/app/routes/circulars.correction.$circularId.tsx
@@ -12,7 +12,11 @@ import { useLoaderData } from '@remix-run/react'
 import { getUser } from './_auth/user.server'
 import { CircularEditForm } from './circulars.edit.$circularId/CircularEditForm'
 import { formatAuthor } from './circulars/circulars.lib'
-import { get, submitterGroup } from './circulars/circulars.server'
+import {
+  get,
+  getChangeRequest,
+  submitterGroup,
+} from './circulars/circulars.server'
 import type { BreadcrumbHandle } from '~/root/Title'
 
 export const handle: BreadcrumbHandle & SEOHandle = {
@@ -29,7 +33,13 @@ export async function loader({
   const user = await getUser(request)
   if (!user?.groups.includes(submitterGroup))
     throw new Response(null, { status: 403 })
-  const circular = await get(parseFloat(circularId))
+  let existingRequest
+  try {
+    existingRequest = await getChangeRequest(parseFloat(circularId), user.sub)
+  } catch (error) {
+    console.info('No existing request found')
+  }
+  const circular = existingRequest ?? (await get(parseFloat(circularId)))
   const defaultDateTime = new Date(circular.createdOn ?? 0).toISOString()
 
   return {

--- a/app/routes/circulars.correction.$circularId.tsx
+++ b/app/routes/circulars.correction.$circularId.tsx
@@ -37,7 +37,8 @@ export async function loader({
   try {
     existingRequest = await getChangeRequest(parseFloat(circularId), user.sub)
   } catch (error) {
-    console.info('No existing request found')
+    const err = error as Response
+    if (err.status !== 404) throw err
   }
   const circular = existingRequest ?? (await get(parseFloat(circularId)))
   const defaultDateTime = new Date(circular.createdOn ?? 0).toISOString()


### PR DESCRIPTION
Currently requesting sequential changes for a circular will replace whatever request already exists with the new changes. 

This pulls that info in now so if a user is to say submit a request to update the subject, then come back and later update the body before their request is approved, their request will now have both changes and be tied to the same zendesk ticket