### PR TITLE
adding synonym moderation link to circulars index page

### DIFF
--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -216,6 +216,11 @@ export default function () {
           {requestedChangeCount > 1 ? 's' : ''}
         </Link>
       )}
+      {userIsModerator && (
+        <Link to="/synonyms" className="usa-button usa-button--outline">
+          Synonym Moderation
+        </Link>
+      )}
       <ToolbarButtonGroup className="position-sticky top-0 bg-white margin-bottom-1 padding-top-1 z-300">
         <Form
           preventScrollReset


### PR DESCRIPTION
# Description
Adds a synonym moderation button link to circulars archive index page for moderators.
<img width="892" alt="Screenshot 2024-10-16 at 12 12 07 PM" src="https://github.com/user-attachments/assets/4b5e81a0-02e2-4d8e-b7ad-8aae19b05ba6">


Related Issue(s)

Resolves https://github.com/nasa-gcn/gcn.nasa.gov/issues/2618
Testing

Manual testing both as a logged in moderator and a logged out user. This should be tested on dev with a logged out user, a logged in non-moderator user, and a logged in moderator.
