### PR TITLE
Fix sending of GCN Circulars, broken by change of plugin names

### DIFF
--- a/app/lib/email.server.ts
+++ b/app/lib/email.server.ts
@@ -98,7 +98,7 @@ export async function sendEmailBulk({
           subject,
           body: getBody(body),
         }),
-        TemplateName: s.emailOutgoing.template,
+        TemplateName: s.email_outgoing.template,
       },
     },
   }


### PR DESCRIPTION
We forgot to update the Architect service discovery names after changing the names of Architect plugins in #2653.