### PR TITLE
Require SSL for all actions on S3 buckets

### DIFF
--- a/src/plugins/email-incoming.js
+++ b/src/plugins/email-incoming.js
@@ -112,6 +112,24 @@ export const deploy = {
                 },
               },
             },
+            {
+              Sid: 'AllowSSLRequestsOnly',
+              Action: 's3:*',
+              Effect: 'Deny',
+              Resource: [
+                { 'Fn::GetAtt': 'EmailIncomingBucket.Arn' },
+                {
+                  'Fn::Sub': [
+                    `\${bukkit}/*`,
+                    { bukkit: { 'Fn::GetAtt': 'EmailIncomingBucket.Arn' } },
+                  ],
+                },
+              ],
+              Condition: {
+                Bool: { 'aws:SecureTransport': false },
+              },
+              Principal: '*',
+            },
           ],
         },
       },

--- a/src/plugins/missionCloudPlatform.js
+++ b/src/plugins/missionCloudPlatform.js
@@ -9,6 +9,30 @@
 // Custom permissions for deployment on Mission Cloud Platform
 export const deploy = {
   start({ cloudformation }) {
+    // Mission Cloud Platform requires that S3 buckets only permit access over
+    // SSL in order to dismiss
+    // https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-5.
+    cloudformation.Resources.StaticBucketPolicy.Properties.PolicyDocument.Statement.push(
+      {
+        Sid: 'AllowSSLRequestsOnly',
+        Action: 's3:*',
+        Effect: 'Deny',
+        Resource: [
+          { 'Fn::GetAtt': 'StaticBucket.Arn' },
+          {
+            'Fn::Sub': [
+              `\${bukkit}/*`,
+              { bukkit: { 'Fn::GetAtt': 'StaticBucket.Arn' } },
+            ],
+          },
+        ],
+        Condition: {
+          Bool: { 'aws:SecureTransport': false },
+        },
+        Principal: '*',
+      }
+    )
+
     // Mission Cloud Platform does not support user-defined public access block
     // configurations; they must be set manually by an administrator
     delete cloudformation.Resources.StaticBucket.Properties


### PR DESCRIPTION
MCP requires us to do this in order to address https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-5.
