### PR TITLE
Fix title for moderation index route

### DIFF
--- a/app/routes/circulars.moderation._index.tsx
+++ b/app/routes/circulars.moderation._index.tsx
@@ -26,7 +26,6 @@ import { ToolbarButtonGroup } from '~/components/ToolbarButtonGroup'
 import type { BreadcrumbHandle } from '~/root/Title'
 
 export const handle: BreadcrumbHandle & SEOHandle = {
-  breadcrumb: 'Moderation',
   getSitemapEntries: () => null,
 }
 


### PR DESCRIPTION
Change the title of the moderation index route from "GCN - Circulars - Moderation - Moderation" to "GCN - Circulars - Moderation".