### PR TITLE
Rename CHIME/FRB Quickstart

### DIFF
--- a/app/routes/missions.tsx
+++ b/app/routes/missions.tsx
@@ -35,7 +35,7 @@ export default function () {
               </NavLink>,
               useFeature('CHIME') && (
                 <NavLink key="chime" to="chime">
-                  Chime
+                  CHIME/FRB
                 </NavLink>
               ),
               <NavLink key="einstein-probe" to="einstein-probe">


### PR DESCRIPTION
# Description
Chime is acronym, not a word, thus needs to be capitalized.
I would like to follow theirs scheme CHIME/FRB.

# Related Issue(s)
Closed Issue: https://github.com/nasa-gcn/gcn.nasa.gov/pull/2702/files

