### PR TITLE
Moves the definition of the send function to resolve issues with kafka related imports in the remix build

### DIFF
--- a/app/lib/email.server.ts
+++ b/app/lib/email.server.ts
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { services, tables } from '@architect/functions'
+import { services } from '@architect/functions'
 import type {
   BulkEmailEntry,
   SendBulkEmailCommandInput,
@@ -17,20 +17,15 @@ import {
   SendBulkEmailCommand,
   SendEmailCommand,
 } from '@aws-sdk/client-sesv2'
-import { paginateQuery, paginateScan } from '@aws-sdk/lib-dynamodb'
-import type { DynamoDBDocument } from '@aws-sdk/lib-dynamodb'
 import chunk from 'lodash/chunk'
 
-import { hostname, origin } from './env.server'
+import { hostname } from './env.server'
 import { getEnvBannerHeaderAndDescription } from './utils'
-import type { Circular } from '~/routes/circulars/circulars.lib'
-import { formatCircularText } from '~/routes/circulars/circulars.lib'
 import { encodeToURL } from '~/routes/unsubscribe.$jwt/jwt.server'
 
 const client = new SESv2Client({})
 // https://docs.aws.amazon.com/ses/latest/dg/quotas.html
 const maxRecipientsPerMessage = 50
-const fromName = 'GCN Circulars'
 
 interface MessageProps {
   /** The name to show in the From: address. */
@@ -82,65 +77,6 @@ async function sendSES(sendCommandInput: SendEmailCommandInput) {
       console.warn(`SES threw ${e.name}. This would be an error in production.`)
     }
   }
-}
-
-async function getEmails() {
-  const db = await tables()
-  const client = db._doc as unknown as DynamoDBDocument
-  const TableName = db.name('circulars_subscriptions')
-  const pages = paginateScan(
-    { client },
-    { AttributesToGet: ['email'], TableName }
-  )
-  const emails: string[] = []
-  for await (const page of pages) {
-    const newEmails = page.Items?.map(({ email }) => email)
-    if (newEmails) emails.push(...newEmails)
-  }
-  return emails
-}
-
-async function getLegacyEmails() {
-  const db = await tables()
-  const client = db._doc as unknown as DynamoDBDocument
-  const TableName = db.name('legacy_users')
-  const pages = paginateQuery(
-    { client },
-    {
-      IndexName: 'legacyReceivers',
-      KeyConditionExpression: 'receive = :receive',
-      ExpressionAttributeValues: {
-        ':receive': 1,
-      },
-      ProjectionExpression: 'email',
-      TableName,
-    }
-  )
-  const emails: string[] = []
-  for await (const page of pages) {
-    const newEmails = page.Items?.map(({ email }) => email)
-    if (newEmails) emails.push(...newEmails)
-  }
-  return emails
-}
-
-export async function send(circular: Circular) {
-  const [emails, legacyEmails] = await Promise.all([
-    getEmails(),
-    getLegacyEmails(),
-  ])
-  const to = [...emails, ...legacyEmails]
-  await sendEmailBulk({
-    fromName,
-    to,
-    subject: circular.subject,
-    body: `${formatCircularText(
-      circular
-    )}\n\n\nView this GCN Circular online at ${origin}/circulars/${
-      circular.circularId
-    }.`,
-    topic: 'circulars',
-  })
 }
 
 /** Send an email to many recipients in parallel. */

--- a/app/lib/email.server.ts
+++ b/app/lib/email.server.ts
@@ -60,7 +60,7 @@ function getFrom(fromName: string) {
   return `${fromName} <no-reply@${hostname}>`
 }
 
-async function sendSES(sendCommandInput: SendEmailCommandInput) {
+async function send(sendCommandInput: SendEmailCommandInput) {
   const command = new SendEmailCommand(sendCommandInput)
   try {
     await client.send(command)
@@ -133,7 +133,7 @@ export async function sendEmail({
   subject,
   body,
 }: MessageProps) {
-  await sendSES({
+  await send({
     Destination: {
       ToAddresses: to,
     },

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -7,7 +7,11 @@
  */
 import { tables } from '@architect/functions'
 import type { DynamoDB } from '@aws-sdk/client-dynamodb'
-import { type DynamoDBDocument, paginateScan } from '@aws-sdk/lib-dynamodb'
+import {
+  type DynamoDBDocument,
+  paginateQuery,
+  paginateScan,
+} from '@aws-sdk/lib-dynamodb'
 import { search as getSearch } from '@nasa-gcn/architect-functions-search'
 import {
   DynamoDBAutoIncrement,
@@ -21,6 +25,7 @@ import { type User, getUser } from '../_auth/user.server'
 import {
   bodyIsValid,
   formatAuthor,
+  formatCircularText,
   formatIsValid,
   parseEventFromSubject,
   subjectIsValid,
@@ -31,7 +36,7 @@ import type {
   CircularChangeRequestKeys,
   CircularMetadata,
 } from './circulars.lib'
-import { send, sendEmail } from '~/lib/email.server'
+import { sendEmail, sendEmailBulk } from '~/lib/email.server'
 import { feature, origin } from '~/lib/env.server'
 import { closeZendeskTicket } from '~/lib/zendesk.server'
 
@@ -40,6 +45,8 @@ type Require<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
 
 export const submitterGroup = 'gcn.nasa.gov/circular-submitter'
 export const moderatorGroup = 'gcn.nasa.gov/circular-moderator'
+
+const fromName = 'GCN Circulars'
 
 const getDynamoDBAutoIncrement = memoizee(
   async function () {
@@ -591,4 +598,63 @@ function validateCircular({
   if (!bodyIsValid(body)) throw new Response('body is invalid', { status: 400 })
   if (!(format === undefined || formatIsValid(format)))
     throw new Response('format is invalid', { status: 400 })
+}
+
+async function getEmails() {
+  const db = await tables()
+  const client = db._doc as unknown as DynamoDBDocument
+  const TableName = db.name('circulars_subscriptions')
+  const pages = paginateScan(
+    { client },
+    { AttributesToGet: ['email'], TableName }
+  )
+  const emails: string[] = []
+  for await (const page of pages) {
+    const newEmails = page.Items?.map(({ email }) => email)
+    if (newEmails) emails.push(...newEmails)
+  }
+  return emails
+}
+
+async function getLegacyEmails() {
+  const db = await tables()
+  const client = db._doc as unknown as DynamoDBDocument
+  const TableName = db.name('legacy_users')
+  const pages = paginateQuery(
+    { client },
+    {
+      IndexName: 'legacyReceivers',
+      KeyConditionExpression: 'receive = :receive',
+      ExpressionAttributeValues: {
+        ':receive': 1,
+      },
+      ProjectionExpression: 'email',
+      TableName,
+    }
+  )
+  const emails: string[] = []
+  for await (const page of pages) {
+    const newEmails = page.Items?.map(({ email }) => email)
+    if (newEmails) emails.push(...newEmails)
+  }
+  return emails
+}
+
+export async function send(circular: Circular) {
+  const [emails, legacyEmails] = await Promise.all([
+    getEmails(),
+    getLegacyEmails(),
+  ])
+  const to = [...emails, ...legacyEmails]
+  await sendEmailBulk({
+    fromName,
+    to,
+    subject: circular.subject,
+    body: `${formatCircularText(
+      circular
+    )}\n\n\nView this GCN Circular online at ${origin}/circulars/${
+      circular.circularId
+    }.`,
+    topic: 'circulars',
+  })
 }

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -31,10 +31,9 @@ import type {
   CircularChangeRequestKeys,
   CircularMetadata,
 } from './circulars.lib'
-import { sendEmail } from '~/lib/email.server'
+import { send, sendEmail } from '~/lib/email.server'
 import { feature, origin } from '~/lib/env.server'
 import { closeZendeskTicket } from '~/lib/zendesk.server'
-import { send } from '~/table-streams/circulars'
 
 // A type with certain keys required.
 type Require<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>

--- a/app/table-streams/circulars/index.ts
+++ b/app/table-streams/circulars/index.ts
@@ -5,25 +5,19 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { tables } from '@architect/functions'
-import { paginateQuery, paginateScan } from '@aws-sdk/lib-dynamodb'
-import type { DynamoDBDocument } from '@aws-sdk/lib-dynamodb'
 import { search as getSearchClient } from '@nasa-gcn/architect-functions-search'
 import { errors } from '@opensearch-project/opensearch'
 import type { DynamoDBRecord } from 'aws-lambda'
 
 import { unmarshallTrigger } from '../utils'
-import { sendEmailBulk } from '~/lib/email.server'
-import { origin } from '~/lib/env.server'
+import { send } from '~/lib/email.server'
 import { send as sendKafka } from '~/lib/kafka.server'
 import { createTriggerHandler } from '~/lib/lambdaTrigger.server'
 import type { Circular } from '~/routes/circulars/circulars.lib'
-import { formatCircularText } from '~/routes/circulars/circulars.lib'
 
 import { $id as circularsJsonSchemaId } from '@nasa-gcn/schema/gcn/circulars.schema.json'
 
 const index = 'circulars'
-const fromName = 'GCN Circulars'
 
 async function removeIndex(id: number) {
   const client = await getSearchClient()
@@ -42,65 +36,6 @@ async function putIndex(circular: Circular) {
     index,
     id: circular.circularId.toString(),
     body: circular,
-  })
-}
-
-async function getEmails() {
-  const db = await tables()
-  const client = db._doc as unknown as DynamoDBDocument
-  const TableName = db.name('circulars_subscriptions')
-  const pages = paginateScan(
-    { client },
-    { AttributesToGet: ['email'], TableName }
-  )
-  const emails: string[] = []
-  for await (const page of pages) {
-    const newEmails = page.Items?.map(({ email }) => email)
-    if (newEmails) emails.push(...newEmails)
-  }
-  return emails
-}
-
-async function getLegacyEmails() {
-  const db = await tables()
-  const client = db._doc as unknown as DynamoDBDocument
-  const TableName = db.name('legacy_users')
-  const pages = paginateQuery(
-    { client },
-    {
-      IndexName: 'legacyReceivers',
-      KeyConditionExpression: 'receive = :receive',
-      ExpressionAttributeValues: {
-        ':receive': 1,
-      },
-      ProjectionExpression: 'email',
-      TableName,
-    }
-  )
-  const emails: string[] = []
-  for await (const page of pages) {
-    const newEmails = page.Items?.map(({ email }) => email)
-    if (newEmails) emails.push(...newEmails)
-  }
-  return emails
-}
-
-export async function send(circular: Circular) {
-  const [emails, legacyEmails] = await Promise.all([
-    getEmails(),
-    getLegacyEmails(),
-  ])
-  const to = [...emails, ...legacyEmails]
-  await sendEmailBulk({
-    fromName,
-    to,
-    subject: circular.subject,
-    body: `${formatCircularText(
-      circular
-    )}\n\n\nView this GCN Circular online at ${origin}/circulars/${
-      circular.circularId
-    }.`,
-    topic: 'circulars',
   })
 }
 

--- a/app/table-streams/circulars/index.ts
+++ b/app/table-streams/circulars/index.ts
@@ -10,10 +10,10 @@ import { errors } from '@opensearch-project/opensearch'
 import type { DynamoDBRecord } from 'aws-lambda'
 
 import { unmarshallTrigger } from '../utils'
-import { send } from '~/lib/email.server'
 import { send as sendKafka } from '~/lib/kafka.server'
 import { createTriggerHandler } from '~/lib/lambdaTrigger.server'
 import type { Circular } from '~/routes/circulars/circulars.lib'
+import { send } from '~/routes/circulars/circulars.server'
 
 import { $id as circularsJsonSchemaId } from '@nasa-gcn/schema/gcn/circulars.schema.json'
 


### PR DESCRIPTION
Temporary solution for #2588

It looks like the issue started with [this commit](https://github.com/nasa-gcn/gcn.nasa.gov/commit/dd4f9d6971c3e35e1d6c46fe69180f4affeacc4b)

This PR moves the definition of the send function so it can still be reusable and should remove any dependency that would have caused the `.node` library to be needed. 

The next step is to figure out the best way to include the zstd library in the build, as future updates will possibly require it for more Kafka functionality