### PR TITLE
Save metafiles, but don't include in deployment bundle

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -1,5 +1,5 @@
 import esbuild from 'esbuild'
-import { copyFile } from 'fs/promises'
+import { copyFile, writeFile } from 'fs/promises'
 import { glob } from 'glob'
 import { extname } from 'node:path'
 import { basename, dirname, join } from 'path'
@@ -40,6 +40,17 @@ const options = {
                   copyFile(input, join(dirname(entryPoint), basename(input)))
                 )
             )
+          )
+        })
+      },
+    },
+    {
+      name: 'write metafile to output directory',
+      setup(build) {
+        build.onEnd(async ({ metafile }) => {
+          await writeFile(
+            join(build.initialOptions.outdir, 'metafile.lambda.json'),
+            JSON.stringify(metafile)
           )
         })
       },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "build:remix": "remix build",
+    "build:remix": "remix build && mv build/server/metafile.* build/",
     "build:sass": "sass -Inode_modules/nasawds/src/theme -Inode_modules/@uswds -Inode_modules/@uswds/uswds/packages app:app",
     "build:esbuild": "node esbuild.js",
     "build:website": "run-s build:sass build:remix",


### PR DESCRIPTION
- Save a metafile for the helper Lambdas so that we can analyze the bundle size.
- Move the metafile for the web application out of the server bundle directory so that it is not uploaded to AWS. This should slightly decrease Lambda cold start times by reducing the size of the deployment bundle.