### PR TITLE
Enable source map support

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -165,6 +165,7 @@ dedicatedMasterType t3.small.search
 
 @plugins
 plugin-remix
+enable-source-maps  # Enable Node.js source map support.
 sandbox-oidc-idp  # Sandbox identity provider
 lambda-cognito-permissions  # Grant the Lambda function access to Cognito to run the credential vending machine.
 static-bucket-permissions  # Functions may only write to the /generated directory in the static bucket.

--- a/src/plugins/enable-source-maps.js
+++ b/src/plugins/enable-source-maps.js
@@ -1,0 +1,14 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Enable Node.js source map support.
+export const set = {
+  env() {
+    return { NODE_OPTIONS: '--enable-source-maps' }
+  },
+}


### PR DESCRIPTION
Node.js requires the command line option `--enable-source-maps` to activate source map support.