### PR TITLE
VTP migration and legacy email announcement

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -253,10 +253,11 @@ export function Layout({ children }: { children?: ReactNode }) {
         <DevBanner />
         <Header />
         <NewsBanner>
-          New! October 18 GCN Classic Outage and Schema v4.2.0. See{' '}
+          Announcing GCN Classic Migration Survey, End of Legacy Circulars
+          Email. See{' '}
           <Link
             className="usa-link"
-            to="/news#gcn-classic-outage-and-schema-release-v420"
+            to="/news#-gcn-classic-migration-survey-and-legacy-circular-submission-email-retirement"
           >
             news and announcements
           </Link>

--- a/app/routes/docs.tsx
+++ b/app/routes/docs.tsx
@@ -198,11 +198,9 @@ export default function () {
               <NavLink key="schema" to="schema">
                 Schema Browser
               </NavLink>,
-              useFeature('VTP_MIGRATION') && (
-                <NavLink key="vtp" to="vtp">
-                  VOEvent Transport Protocol Migration
-                </NavLink>
-              ),
+              <NavLink key="vtp" to="vtp">
+                VOEvent Transport Protocol Migration
+              </NavLink>,
               <NavLink key="admin" to="admin">
                 Administration
               </NavLink>,

--- a/app/routes/docs.vtp.mdx
+++ b/app/routes/docs.vtp.mdx
@@ -17,13 +17,6 @@ import {
   IconListItem,
 } from '@trussworks/react-uswds'
 
-import { feature } from '~/lib/env.server'
-
-export function loader() {
-  if (feature('VTP_MIGRATION')) return null
-  else throw new Response(null, { status: 404 })
-}
-
 # VOEvent Transport Protocol Migration
 
 VOEvent Transport Protocol (VTP) is a product of the [International Virtual Observatory Alliance (IVOA)](https://www.ivoa.net) that provides a mechanism for distribution of VOEvents to astronomical communities. The [Comet VOEvent broker for Python](https://comet.transientskp.org/en/latest/) and the [GCN Classic VOEvent distribution system](https://gcn.gsfc.nasa.gov/voevent.html) have been operational for many years, but are not actively developed or maintained. VTP is also unsafe on the modern Internet because it lacks security features to protect against "man-in-the-middle" attacks ([although there are proposals to fix the security issues with VTP](https://comet.transientskp.org/en/stable/appendix/VOEvent-OpenPGP.html), they have not been widely adopted).

--- a/app/routes/news._index.mdx
+++ b/app/routes/news._index.mdx
@@ -29,6 +29,27 @@ import { Anchor } from '~/components/Anchor'
     <CollectionItem
       className="maxw-none"
       variantComponent={
+        <CollectionCalendarDate datetime={'November 8, 2024'} />
+      }
+    >
+      <CollectionHeading headingLevel="h3">
+        <Anchor> GCN Classic Migration Survey and Legacy Circular Submission Email Retirement</Anchor>
+      </CollectionHeading>
+      <CollectionDescription>
+        #### VOEvent Transport Protocol (VTP) Migration Survey
+          The GCN team is exploring 3 options to meet the VOEvent needs of the GCN user community. The GCN Classic VOEvent broker must be updated to meet NASA standards. If you are a VOEvent user via the [GCN Classic servers](https://gcn.gsfc.nasa.gov/voevent.html):
+          - Evaluate the [replacement options](/docs/vtp)
+          - Provide feedback via [our survey](https://forms.gle/8tVRkmQd2v99FqYYA) by **November 30, 2024**
+        #### Retirement of Legacy Email Submission Address
+          We plan to retire the legacy email address (gcncirc@capella2.gsfc.nasa.gov) for GCN Circular submission on **December 31, 2024**. Utilize one of the other Circular submission methods:
+          - Email circulars@gcn.nasa.gov
+          - Submit via the [web form](/circulars/new), which also offers enhanced features with Markdown capability to add tables, links, and formatting.
+      </CollectionDescription>
+    </CollectionItem>
+
+    <CollectionItem
+      className="maxw-none"
+      variantComponent={
         <CollectionCalendarDate datetime={'October 15, 2024'} />
       }
     >


### PR DESCRIPTION
# Description
VTP Migration and legacy circulars email retirement announcement.  Also includes removing the feature flag from the VTP migration documentations.

# Related Issue(s)
Addresses part of #2483 and resolves #2608.