### PR TITLE
Courey/update table stream

### DIFF
--- a/__tests__/table-streams/synonyms.ts
+++ b/__tests__/table-streams/synonyms.ts
@@ -277,24 +277,6 @@ describe('testing synonymGroup table-stream', () => {
         slug: additionalEventSlug,
       },
     ]
-    const currentPut = {
-      index: 'synonym-groups',
-      id: synonymId,
-      body: {
-        synonymId,
-        slugs: [eventSlug],
-        eventIds: [eventId],
-      },
-    }
-    const additionalPut = {
-      index: 'synonym-groups',
-      id: previousSynonymId,
-      body: {
-        synonymId: previousSynonymId,
-        slugs: [additionalEventSlug],
-        eventIds: [additionalEventId],
-      },
-    }
 
     const mockSearch = jest.fn().mockReturnValue({
       body: {
@@ -338,8 +320,16 @@ describe('testing synonymGroup table-stream', () => {
 
     expect(mockSearch).toHaveBeenCalledTimes(1)
     expect(mockQuery).toHaveBeenCalledTimes(2)
-    expect(mockIndex).toHaveBeenNthCalledWith(1, additionalPut)
-    expect(mockIndex).toHaveBeenNthCalledWith(2, currentPut)
+    putData.id = synonymId
+    putData.body.synonymId = synonymId
+    putData.body.eventIds = [eventId]
+    putData.body.slugs = [eventSlug]
+    expect(mockIndex).toHaveBeenCalledWith(putData)
+    putData.id = previousSynonymId
+    putData.body.synonymId = previousSynonymId
+    putData.body.eventIds = [additionalEventId]
+    putData.body.slugs = [additionalEventSlug]
+    expect(mockIndex).toHaveBeenCalledWith(putData)
     expect(mockIndex).toHaveBeenCalledTimes(2)
     expect(mockDelete).not.toHaveBeenCalled()
   })

--- a/__tests__/table-streams/synonyms.ts
+++ b/__tests__/table-streams/synonyms.ts
@@ -132,6 +132,8 @@ describe('testing synonymGroup table-stream', () => {
     expect(mockIndex).toHaveBeenCalledWith(putData)
     expect(mockIndex).toHaveBeenCalledTimes(1)
     expect(mockDelete).not.toHaveBeenCalled()
+    expect(mockQuery).toHaveBeenCalledTimes(1)
+    expect(mockSearch).toHaveBeenCalledTimes(1)
   })
 
   test('insert into existing synonym group with removal of previous now unused group', async () => {
@@ -183,9 +185,13 @@ describe('testing synonymGroup table-stream', () => {
 
     await handler(mockStreamEvent)
 
+    expect(mockSearch).toHaveBeenCalledTimes(1)
+    expect(mockQuery).toHaveBeenCalledTimes(2)
     // the new group opensearch record is updated
     expect(mockIndex).toHaveBeenCalledWith(putData)
+    expect(mockIndex).toHaveBeenCalledTimes(1)
     // the old group opensearch record is deleted
     expect(mockDelete).toHaveBeenCalledWith(deleteData)
+    expect(mockDelete).toHaveBeenCalledTimes(1)
   })
 })

--- a/__tests__/table-streams/synonyms.ts
+++ b/__tests__/table-streams/synonyms.ts
@@ -78,13 +78,10 @@ const mockStreamEvent = {
 }
 
 // Github-slugger is mocked to prevent jest failing to properly load the package. If Jest attempts
-// to load it, it will encounter a syntax error. Since these eventIds do not have any characters that
-// would be changed by the slugger, ensuring they are all lowercase is enough to mock the behavior
-// of github-slugger in this case.
+// to load it, it will encounter a syntax error. Since all places where a slug would be created have been mocked,
+// it doesn't need to return anything.
 jest.mock('github-slugger', () => ({
-  slug: (eventId: string) => {
-    return eventId.toLowerCase()
-  },
+  slug: jest.fn(),
 }))
 
 jest.mock('@nasa-gcn/architect-functions-search', () => ({

--- a/__tests__/table-streams/synonyms.ts
+++ b/__tests__/table-streams/synonyms.ts
@@ -8,13 +8,14 @@
 import { tables } from '@architect/functions'
 import { search } from '@nasa-gcn/architect-functions-search'
 import type { DynamoDBRecord } from 'aws-lambda'
+import crypto from 'crypto'
 
-import type { Synonym } from '~/routes/synonyms/synonyms.lib'
 import { handler } from '~/table-streams/synonyms/index'
 
-const synonymId = 'abcde-abcde-abcde-abcde-abcde'
+const synonymId = crypto.randomUUID()
 const eventId = 'GRB 123'
 const existingEventId = 'GRB 99999999'
+const previousSynonymId = crypto.randomUUID()
 
 const putData = {
   index: 'synonym-groups',
@@ -48,6 +49,7 @@ const mockIndex = jest.fn()
 const mockDelete = jest.fn()
 const mockQuery = jest.fn()
 
+const eventSlug = eventId.replace(' ', '-').toLowerCase()
 const mockStreamEvent = {
   Records: [
     {
@@ -64,6 +66,9 @@ const mockStreamEvent = {
           eventId: {
             S: eventId,
           },
+          slug: {
+            S: eventSlug,
+          },
         },
         NewImage: {
           synonymId: {
@@ -71,6 +76,9 @@ const mockStreamEvent = {
           },
           eventId: {
             S: eventId,
+          },
+          slug: {
+            S: eventSlug,
           },
         },
         SequenceNumber: '111',
@@ -88,8 +96,12 @@ afterEach(() => {
 })
 
 describe('testing put synonymGroup table-stream', () => {
-  test('insert new synonym group', async () => {
-    const mockItems = [{ synonymId, eventId }]
+  test('insert initial synonym record where no existing opensearch record exists', async () => {
+    const mockSearch = jest
+      .fn()
+      .mockReturnValue({ body: { hits: { hits: [] } } })
+    const slug = eventId.replace(' ', '-').toLowerCase()
+    const mockItems = [{ synonymId, eventId, slug }]
     const mockClient = {
       synonyms: {
         query: mockQuery,
@@ -101,103 +113,79 @@ describe('testing put synonymGroup table-stream', () => {
     ;(search as unknown as jest.Mock).mockReturnValue({
       index: mockIndex,
       delete: mockDelete,
+      search: mockSearch,
     })
 
     await handler(mockStreamEvent)
-
+    putData.body.slugs.push(slug)
     expect(mockIndex).toHaveBeenCalledWith(putData)
   })
 
-  test('insert into existing synonym group', async () => {
-    const mockItems = [
-      { synonymId, eventId: existingEventId },
-      { synonymId, eventId },
-    ]
-    const mockClient = {
-      synonyms: {
-        query: mockQuery,
-      },
-    }
-    mockQuery.mockResolvedValue({ Items: mockItems })
-    ;(tables as unknown as jest.Mock).mockResolvedValue(mockClient)
-    putData.body.eventIds = [existingEventId, eventId]
-    ;(search as unknown as jest.Mock).mockReturnValue({
-      index: mockIndex,
-      delete: mockDelete,
-    })
-
-    await handler(mockStreamEvent)
-
-    expect(mockIndex).toHaveBeenCalledWith(putData)
-  })
-
-  test('insert only once', async () => {
-    const mockItems = [
-      { synonymId, eventId: existingEventId },
-      { synonymId, eventId },
-    ]
-    const mockClient = {
-      synonyms: {
-        query: mockQuery,
-      },
-    }
-    mockQuery.mockResolvedValue({ Items: mockItems })
-    ;(tables as unknown as jest.Mock).mockResolvedValue(mockClient)
-    putData.body.eventIds = [existingEventId, eventId]
-    ;(search as unknown as jest.Mock).mockReturnValue({
-      index: mockIndex,
-      delete: mockDelete,
-    })
-
-    await handler(mockStreamEvent)
-
-    expect(mockIndex).toHaveBeenCalledWith(putData)
-  })
-})
-
-describe('testing delete synonymGroup table-stream', () => {
-  test('remove one eventId while leaving others', async () => {
-    const mockItems = [{ synonymId, eventId: existingEventId }]
-    const mockClient = {
-      synonyms: {
-        query: mockQuery,
-      },
-    }
-    mockQuery.mockResolvedValue({ Items: mockItems })
-    ;(tables as unknown as jest.Mock).mockResolvedValue(mockClient)
-    mockStreamEvent.Records[0].eventName = 'REMOVE'
-    putData.body.eventIds = [existingEventId]
-    ;(search as unknown as jest.Mock).mockReturnValue({
-      index: mockIndex,
-      delete: mockDelete,
-    })
-
-    await handler(mockStreamEvent)
-
-    expect(mockIndex).toHaveBeenCalledWith(putData)
-  })
-
-  test('remove final synonym and delete synonym group', async () => {
-    const mockItems = [] as Synonym[]
-    const mockClient = {
-      synonyms: {
-        query: mockQuery,
-      },
-    }
-    mockQuery.mockResolvedValue({ Items: mockItems })
-    ;(tables as unknown as jest.Mock).mockResolvedValue(mockClient)
-    mockStreamEvent.Records[0].eventName = 'REMOVE'
+  test('insert into existing synonym group with removal of now unused group', async () => {
+    const existingEventSlug = existingEventId.replace(' ', '-').toLowerCase()
     const deleteData = {
       index: 'synonym-groups',
-      id: synonymId,
+      id: previousSynonymId,
     }
+
+    const mockSearch = jest.fn().mockReturnValue({
+      body: {
+        hits: {
+          hits: [
+            {
+              _source: {
+                synonymId: previousSynonymId,
+                eventIds: [eventId],
+                slugs: [eventSlug],
+              },
+            },
+          ],
+        },
+      },
+    })
+
+    const mockItems = [
+      { synonymId, eventId: existingEventId, slug: existingEventSlug },
+      { synonymId, eventId, slug: eventSlug },
+    ]
+
+    const mockPreviousItems = [
+      { synonymId: previousSynonymId, eventId, slug: eventSlug },
+    ]
+
+    const implementedMockQuery = mockQuery.mockImplementation((query) => {
+      if (query.ExpressionAttributeValues[':synonymId'] == previousSynonymId) {
+        return { Items: mockPreviousItems }
+      } else {
+        return { Items: mockItems }
+      }
+    })
     ;(search as unknown as jest.Mock).mockReturnValue({
       index: mockIndex,
       delete: mockDelete,
+      search: mockSearch,
     })
+    const mockClient = {
+      synonyms: {
+        query: implementedMockQuery,
+      },
+    }
 
+    ;(tables as unknown as jest.Mock).mockResolvedValue(mockClient)
+    putData.body.eventIds = [existingEventId, eventId]
+    putData.body.slugs = [existingEventSlug, eventSlug]
+
+    mockQuery.mockImplementation((query) => {
+      if (query.ExpressionAttributeValues[':synonymId'] == previousSynonymId) {
+        return { Items: mockPreviousItems }
+      } else {
+        return { Items: mockItems }
+      }
+    })
     await handler(mockStreamEvent)
-
+    // the new group opensearch record is updated
+    expect(mockIndex).toHaveBeenCalledWith(putData)
+    // the old group opensearch record is deleted
     expect(mockDelete).toHaveBeenCalledWith(deleteData)
   })
 })

--- a/app/routes/synonyms/synonyms.server.ts
+++ b/app/routes/synonyms/synonyms.server.ts
@@ -115,6 +115,34 @@ export async function searchSynonymsByEventId({
   }
 }
 
+export async function opensearchKeywordSearch({
+  eventId,
+}: {
+  eventId: string
+}) {
+  const client = await getSearchClient()
+  const indexName = 'synonym-groups'
+
+  const query = {
+    query: {
+      term: {
+        'eventIds.keyword': eventId,
+      },
+    },
+  }
+
+  const response = await client.search({
+    index: indexName,
+    body: query,
+  })
+
+  if (response.body.hits.hits.length > 0) {
+    return response.body.hits.hits[0]._source
+  } else {
+    return null
+  }
+}
+
 async function validateEventIds({ eventIds }: { eventIds: string[] }) {
   const promises = eventIds.map((eventId) => {
     return getSynonymMembers(eventId)

--- a/app/routes/synonyms/synonyms.server.ts
+++ b/app/routes/synonyms/synonyms.server.ts
@@ -114,34 +114,6 @@ export async function searchSynonymsByEventId({
   }
 }
 
-export async function opensearchKeywordSearch({
-  eventId,
-}: {
-  eventId: string
-}) {
-  const client = await getSearchClient()
-  const indexName = 'synonym-groups'
-
-  const query = {
-    query: {
-      term: {
-        'eventIds.keyword': eventId,
-      },
-    },
-  }
-
-  const response = await client.search({
-    index: indexName,
-    body: query,
-  })
-
-  if (response.body.hits.hits.length > 0) {
-    return response.body.hits.hits[0]._source
-  } else {
-    return []
-  }
-}
-
 async function validateEventIds({ eventIds }: { eventIds: string[] }) {
   const promises = eventIds.map((eventId) => {
     return getSynonymMembers(eventId)

--- a/app/routes/synonyms/synonyms.server.ts
+++ b/app/routes/synonyms/synonyms.server.ts
@@ -106,7 +106,6 @@ export async function searchSynonymsByEventId({
       fields: { eventIds: string[]; synonymId: string; slugs: string[] }
     }) => body
   )
-
   return {
     items: results,
     totalItems,
@@ -139,7 +138,7 @@ export async function opensearchKeywordSearch({
   if (response.body.hits.hits.length > 0) {
     return response.body.hits.hits[0]._source
   } else {
-    return null
+    return []
   }
 }
 

--- a/app/table-streams/synonyms/index.ts
+++ b/app/table-streams/synonyms/index.ts
@@ -41,43 +41,22 @@ async function putIndex(synonymGroup: SynonymGroup) {
 export const handler = createTriggerHandler(
   async ({ eventName, dynamodb }: DynamoDBRecord) => {
     if (!eventName || !dynamodb) return
-
-    const { synonymId, eventId } = unmarshallTrigger(
-      dynamodb!.NewImage
-    ) as Synonym
-    let previousSynonymId = null
-    if (dynamodb!.OldImage) {
-      const { synonymId: oldSynonymId } = unmarshallTrigger(
-        dynamodb!.OldImage
-      ) as Synonym
-      previousSynonymId = oldSynonymId
-    }
-
-    const dynamoSynonyms = await getSynonymsByUuid(synonymId)
-    const dynamoPreviousGroup = previousSynonymId
-      ? (await getSynonymsByUuid(previousSynonymId)).filter(
-          (synonym) => synonym.eventId != eventId
-        )
-      : []
-
-    if (previousSynonymId && dynamoPreviousGroup.length === 0) {
-      await removeIndex(previousSynonymId)
-    } else if (previousSynonymId && dynamoPreviousGroup.length > 0) {
-      await putIndex({
-        synonymId: previousSynonymId,
-        eventIds: dynamoPreviousGroup.map((synonym) => synonym.eventId),
-        slugs: dynamoPreviousGroup.map((synonym) => synonym.slug),
-      })
-    }
-
-    if (dynamoSynonyms.length > 0) {
-      await putIndex({
-        synonymId,
-        eventIds: dynamoSynonyms.map((synonym) => synonym.eventId),
-        slugs: dynamoSynonyms.map((synonym) => synonym.slug),
-      })
-    } else {
-      await removeIndex(synonymId)
-    }
+    await Promise.all(
+      [dynamodb.OldImage, dynamodb.NewImage]
+        .filter((image) => image !== undefined)
+        .map(async (image) => {
+          const { synonymId } = unmarshallTrigger(image) as Synonym
+          const synonyms = await getSynonymsByUuid(synonymId)
+          if (synonyms.length > 0) {
+            await putIndex({
+              synonymId,
+              eventIds: synonyms.map((synonym) => synonym.eventId),
+              slugs: synonyms.map((synonym) => synonym.slug),
+            })
+          } else {
+            await removeIndex(synonymId)
+          }
+        })
+    )
   }
 )

--- a/app/table-streams/synonyms/index.ts
+++ b/app/table-streams/synonyms/index.ts
@@ -51,11 +51,11 @@ export const handler = createTriggerHandler(
     const dynamoSynonyms = await getSynonymsByUuid(synonymId)
     const opensearchSynonym = await opensearchKeywordSearch({ eventId })
     const previousSynonymId = opensearchSynonym.synonymId
-    const dynamoPreviousGroup = await getSynonymsByUuid(previousSynonymId)
+    const dynamoPreviousGroup = (
+      await getSynonymsByUuid(previousSynonymId)
+    ).filter((synonym) => synonym.eventId != eventId)
 
-    if (dynamoPreviousGroup.length === 0) {
-      await removeIndex(previousSynonymId)
-    }
+    if (dynamoPreviousGroup.length === 0) await removeIndex(previousSynonymId)
 
     if (dynamoSynonyms.length > 0) {
       await putIndex({

--- a/app/table-streams/synonyms/index.ts
+++ b/app/table-streams/synonyms/index.ts
@@ -59,9 +59,9 @@ export const handler = createTriggerHandler(
         )
       : []
 
-    if (dynamoPreviousGroup.length === 0 && previousSynonymId) {
+    if (previousSynonymId && dynamoPreviousGroup.length === 0) {
       await removeIndex(previousSynonymId)
-    } else {
+    } else if (previousSynonymId && dynamoPreviousGroup.length > 0) {
       await putIndex({
         synonymId: previousSynonymId,
         eventIds: dynamoPreviousGroup.map((synonym) => synonym.eventId),


### PR DESCRIPTION
This change updates the table-stream to account for the past synonymId when a synonym group is deleted. 

# Testing
This is very challenging to test. It does not work as expected when using the moderator interface locally because table-streams are not supported locally. 

I tested it by running the event via the invoker.
The challenge with this method is that I don't think it takes into account the state of dynamodb. This means that during testing with the invoker, the original dynamodb record is still in dynamo. This breaks the functionality for the table-stream because it is checking to make sure nothing still exists in the original synonymId's group. But if the record in dynamodb is not updated, that check will find the existing record and skip the delete. 

I added in this line to work around that:
`filter((synonym) => synonym.eventId != eventId)`

It feels a little odd because in order to trigger this table-stream that original record should have changed already. If I understand correctly, the order of operations is the dynamodb change is made which then triggers the table-stream. So that record should not exist with that synonymId in dynamo when this runs. 

It shouldn't hurt to have that filter on there, but I'm unsure if it's necessary because of limitations in local testing. 

This is the result of running a modifiy:
```
{
  body: {
    _index: 'synonym-groups',
    _id: '1aa5892d-4cea-4391-9750-e5cf681bdfd4',
    _version: 2,
    result: 'deleted',
    _shards: { total: 2, successful: 1, failed: 0 },
    _seq_no: 123,
    _primary_term: 1
  },
  statusCode: 200,
  headers: {
    'x-elastic-product': 'Elasticsearch',
    'content-type': 'application/json',
    'content-length': '184'
  },
  meta: {
    context: null,
    request: { params: [Object], options: {}, id: 2 },
    name: 'opensearch-js',
    connection: {
      url: 'http://localhost:9200/',
      id: 'http://localhost:9200/',
      headers: {},
      deadCount: 0,
      resurrectTimeout: 0,
      _openRequests: 0,
      status: 'alive',
      roles: [Object]
    },
    attempts: 0,
    aborted: false
  }
}
```

EDITED TO ADD:
I'd like to explain the updates so everyone is clear on the cases involved.
originally the synonyms were deleted if everything was removed and when a synonym was removed from a group, no new synonym was created. We changed this when we made it so that every eventId has a synonym record and I didn't update the table sync. 

## code walk through

cases:
1. If a synonym is created initially, there are no existing records to update and there would be no previous synonymId involved.
2. if a synonym is removed from a group, it needs to not only update the new synonym record, but it also needs to be removed from the old synonym record. 
3. If the synonym is the last one remaining in a group and that group has been deleted (so all the members get new synonymIds) then the opensearch record for that group needs to be removed while also creating the new records for the synonyms. 

here is a breakdown of the code for the handler:
```
    const { synonymId, eventId } = unmarshallTrigger(
      dynamodb!.NewImage
    ) as Synonym
    const dynamoSynonyms = await getSynonymsByUuid(synonymId)
```
the updated or new synonym comes through. We get any other dynamo records that belong in the group
```
    const opensearchSynonym = await opensearchKeywordSearch({ eventId })
```
here I am checking to see if there is an existing opensearch record for that eventId. This is because in the update for dynamo, the eventId doesn't change, but the synonymId does. There is nothing retaining the knowledge of if there was a previous group involved in this update and what that previous synonymId would be. So to get that, we have to look at opensearch to see if there is an existing record for this eventId
```
    const previousSynonymId = opensearchSynonym
      ? opensearchSynonym.synonymId
      : null
    const dynamoPreviousGroup = previousSynonymId
      ? (await getSynonymsByUuid(previousSynonymId)).filter(
          (synonym) => synonym.eventId != eventId
        )
      : []
```
If there is a previous synonymId, it is stored in the previousSynonym variable. That is used to determine if we need to get the members of that previous group. If there was a previous synonymId involved, we look to see if there are other members of the group left. We do this because we need to update the existing openSearch record from the previous group in addition to updating the current synonym group. 
```
    if (dynamoPreviousGroup.length === 0 && previousSynonymId) {
      await removeIndex(previousSynonymId)
    } else  if (previousSynonymId && dynamoPreviousGroup.length > 0){
      await putIndex({
        synonymId: previousSynonymId,
        eventIds: dynamoPreviousGroup.map((synonym) => synonym.eventId),
        slugs: dynamoPreviousGroup.map((synonym) => synonym.slug),
      })
    }
```
If there is a previous group, and it has no members left, it needs to remove the previous synonym record from opensearch.
If there is a previous group and it still has members, it needs to be updated to remove the current eventId from the opensearch record.
```
    if (dynamoSynonyms.length > 0) {
      await putIndex({
        synonymId,
        eventIds: dynamoSynonyms.map((synonym) => synonym.eventId),
        slugs: dynamoSynonyms.map((synonym) => synonym.slug),
      })
    } else {
      await removeIndex(synonymId)
    }
  }
)
```
This part is updating the current synonym group. If there are any members in the current group, then the opensearch record is updated with the current members.

If there are no members of the current group (which shouldn't really happen since we create a new synonym record when we update a synonymId on a dynamo record) i left this in so if there were no members of the group it would be removed.

## test walk through

I updated the unit tests for this. These kinds of tests are heavily mocked, so the test is only as good as the mock is.
There are only five cases under test here. 
1. an initial synonym record is created. So no previous synonym group exists so there is nothing to update except the current group.
2. an eventId is removed from it's existing group and placed into a new group. In this case it has to do an update to the new group and the old group is removed because it has no members.
3. moving an eventId into existing synonym group with removal from old group with remaining members, so both are updated
4. moving an eventId into new synonym group with removal from old group with remaining members so both the new and old opensearch records are updated
5. insert into new synonym group with removal from old group without remaining members so the new record is updated and the old is deleted.
