### PR TITLE
create synonym group for eventId if none exists

### DIFF
--- a/__tests__/synonyms.server.ts
+++ b/__tests__/synonyms.server.ts
@@ -11,6 +11,8 @@ import {
 
 jest.mock('@architect/functions')
 const synonymId = 'abcde-abcde-abcde-abcde-abcde'
+const altSynonymId1 = 'zyxw-zyxw-zyxw-zyxw-zyxw'
+const altSynonymId2 = 'lmno-lmno-lmno-lmno-lmno'
 const exampleCirculars = [
   {
     Items: [
@@ -124,10 +126,6 @@ describe('putSynonyms', () => {
   const mockBatchWrite = jest.fn()
   const mockQuery = jest.fn()
 
-  beforeAll(() => {
-    jest.spyOn(crypto, 'randomUUID').mockReturnValue(synonymId)
-  })
-
   afterAll(() => {
     jest.restoreAllMocks()
     awsSDKMock.restore('DynamoDB')
@@ -180,6 +178,7 @@ describe('putSynonyms', () => {
   })
 
   test('putSynonyms should write to DynamoDB if there are additions', async () => {
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue(synonymId)
     const mockClient = {
       batchWrite: mockBatchWrite,
       query: mockQuery,
@@ -225,6 +224,10 @@ describe('putSynonyms', () => {
   })
 
   test('putSynonyms should write to DynamoDB if there are subtractions', async () => {
+    jest
+      .spyOn(crypto, 'randomUUID')
+      .mockImplementationOnce(() => altSynonymId1)
+      .mockImplementationOnce(() => altSynonymId2)
     const mockClient = {
       batchWrite: mockBatchWrite,
     }
@@ -242,8 +245,16 @@ describe('putSynonyms', () => {
     const params = {
       RequestItems: {
         synonyms: [
-          { DeleteRequest: { Key: { eventId: 'eventId3' } } },
-          { DeleteRequest: { Key: { eventId: 'eventId4' } } },
+          {
+            PutRequest: {
+              Item: { eventId: 'eventId3', synonymId: altSynonymId1 },
+            },
+          },
+          {
+            PutRequest: {
+              Item: { eventId: 'eventId4', synonymId: altSynonymId2 },
+            },
+          },
         ],
       },
     }
@@ -251,6 +262,10 @@ describe('putSynonyms', () => {
   })
 
   test('putSynonyms should write to DynamoDB if there are additions and subtractions', async () => {
+    jest
+      .spyOn(crypto, 'randomUUID')
+      .mockImplementationOnce(() => altSynonymId1)
+      .mockImplementationOnce(() => altSynonymId2)
     const mockClient = {
       batchWrite: mockBatchWrite,
       query: mockQuery,
@@ -278,16 +293,18 @@ describe('putSynonyms', () => {
       RequestItems: {
         synonyms: [
           {
-            DeleteRequest: {
-              Key: {
+            PutRequest: {
+              Item: {
                 eventId: 'eventId3',
+                synonymId: altSynonymId1,
               },
             },
           },
           {
-            DeleteRequest: {
-              Key: {
+            PutRequest: {
+              Item: {
                 eventId: 'eventId4',
+                synonymId: altSynonymId2,
               },
             },
           },

--- a/__tests__/synonyms.server.ts
+++ b/__tests__/synonyms.server.ts
@@ -4,7 +4,10 @@ import * as awsSDKMock from 'aws-sdk-mock'
 import crypto from 'crypto'
 
 import type { Circular } from '~/routes/circulars/circulars.lib'
-import { createSynonyms, putSynonyms } from '~/routes/synonyms/synonyms.server'
+import {
+  moderatorCreateSynonyms,
+  putSynonyms,
+} from '~/routes/synonyms/synonyms.server'
 
 jest.mock('@architect/functions')
 const synonymId = 'abcde-abcde-abcde-abcde-abcde'
@@ -36,7 +39,7 @@ const exampleCirculars = [
   { Items: [] },
 ]
 
-describe('createSynonyms', () => {
+describe('moderatorCreateSynonyms', () => {
   beforeEach(() => {
     const mockBatchWrite = jest.fn()
     const mockQuery = jest.fn()
@@ -65,7 +68,7 @@ describe('createSynonyms', () => {
     jest.restoreAllMocks()
   })
 
-  test('createSynonyms should write to DynamoDB', async () => {
+  test('moderatorCreateSynonyms should write to DynamoDB', async () => {
     const mockBatchWriteItem = jest.fn(
       (
         params: DynamoDB.DocumentClient.BatchWriteItemInput,
@@ -81,12 +84,12 @@ describe('createSynonyms', () => {
     awsSDKMock.mock('DynamoDB', 'batchWriteItem', mockBatchWriteItem)
 
     const synonymousEventIds = ['eventId1', 'eventId2']
-    const result = await createSynonyms(synonymousEventIds)
+    const result = await moderatorCreateSynonyms(synonymousEventIds)
 
     expect(result).toBe(synonymId)
   })
 
-  test('createSynonyms with nonexistent eventId throws Response 400', async () => {
+  test('moderatorCreateSynonyms with nonexistent eventId throws Response 400', async () => {
     const mockBatchWriteItem = jest.fn(
       (
         params: DynamoDB.DocumentClient.BatchWriteItemInput,
@@ -103,7 +106,7 @@ describe('createSynonyms', () => {
 
     const synonymousEventIds = ['eventId1', 'nope']
     try {
-      await createSynonyms(synonymousEventIds)
+      await moderatorCreateSynonyms(synonymousEventIds)
     } catch (error) {
       // eslint-disable-next-line jest/no-conditional-expect
       expect(error).toBeInstanceOf(Response)

--- a/app/email-incoming/circulars/index.ts
+++ b/app/email-incoming/circulars/index.ts
@@ -27,6 +27,10 @@ import {
 import { sendEmail } from '~/lib/email.server'
 import { hostname, origin } from '~/lib/env.server'
 import { putRaw, submitterGroup } from '~/routes/circulars/circulars.server'
+import {
+  createSynonyms,
+  synonymExists,
+} from '~/routes/synonyms/synonyms.server'
 
 interface UserData {
   email: string
@@ -99,6 +103,8 @@ export const handler = createEmailIncomingMessageHandler(
     // Removes sub as a property if it is undefined from the legacy users
     if (!circular.sub) delete circular.sub
     const { circularId } = await putRaw(circular)
+    if (eventId && !(await synonymExists({ eventId })))
+      await createSynonyms([eventId])
 
     // Send a success email
     await sendSuccessEmail({

--- a/app/email-incoming/circulars/index.ts
+++ b/app/email-incoming/circulars/index.ts
@@ -27,10 +27,7 @@ import {
 import { sendEmail } from '~/lib/email.server'
 import { hostname, origin } from '~/lib/env.server'
 import { putRaw, submitterGroup } from '~/routes/circulars/circulars.server'
-import {
-  createSynonyms,
-  synonymExists,
-} from '~/routes/synonyms/synonyms.server'
+import { tryInitSynonym } from '~/routes/synonyms/synonyms.server'
 
 interface UserData {
   email: string
@@ -103,8 +100,7 @@ export const handler = createEmailIncomingMessageHandler(
     // Removes sub as a property if it is undefined from the legacy users
     if (!circular.sub) delete circular.sub
     const { circularId } = await putRaw(circular)
-    if (eventId && !(await synonymExists({ eventId })))
-      await createSynonyms([eventId])
+    if (eventId) await tryInitSynonym(eventId)
 
     // Send a success email
     await sendSuccessEmail({

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -313,7 +313,8 @@ export async function put(
   const eventId = parseEventFromSubject(item.subject)
   if (eventId) circular.eventId = eventId
   const result = await putRaw(circular)
-  if (eventId && !(await synonymExists({ eventId }))) createSynonyms([eventId])
+  if (eventId && !(await synonymExists({ eventId })))
+    await createSynonyms([eventId])
   return result
 }
 

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -22,6 +22,7 @@ import memoizee from 'memoizee'
 import { dedent } from 'ts-dedent'
 
 import { type User, getUser } from '../_auth/user.server'
+import { createSynonyms, synonymExists } from '../synonyms/synonyms.server'
 import {
   bodyIsValid,
   formatAuthor,
@@ -310,7 +311,11 @@ export async function put(
   }
 
   const eventId = parseEventFromSubject(item.subject)
-  if (eventId) circular.eventId = eventId
+  if (eventId) {
+    circular.eventId = eventId
+    const synonymRecordExists = await synonymExists({ eventId })
+    if (!synonymRecordExists) createSynonyms([eventId])
+  }
 
   return await putRaw(circular)
 }

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -311,13 +311,10 @@ export async function put(
   }
 
   const eventId = parseEventFromSubject(item.subject)
-  if (eventId) {
-    circular.eventId = eventId
-    const synonymRecordExists = await synonymExists({ eventId })
-    if (!synonymRecordExists) createSynonyms([eventId])
-  }
-
-  return await putRaw(circular)
+  if (eventId) circular.eventId = eventId
+  const result = await putRaw(circular)
+  if (eventId && !(await synonymExists({ eventId }))) createSynonyms([eventId])
+  return result
 }
 
 export async function circularRedirect(query: string) {

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -22,7 +22,7 @@ import memoizee from 'memoizee'
 import { dedent } from 'ts-dedent'
 
 import { type User, getUser } from '../_auth/user.server'
-import { createSynonyms, synonymExists } from '../synonyms/synonyms.server'
+import { tryInitSynonym } from '../synonyms/synonyms.server'
 import {
   bodyIsValid,
   formatAuthor,
@@ -313,8 +313,7 @@ export async function put(
   const eventId = parseEventFromSubject(item.subject)
   if (eventId) circular.eventId = eventId
   const result = await putRaw(circular)
-  if (eventId && !(await synonymExists({ eventId })))
-    await createSynonyms([eventId])
+  if (eventId) await tryInitSynonym(eventId)
   return result
 }
 

--- a/app/routes/synonyms.new.tsx
+++ b/app/routes/synonyms.new.tsx
@@ -28,7 +28,7 @@ import { getUser } from './_auth/user.server'
 import { moderatorGroup } from './circulars/circulars.server'
 import {
   autoCompleteEventIds,
-  createSynonyms,
+  moderatorCreateSynonyms,
 } from './synonyms/synonyms.server'
 import DetailsDropdownContent from '~/components/DetailsDropdownContent'
 import { getFormDataString } from '~/lib/utils'
@@ -40,7 +40,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const data = await request.formData()
   const eventIds = getFormDataString(data, 'synonyms')?.split(',')
   if (!eventIds) throw new Response(null, { status: 400 })
-  const synonymId = await createSynonyms(eventIds)
+  const synonymId = await moderatorCreateSynonyms(eventIds)
   return redirect(`/synonyms/${synonymId}`)
 }
 

--- a/app/routes/synonyms/synonyms.server.ts
+++ b/app/routes/synonyms/synonyms.server.ts
@@ -122,6 +122,20 @@ async function getSynonymMembers(eventId: string) {
   return Items as Circular[]
 }
 
+export async function synonymExists({ eventId }: { eventId: string }) {
+  const db = await tables()
+  const { Items } = await db.synonyms.query({
+    KeyConditionExpression: '#eventId = :eventId',
+    ExpressionAttributeNames: {
+      '#eventId': 'eventId',
+    },
+    ExpressionAttributeValues: {
+      ':eventId': eventId,
+    },
+  })
+  return Items.length >= 1
+}
+
 /*
  * If an eventId already has a synonym and is passed in, it will unlink the
  * eventId from the old synonym and the only remaining link will be to the


### PR DESCRIPTION
# Description
This change adds functionality to check if there is an existing synonym group for an eventId upon circular creation. If there is an eventId and no synonym group for that eventId, it creates one. If there is no eventId it skips. If there is an eventId and the synonym group already exists for that eventId it skips.

# Related Issue(s)
Resolves #2661 

# Testing
I tested this locally. 
However, because it is in a critical area, we need to thoroughly test it on dev.