### PR TITLE
Update openid-client to 5.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30265,11 +30265,12 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.1.tgz",
-      "integrity": "sha512-PtrWsY+dXg6y8mtMPyL/namZSYVz8pjXz3yJiBNZsEdCnu9miHLB4ELVC85WvneMKo2Rg62Ay7NkuCpM0bgiLQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "license": "MIT",
       "dependencies": {
-        "jose": "^4.15.1",
+        "jose": "^4.15.9",
         "lru-cache": "^6.0.0",
         "object-hash": "^2.2.0",
         "oidc-token-hash": "^5.0.3"


### PR DESCRIPTION
openid-client underwent a major redesign from v5 to v6. Update to the last v5.x.x release.