### PR TITLE
news item for oct18 outage and schema v4.2.0 

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -253,7 +253,7 @@ export function Layout({ children }: { children?: ReactNode }) {
         <DevBanner />
         <Header />
         <NewsBanner>
-          New! Circulars over Kafka, Heartbeat Topic, and Schema v4.1.0. See{' '}
+          New! October 18 GCN Classic Outage and Schema v4.2.0. See{' '}
           <Link
             className="usa-link"
             to="/news#circulars-are-now-available-via-kafka-heartbeat-kafka-topic-and-schema-release-v410"

--- a/app/routes/news._index.mdx
+++ b/app/routes/news._index.mdx
@@ -29,6 +29,26 @@ import { Anchor } from '~/components/Anchor'
     <CollectionItem
       className="maxw-none"
       variantComponent={
+        <CollectionCalendarDate datetime={'October 15, 2024'} />
+      }
+    >
+      <CollectionHeading headingLevel="h3">
+        <Anchor>GCN Classic Outage and Schema Release v4.2.0</Anchor>
+      </CollectionHeading>
+      <CollectionDescription>
+        - Due to planned network maintenance at GSFC, the connections to GCN Classic will have intermittent loss of network connectivity on Friday, October 18 from 7 pm ET (23:00 UTC) until 11 pm ET (3:00 UTC October 19). This affects the following GCN services:
+          - GCN Classic Notices distribution via socket, VOEvent, and email
+          - GCN Classic Notices web site archive
+          - GCN Classic-to-Kafka connection and distribution of Notices via Kafka and email, however JSON-format Notices distrbution via GCN Kafka will be unaffected
+          - Forwarding of GCN Circulars submitted to gcncirc@capella2.gsfc.nasa.gov, however submission to circulars@gcn.nasa.gov and the [web form](/circulars) will be unaffected.
+        - **Schema v4.2.0** includes the following update:
+          - `id` property (from the Event core schema) added to [IceCube lvk_nu_track_search notices](https://gcn.nasa.gov/docs/schema/v4.2.0/gcn/notices/icecube/lvk_nu_track_search.schema.json).
+      </CollectionDescription>
+    </CollectionItem>
+
+    <CollectionItem
+      className="maxw-none"
+      variantComponent={
         <CollectionCalendarDate datetime={'July 30, 2024'} />
       }
     >


### PR DESCRIPTION
# Description
Announcement for upcoming outage due to network maintenance and new minor schema release.

This is a draft - let's wait until ~Oct 15 to announce in case we have additional items to add.

# Related Issue(s)

# Testing
Tested in local development.