### PR TITLE
update burstcube status

### DIFF
--- a/app/routes/missions.burstcube/route.mdx
+++ b/app/routes/missions.burstcube/route.mdx
@@ -7,10 +7,6 @@ import logo from './logo.png'
 
 import { Alert } from '@trussworks/react-uswds'
 
-<Alert type="warning" heading="Not yet active" headingLevel="h4">
-  BurstCube Notice types are not yet in production.
-</Alert>
-
 # BurstCube
 
 <img
@@ -24,14 +20,18 @@ import { Alert } from '@trussworks/react-uswds'
 
 **Launch Date:** March 21, 2024
 
-**Start of Science Operations:** May/June 2024
+**ISS Deployment:** April 18, 2024
 
-**End of Operations:** No specific requirement
+**Start of Science Operations:** May 30, 2024
+
+**End of Operations:** September 13, 2024
 
 **Data Archive:**
 [HEASARC BurstCube Archive](https://heasarc.gsfc.nasa.gov/docs/burstcube/archive/)
 
 [BurstCube](https://science.nasa.gov/mission/burstcube/) is a 6U CubeSat operated by NASA. It monitors the sky, autonomously detecting gamma-ray transients and relaying alerts to the ground via NASA's TDRS space communication network.
+
+Note that during its shorter-than-planned mission, BurstCube never generated any GCN Notices. This mission page is maintained to provide a record of what was planned and Notice schema design, so that they may be useful for similar future missions.
 
 <div className="overflow-table">
 

--- a/app/routes/missions.burstcube/route.mdx
+++ b/app/routes/missions.burstcube/route.mdx
@@ -5,8 +5,6 @@ handle:
 
 import logo from './logo.png'
 
-import { Alert } from '@trussworks/react-uswds'
-
 # BurstCube
 
 <img


### PR DESCRIPTION
# Description
Updated BurstCube mission status and explained why page is being maintained as a reference for future missions.

# Related Issue(s)
Resolves #2583 

# Testing
Rendered in local version.