### PR TITLE
Refactor request error checks to use common throwForStatus func

### DIFF
--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -72,3 +72,13 @@ export function useSearchString() {
   if (searchString) searchString = `?${searchString}`
   return searchString
 }
+
+/** Throw an error if the request failed.
+ *
+ * Based on https://requests.readthedocs.io/en/latest/api/#requests.Response.raise_for_status.
+ */
+export function throwForStatus(response: Response) {
+  if (!response.ok) {
+    throw new Error('Request failed', { cause: response })
+  }
+}

--- a/app/lib/zendesk.server.ts
+++ b/app/lib/zendesk.server.ts
@@ -7,6 +7,7 @@
  */
 import { getEnvOrDie } from './env.server'
 import { getBasicAuthHeaders } from './headers.server'
+import { throwForStatus } from './utils'
 
 interface ZendeskRequest {
   requester: Requester
@@ -41,16 +42,13 @@ export async function postZendeskRequest(request: ZendeskRequest) {
     }
   )
 
-  if (!response.ok) {
-    console.error(response)
-    throw new Error(`Request failed with status ${response.status}`)
-  }
+  throwForStatus(response)
 
   const responseJson = await response.json()
   if (!responseJson.request.id) {
-    console.error(responseJson)
     throw new Error(
-      'ZenDesk request succeeded, but did not return a request ID'
+      'ZenDesk request succeeded, but did not return a request ID',
+      { cause: responseJson }
     )
   }
 
@@ -77,8 +75,5 @@ export async function closeZendeskTicket(ticketId: number) {
     }
   )
 
-  if (!response.ok) {
-    console.error(response)
-    throw new Error(`Request failed with status ${response.status}`)
-  }
+  throwForStatus(response)
 }

--- a/app/routes/api.tooltip.arxiv.$.ts
+++ b/app/routes/api.tooltip.arxiv.$.ts
@@ -10,6 +10,7 @@ import { DOMParser } from '@xmldom/xmldom'
 import invariant from 'tiny-invariant'
 
 import { publicStaticShortTermCacheControlHeaders } from '~/lib/headers.server'
+import { throwForStatus } from '~/lib/utils'
 
 export async function loader({ params: { '*': value } }: LoaderFunctionArgs) {
   invariant(value)
@@ -18,10 +19,7 @@ export async function loader({ params: { '*': value } }: LoaderFunctionArgs) {
   url.searchParams.set('id_list', value)
   const response = await fetch(url)
 
-  if (!response.ok) {
-    console.error(response)
-    throw new Error('arXiv request failed')
-  }
+  throwForStatus(response)
 
   const text = await response.text()
   const entry = new DOMParser()

--- a/app/routes/api.tooltip.doi.$.ts
+++ b/app/routes/api.tooltip.doi.$.ts
@@ -11,7 +11,7 @@ import invariant from 'tiny-invariant'
 
 import { getEnvOrDieInProduction } from '~/lib/env.server'
 import { publicStaticShortTermCacheControlHeaders } from '~/lib/headers.server'
-import { stripTags } from '~/lib/utils'
+import { stripTags, throwForStatus } from '~/lib/utils'
 
 const adsTokenTooltip = getEnvOrDieInProduction('ADS_TOKEN_TOOLTIP')
 
@@ -29,10 +29,7 @@ export async function loader({ params: { '*': value } }: LoaderFunctionArgs) {
     headers: { Authorization: `Bearer ${adsTokenTooltip}` },
   })
 
-  if (!response.ok) {
-    console.error(response)
-    throw new Error('ADS request failed')
-  }
+  throwForStatus(response)
 
   const item:
     | {

--- a/app/routes/api.tooltip.tns.$.ts
+++ b/app/routes/api.tooltip.tns.$.ts
@@ -10,6 +10,7 @@ import invariant from 'tiny-invariant'
 
 import { getEnvOrDie } from '~/lib/env.server'
 import { publicStaticShortTermCacheControlHeaders } from '~/lib/headers.server'
+import { throwForStatus } from '~/lib/utils'
 
 const splitter = /[:.]/
 
@@ -33,10 +34,7 @@ export async function loader({ params: { '*': value } }: LoaderFunctionArgs) {
     body: formData,
   })
 
-  if (!response.ok) {
-    console.error(response)
-    throw new Error('TNS request failed')
-  }
+  throwForStatus(response)
 
   const {
     objname,

--- a/app/routes/circulars.$circularId.($version)/AstroData.components.tsx
+++ b/app/routes/circulars.$circularId.($version)/AstroData.components.tsx
@@ -9,7 +9,7 @@ import { type LoaderFunction } from '@remix-run/node'
 import { type useLoaderData } from '@remix-run/react'
 
 import { AstroDataLinkWithTooltip } from './AstroDataContext'
-import { useSearchString } from '~/lib/utils'
+import { throwForStatus, useSearchString } from '~/lib/utils'
 import { type loader as arxivTooltipLoader } from '~/routes/api.tooltip.arxiv.$'
 import { type loader as circularTooltipLoader } from '~/routes/api.tooltip.circular.$'
 import { type loader as doiTooltipLoader } from '~/routes/api.tooltip.doi.$'
@@ -22,7 +22,7 @@ async function fetchTooltipData<loader extends LoaderFunction>(
   value: JSX.IntrinsicElements['data']['value']
 ): Promise<ReturnType<typeof useLoaderData<loader>>> {
   const response = await fetch(`/api/tooltip/${className}/${value}`)
-  if (!response.ok) throw new Error('failed to fetch tooltip')
+  throwForStatus(response)
   return await response.json()
 }
 


### PR DESCRIPTION
Inspired by https://requests.readthedocs.io/en/latest/api/#requests.Response.raise_for_status.