### PR TITLE
Add Synonym link to NavBar for moderators

### DIFF
--- a/app/root/header/Header.tsx
+++ b/app/root/header/Header.tsx
@@ -111,7 +111,7 @@ export function Header() {
       <USWDSHeader basic className={`usa-header--dark ${styles.header}`}>
         <div className="usa-nav-container">
           <div className="usa-navbar">
-            <Title>
+            <Title style={{ width: 'max-content' }}>
               <Link to="/">
                 <Meatball className="width-auto" />
                 <span>General Coordinates Network</span>

--- a/app/root/header/Header.tsx
+++ b/app/root/header/Header.tsx
@@ -17,7 +17,7 @@ import { useEffect, useState } from 'react'
 import { useClickAnyWhere, useWindowSize } from 'usehooks-ts'
 
 import { Meatball } from '~/components/meatball/Meatball'
-import { useEmail, useUserIdp } from '~/root'
+import { useEmail, useModStatus, useUserIdp } from '~/root'
 
 import styles from './header.module.css'
 
@@ -74,6 +74,7 @@ export function Header() {
   const [expanded, setExpanded] = useState(false)
   const [userMenuIsOpen, setUserMenuIsOpen] = useState(false)
   const isMobile = useWindowSize().width < 1024
+  const isModerator = useModStatus()
 
   function toggleMobileNav() {
     setExpanded((expanded) => !expanded)
@@ -139,6 +140,15 @@ export function Header() {
               >
                 Circulars
               </NavLink>,
+              isModerator ? (
+                <NavLink
+                  className="usa-nav__link"
+                  to="/synonyms"
+                  key="/synonyms"
+                >
+                  Synonyms
+                </NavLink>
+              ) : null,
               <NavLink className="usa-nav__link" to="/docs" key="/docs">
                 Documentation
               </NavLink>,


### PR DESCRIPTION
# Description
Adding moderator gated link to Synonyms moderation route.

With the link not visible as a non-logged in user:
<img width="1224" alt="Screenshot 2024-10-10 at 5 06 57 PM" src="https://github.com/user-attachments/assets/ab95fac9-5ce9-4dcd-b984-d9982abf92db">


With the link visible:
<img width="1226" alt="Screenshot 2024-10-10 at 5 06 44 PM" src="https://github.com/user-attachments/assets/82b5c89c-9a7b-4cd8-98a9-72aef4cf8eb5">

With the link not visible as a logged in user:
<img width="1223" alt="Screenshot 2024-10-10 at 5 10 19 PM" src="https://github.com/user-attachments/assets/bea41870-9d94-4d09-873e-558763cdd233">

Mobile view:
<img width="456" alt="Screenshot 2024-10-10 at 5 13 54 PM" src="https://github.com/user-attachments/assets/678a7726-06a9-44d7-ac8c-8dcd86fcecec">
<img width="425" alt="Screenshot 2024-10-10 at 5 13 47 PM" src="https://github.com/user-attachments/assets/4f3ce842-233a-46ab-ac40-7f599e4cf3af">

and because I know you'll ask about it, the reason I added `style={{ width: 'max-content' }}` to the Title is because without it, the additional characters in the PrimaryNav cause the "General Coordinates Network" to all stack on top of each other which makes the header very noticeably taller than normal. Here is an image without that style added:
<img width="1060" alt="Screenshot 2024-10-10 at 4 06 11 PM" src="https://github.com/user-attachments/assets/ae7e285e-1ace-4ad6-aa8a-0f38b8f88e09">

I can add "Syno" without anything changing at all, but if you add the rest of the word things start to change slightly to fit all the text in the nav bar.

# Related Issue(s)
Resolves #2618 

# Testing
Manual testing both as a logged in moderator and a logged out user. This should be tested on dev with a logged out user, a logged in non-moderator user, and a logged in moderator.
