### PR TITLE
Ignore AWS SDK packages for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,9 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
-      aws:
-        patterns:
-          - '@aws-sdk/*'
       remix:
         patterns:
           - '@remix-run/*'
+    ignore:
+      # Ignore AWS SDK packages because they are provided by the Lambda runtime.
+      - dependency-name: '@aws-sdk/*'


### PR DESCRIPTION
These packages are provided by the Lambda runtime.