### PR TITLE
Circulars: Correct Lucene Feature Flag Typo

### DIFF
--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -161,7 +161,7 @@ export async function search({
         }
 
   const queryObj = query
-    ? feature('CICRULARS_LUCENE')
+    ? feature('CIRCULARS_LUCENE')
       ? {
           simple_query_string: {
             query,


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
There was a typo in Lucene Feature flag in `circulars.server.ts`. This PR corrects it.


# Testing
1. Verify Spelling of plural form of ["Circular"](https://www.merriam-webster.com/dictionary/circular)
