### PR TITLE
Don't bundle string-split-html for client side

### DIFF
--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { stripTags } from '~/lib/utils'
+import { stripTags } from '~/lib/utils.server'
 
 describe('stripTags', () => {
   const textBody = '<NUMPAGES>123</NUMPAGES>'

--- a/app/lib/utils.server.ts
+++ b/app/lib/utils.server.ts
@@ -1,0 +1,12 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { stripHtml } from 'string-strip-html'
+
+export function stripTags(text: string) {
+  return stripHtml(text).result
+}

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -6,11 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { useSearchParams } from '@remix-run/react'
-import { stripHtml } from 'string-strip-html'
-
-export function stripTags(text: string) {
-  return stripHtml(text).result
-}
 
 export function formatAndNoticeTypeToTopic(
   noticeFormat: string,

--- a/app/routes/api.tooltip.doi.$.ts
+++ b/app/routes/api.tooltip.doi.$.ts
@@ -11,7 +11,8 @@ import invariant from 'tiny-invariant'
 
 import { getEnvOrDieInProduction } from '~/lib/env.server'
 import { publicStaticShortTermCacheControlHeaders } from '~/lib/headers.server'
-import { stripTags, throwForStatus } from '~/lib/utils'
+import { throwForStatus } from '~/lib/utils'
+import { stripTags } from '~/lib/utils.server'
 
 const adsTokenTooltip = getEnvOrDieInProduction('ADS_TOKEN_TOOLTIP')
 


### PR DESCRIPTION
The package string-strip-html was being bundled for the client side, even though it was only used on the server side (in a loader function). Move the reference to it to a file with the extension .server.ts to force it to be bundled only for the server.