### PR TITLE
Circulars: Lucene Shortcuts and Archive Page Documentation

### DIFF
--- a/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
@@ -23,9 +23,23 @@ export function LuceneAccordion({
           Lucene Search Syntax Page
         </Link>
         {'. '}
+        <div>Lucene Examples</div>
         <div>
-          <Button type="button" onClick={() => populateSearch('test')}>
-            child
+          <Button
+            type="button"
+            onClick={() => populateSearch('subject:"SWIFT"')}
+          >
+            subject:"SWIFT"
+          </Button>
+
+          <Button type="button" onClick={() => populateSearch('body:"GRB"')}>
+            body:"GRB"
+          </Button>
+          <Button
+            type="button"
+            onClick={() => populateSearch('body:"Tomas Ahumada Mena"')}
+          >
+            body:"Tomas Ahumada Mena"
           </Button>
         </div>
       </div>

--- a/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
@@ -1,53 +1,26 @@
 import { Link } from '@remix-run/react'
-import { Button, Grid, GridContainer, Icon } from '@trussworks/react-uswds'
-import React, { useState } from 'react'
 
 export function LuceneAccordion() {
-  const [isOpen, setIsOpen] = useState<boolean>(false)
-
   return (
-    <div
-      className="usa-accordion usa-accordion--multiselectable usa-accordion--bordered margin-y-1"
-      data-allow-multiple
+    <details
+    // className="usa-accordion usa-accordion--multiselectable usa-accordion--bordered margin-y-1"
+    // data-allow-multiple
+    // onClick={() => setIsOpen(!isOpen)}
     >
-      <div>
-        <div
-          className="bg-base-lightest hover:bg-base-lighter height-auto cursor-pointer padding-y-1"
-          onClick={() => setIsOpen(!isOpen)}
-        >
-          <GridContainer>
-            <Grid row className="padding-y-1">
-              <Grid col={11} className="grid-col">
-                <p className="margin-y-0">Advanced Search</p>
-              </Grid>
-              <Grid col={1}>
-                <div className="float-right">
-                  <Button
-                    type="button"
-                    className="usa-button--unstyled"
-                    onClick={() => setIsOpen(!isOpen)}
-                  >
-                    {isOpen ? <Icon.ExpandLess /> : <Icon.ExpandMore />}
-                  </Button>
-                </div>
-              </Grid>
-            </Grid>
-          </GridContainer>
-          <div
-            id="accordion-item-1"
-            hidden={!isOpen}
-            className="usa-accordion__content usa-prose padding-y-1"
-          >
-            To narrow the search results, use Lucene search syntax. This allows
-            for specifying which circular field to search (submitter, subject,
-            and/or body). Further documentation can be found on the{' '}
-            <Link className="usa-link" to="/docs/circulars/lucene">
-              Lucene Search Syntax Page
-            </Link>
-            {'. '}
-          </div>
-        </div>
+      <summary>Advanced Search</summary>
+
+      <div
+        id="accordion-item-1"
+        className="usa-accordion__content usa-prose padding-y-1"
+      >
+        To narrow the search results, use Lucene search syntax. This allows for
+        specifying which circular field to search (submitter, subject, and/or
+        body). Further documentation can be found on the{' '}
+        <Link className="usa-link" to="/docs/circulars/lucene">
+          Lucene Search Syntax Page
+        </Link>
+        {'. '}
       </div>
-    </div>
+    </details>
   )
 }

--- a/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
@@ -1,0 +1,49 @@
+import { Button, Grid, GridContainer, Icon } from '@trussworks/react-uswds'
+import React, { useState } from 'react'
+
+export function LuceneAccordion() {
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+
+  return (
+    <div
+      className="usa-accordion usa-accordion--multiselectable usa-accordion--bordered margin-y-1"
+      data-allow-multiple
+    >
+      <div>
+        <div
+          className="bg-base-lightest hover:bg-base-lighter height-auto cursor-pointer padding-y-1"
+          onClick={() => setIsOpen(!isOpen)}
+        >
+          <GridContainer>
+            <Grid row className="padding-y-1">
+              <Grid col={11} className="grid-col">
+                <p className="margin-y-0">Advanced Search</p>
+              </Grid>
+              <Grid col={1}>
+                <div className="float-right">
+                  <Button
+                    type="button"
+                    className="usa-button--unstyled"
+                    onClick={() => setIsOpen(!isOpen)}
+                  >
+                    {isOpen ? <Icon.ExpandLess /> : <Icon.ExpandMore />}
+                  </Button>
+                </div>
+              </Grid>
+            </Grid>
+          </GridContainer>
+          <div
+            id="accordion-item-1"
+            hidden={!isOpen}
+            className="usa-accordion__content usa-prose padding-y-1"
+          >
+            This is where the content for the advanced search will be displayed.
+            This will include a brief explanation of what Lucene is and how to
+            use it. There will also be a link to the Lucene documentation and
+            modal
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
@@ -37,9 +37,9 @@ export function LuceneAccordion({
           </Button>
           <Button
             type="button"
-            onClick={() => populateSearch('body:"Tomas Ahumada Mena"')}
+            onClick={() => populateSearch('submitter:"Tomas Ahumada Mena"')}
           >
-            body:"Tomas Ahumada Mena"
+            submitter:"Tomas Ahumada Mena"
           </Button>
         </div>
       </div>

--- a/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
@@ -27,21 +27,21 @@ export function LuceneAccordion({
         <div>
           <Button
             type="button"
-            className="usa-button--outline"
-            onClick={() => populateSearch('subject:"SWIFT"')}
+            outline
+            onClick={() => populateSearch('subject:"Swift"')}
           >
-            subject:"SWIFT"
+            subject:"Swift"
           </Button>
           <Button
             type="button"
-            className="usa-button--outline"
+            outline
             onClick={() => populateSearch('body:"GRB"')}
           >
             body:"GRB"
           </Button>
           <Button
             type="button"
-            className="usa-button--outline"
+            outline
             onClick={() => populateSearch('submitter:"Tomas Ahumada Mena"')}
           >
             submitter:"Tomas Ahumada Mena"

--- a/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
@@ -4,7 +4,7 @@ import { Button } from '@trussworks/react-uswds'
 export function LuceneAccordion({
   querySetter,
 }: {
-  querySetter: (arg0: string) => void
+  querySetter: (value: string) => void
 }) {
   function populateSearch() {
     querySetter('value')

--- a/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
@@ -23,20 +23,25 @@ export function LuceneAccordion({
           Lucene Search Syntax Page
         </Link>
         {'. '}
-        <div>Lucene Examples</div>
+        <h4>Lucene Examples:</h4>
         <div>
           <Button
             type="button"
+            className="usa-button--outline"
             onClick={() => populateSearch('subject:"SWIFT"')}
           >
             subject:"SWIFT"
           </Button>
-
-          <Button type="button" onClick={() => populateSearch('body:"GRB"')}>
+          <Button
+            type="button"
+            className="usa-button--outline"
+            onClick={() => populateSearch('body:"GRB"')}
+          >
             body:"GRB"
           </Button>
           <Button
             type="button"
+            className="usa-button--outline"
             onClick={() => populateSearch('submitter:"Tomas Ahumada Mena"')}
           >
             submitter:"Tomas Ahumada Mena"

--- a/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@remix-run/react'
 import { Button, Grid, GridContainer, Icon } from '@trussworks/react-uswds'
 import React, { useState } from 'react'
 
@@ -37,10 +38,13 @@ export function LuceneAccordion() {
             hidden={!isOpen}
             className="usa-accordion__content usa-prose padding-y-1"
           >
-            This is where the content for the advanced search will be displayed.
-            This will include a brief explanation of what Lucene is and how to
-            use it. There will also be a link to the Lucene documentation and
-            modal
+            To narrow the search results, use Lucene search syntax. This allows
+            for specifying which circular field to search (submitter, subject,
+            and/or body). Further documentation can be found on the{' '}
+            <Link className="usa-link" to="/docs/circulars/lucene">
+              Lucene Search Syntax Page
+            </Link>
+            {'. '}
           </div>
         </div>
       </div>

--- a/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
@@ -1,18 +1,21 @@
 import { Link } from '@remix-run/react'
+import { Button } from '@trussworks/react-uswds'
 
-export function LuceneAccordion() {
+export function LuceneAccordion({
+  querySetter,
+}: {
+  querySetter: (arg0: string) => void
+}) {
+  function populateSearch() {
+    querySetter('value')
+    console.log('clickedPopulateSearch')
+    return null
+  }
   return (
-    <details
-    // className="usa-accordion usa-accordion--multiselectable usa-accordion--bordered margin-y-1"
-    // data-allow-multiple
-    // onClick={() => setIsOpen(!isOpen)}
-    >
+    <details>
       <summary>Advanced Search</summary>
 
-      <div
-        id="accordion-item-1"
-        className="usa-accordion__content usa-prose padding-y-1"
-      >
+      <div>
         To narrow the search results, use Lucene search syntax. This allows for
         specifying which circular field to search (submitter, subject, and/or
         body). Further documentation can be found on the{' '}
@@ -20,6 +23,11 @@ export function LuceneAccordion() {
           Lucene Search Syntax Page
         </Link>
         {'. '}
+        <div>
+          <Button type="button" onClick={() => populateSearch()}>
+            child
+          </Button>
+        </div>
       </div>
     </details>
   )

--- a/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/CircularsLuceneMenu.tsx
@@ -2,14 +2,14 @@ import { Link } from '@remix-run/react'
 import { Button } from '@trussworks/react-uswds'
 
 export function LuceneAccordion({
+  query,
   querySetter,
 }: {
+  query?: string
   querySetter: (value: string) => void
 }) {
-  function populateSearch() {
-    querySetter('value')
-    console.log('clickedPopulateSearch')
-    return null
+  function populateSearch(value: string) {
+    querySetter(`${query} ${value}`)
   }
   return (
     <details>
@@ -24,7 +24,7 @@ export function LuceneAccordion({
         </Link>
         {'. '}
         <div>
-          <Button type="button" onClick={() => populateSearch()}>
+          <Button type="button" onClick={() => populateSearch('test')}>
             child
           </Button>
         </div>

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -51,7 +51,7 @@ import { ToolbarButtonGroup } from '~/components/ToolbarButtonGroup'
 import { origin } from '~/lib/env.server'
 import { getFormDataString } from '~/lib/utils'
 import { postZendeskRequest } from '~/lib/zendesk.server'
-import { useModStatus } from '~/root'
+import { useFeature, useModStatus } from '~/root'
 
 import searchImg from 'nasawds/src/img/usa-icons-bg/search--white.svg'
 
@@ -261,9 +261,7 @@ export default function () {
         To navigate to a specific circular, enter the associated Circular ID
         (e.g. 'gcn123', 'Circular 123', or '123').
       </Hint>
-
-      <LuceneAccordion />
-
+      {useFeature('CIRCULARS_LUCENE') && <LuceneAccordion />}
       {clean && (
         <>
           <CircularsIndex

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -261,7 +261,9 @@ export default function () {
         To navigate to a specific circular, enter the associated Circular ID
         (e.g. 'gcn123', 'Circular 123', or '123').
       </Hint>
-      {useFeature('CIRCULARS_LUCENE') && <LuceneAccordion />}
+      {useFeature('CIRCULARS_LUCENE') && (
+        <LuceneAccordion querySetter={setInputQuery} />
+      )}
       {clean && (
         <>
           <CircularsIndex

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -228,6 +228,7 @@ export default function () {
             name="query"
             type="search"
             defaultValue={inputQuery}
+            value={inputQuery}
             placeholder="Search"
             aria-describedby="searchHint"
             onChange={({ target: { form, value } }) => {
@@ -262,7 +263,7 @@ export default function () {
         (e.g. 'gcn123', 'Circular 123', or '123').
       </Hint>
       {useFeature('CIRCULARS_LUCENE') && (
-        <LuceneAccordion querySetter={setInputQuery} />
+        <LuceneAccordion query={inputQuery} querySetter={setInputQuery} />
       )}
       {clean && (
         <>

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -43,6 +43,7 @@ import {
 import CircularPagination from './CircularPagination'
 import CircularsHeader from './CircularsHeader'
 import CircularsIndex from './CircularsIndex'
+import { LuceneAccordion } from './CircularsLuceneMenu'
 import { DateSelector } from './DateSelectorMenu'
 import { SortSelector } from './SortSelectorButton'
 import Hint from '~/components/Hint'
@@ -260,6 +261,9 @@ export default function () {
         To navigate to a specific circular, enter the associated Circular ID
         (e.g. 'gcn123', 'Circular 123', or '123').
       </Hint>
+
+      <LuceneAccordion />
+
       {clean && (
         <>
           <CircularsIndex

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -160,7 +160,7 @@ export async function search({
         }
 
   const queryObj = query
-    ? feature('CICRULARS_LUCENE')
+    ? feature('CIRCULARS_LUCENE')
       ? {
           simple_query_string: {
             query,


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
This adds a brief explanation of Lucene queries to the Circulars Archive page as well as shortcut buttons to populate the search bar with common Lucene search syntax 

# Related Issue(s)

Tracked by #2288 

# Testing
1. Navigate to Circulars Archive
2. Click on the "Advanced Search" (Tentative Label) Accordion Menu
3. The menu should expand
4. Any Shortcut buttons should be clickable, resulting in the addition of the selected lucene query to the query. This should be reflected directly in the search bar and should not clear the existing query 
