### PR TITLE
Fix tooltips for TNS entries with empty internal_names field

### DIFF
--- a/app/routes/api.tooltip.tns.$.ts
+++ b/app/routes/api.tooltip.tns.$.ts
@@ -39,16 +39,20 @@ export async function loader({ params: { '*': value } }: LoaderFunctionArgs) {
   }
 
   const {
+    objname,
+    name_prefix,
     ra,
     dec,
     internal_names: names,
   }: {
+    objname: string
+    name_prefix: string
     ra?: string
     dec?: string
     internal_names?: string
   } = (await response.json()).data.reply
 
-  if (!(ra && dec && names)) throw new Response(null, { status: 404 })
+  if (!(ra && dec)) throw new Response(null, { status: 404 })
 
   return json(
     {
@@ -56,7 +60,9 @@ export async function loader({ params: { '*': value } }: LoaderFunctionArgs) {
       dec: dec.split(splitter),
       // Some TNS events have values of `internal_names` that have an orphaned
       // leading or trailing comma, such as `', PS24brk'`. Strip them out.
-      names: names.split(/\s*,\s*/).filter(Boolean),
+      names: (names || `${name_prefix}${objname}`)
+        .split(/\s*,\s*/)
+        .filter(Boolean),
     },
     { headers: publicStaticShortTermCacheControlHeaders }
   )


### PR DESCRIPTION
Some TNS entries do not have the `internal_names` response field populated. For such entries, we would display the text "Not found" in the tooltip. See, for example, AT2023qxj in
https://gcn.nasa.gov/circulars/34574.

For such TNS entries, use the TNS name itself as a default name (in this example, "AT2023qxj").