### PR TITLE
Fix link for Einstein Probe example alert JSON

### DIFF
--- a/app/routes/missions.einstein-probe/route.mdx
+++ b/app/routes/missions.einstein-probe/route.mdx
@@ -36,7 +36,7 @@ The [Einstein Probe (EP)](https://ep.bao.ac.cn/ep/) is a mission of the Chinese 
 Einstein Probe distributes alerts for the detection of gamma-ray transients. These notices are published on the GCN Kafka topic `gcn.notices.einstein_probe.wxt.alert`.
 
 The [GCN schema](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) and
-example [JSON message](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.example.json) files are available to use for [Einstein Probe Schema](/schema/stable/gcn/notices/einstein_probe). See the [Schema Browser](/docs/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) for more information on the properties defined in the schema.
+example [JSON message](/schema/stable/gcn/notices/einstein_probe/wxt/alert.example.json) files are available to use for [Einstein Probe Schema](/schema/stable/gcn/notices/einstein_probe). See the [Schema Browser](/docs/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) for more information on the properties defined in the schema.
 
 Detailed description and examples of EP Notices are available in the [GCN Schema GitHub project](https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/einstein_probe/wxt).
 


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
The link to an example JSON alert for Einstein probe on this page: https://gcn.nasa.gov/missions/einstein-probe leads to a 404 due to an error in the linked filename. 

# Testing
Tested in local development environment.