### PR TITLE
Fermi notices

### DIFF
--- a/app/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes.tsx
+++ b/app/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes.tsx
@@ -242,6 +242,11 @@ export function NoticeTypeCheckboxes({
     JsonNoticeTypeLinks.Fermi = '/missions/fermi'
   }
 
+  if (useFeature('SUPER_K_QUICKSTART')) {
+    JsonNoticeTypes['Super Kamiokande'] = ['gcn.notices.superk']
+    JsonNoticeTypeLinks['Super Kamiokande'] = '/missions/sksn'
+  }
+
   const counterfunction = (childRef: HTMLInputElement) => {
     if (childRef.checked) {
       userSelected.add(childRef.name)

--- a/app/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes.tsx
+++ b/app/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes.tsx
@@ -244,7 +244,7 @@ export function NoticeTypeCheckboxes({
 
   if (useFeature('SUPER_K_QUICKSTART')) {
     JsonNoticeTypes['Super Kamiokande'] = [
-      'gcn.notices.superk.sn_alert.real',
+      'gcn.notices.superk.sn_alert',
       'gcn.notices.superk.sn_alert.test',
     ]
     JsonNoticeTypeLinks['Super Kamiokande'] = '/missions/sksn'

--- a/app/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes.tsx
+++ b/app/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes.tsx
@@ -243,7 +243,10 @@ export function NoticeTypeCheckboxes({
   }
 
   if (useFeature('SUPER_K_QUICKSTART')) {
-    JsonNoticeTypes['Super Kamiokande'] = ['gcn.notices.superk']
+    JsonNoticeTypes['Super Kamiokande'] = [
+      'gcn.notices.superk.sn_alert.real',
+      'gcn.notices.superk.sn_alert.test',
+    ]
     JsonNoticeTypeLinks['Super Kamiokande'] = '/missions/sksn'
   }
 


### PR DESCRIPTION
Shortened list of new fermi notices. Just the `gcn.notices.fermi.gbm` (alert is implied) and an enum can be used to determine the sub type of the alert
