### PR TITLE
Raise 404, not 500, if circularId is not finite

### DIFF
--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -240,6 +240,8 @@ export async function get(
   circularId: number,
   version?: number
 ): Promise<Circular> {
+  if (isNaN(circularId) || (version !== undefined && isNaN(version)))
+    throw new Response(null, { status: 404 })
   const circularVersions = await getDynamoDBVersionAutoIncrement(circularId)
   const result = await circularVersions.get(version)
   if (!result)
@@ -367,6 +369,7 @@ export async function putVersion(
  * @returns an array of previous versions of a Circular sorted by version
  */
 export async function getVersions(circularId: number): Promise<number[]> {
+  if (isNaN(circularId)) throw new Response(null, { status: 404 })
   const circularVersionsAutoIncrement =
     await getDynamoDBVersionAutoIncrement(circularId)
   return await circularVersionsAutoIncrement.list()


### PR DESCRIPTION
Fixes the following error:

```
2024-12-10T16:45:51.373Z	96341ef3-33ab-481f-9a5a-9d7c10f78c14	ERROR	Error: Special numeric value NaN is not allowed
    at convertToNumberAttr (/var/runtime/node_modules/@aws-sdk/util-dynamodb/dist-cjs/index.js:212:11)
    at convertToAttr (/var/runtime/node_modules/@aws-sdk/util-dynamodb/dist-cjs/index.js:120:12)
    at marshall (/var/runtime/node_modules/@aws-sdk/util-dynamodb/dist-cjs/index.js:307:26)
    at marshallFunc (/var/runtime/node_modules/@aws-sdk/lib-dynamodb/dist-cjs/index.js:130:97)
    at processObj (/var/runtime/node_modules/@aws-sdk/lib-dynamodb/dist-cjs/index.js:69:14)
    at /var/runtime/node_modules/@aws-sdk/lib-dynamodb/dist-cjs/index.js:122:28
    at Array.reduce (<anonymous>)
    at processAllKeysInObj (/var/runtime/node_modules/@aws-sdk/lib-dynamodb/dist-cjs/index.js:118:30)
    at processObj (/var/runtime/node_modules/@aws-sdk/lib-dynamodb/dist-cjs/index.js:78:16)
    at processKeysInObj (/var/runtime/node_modules/@aws-sdk/lib-dynamodb/dist-cjs/index.js:107:28)
```
