### PR TITLE
Reapply "Remove Circular ingestion from legacy email"

### DIFF
--- a/app/email-incoming/circulars/__tests__/parse.ts
+++ b/app/email-incoming/circulars/__tests__/parse.ts
@@ -39,41 +39,10 @@ describe('getFromAddress', () => {
     ).toThrow('From address is missing')
   })
 
-  test("raises if the from address name does not contain ' via '", () => {
-    expect(() =>
-      getFromAddress(
-        parseFrom(
-          '"Example <example@example.com>" <mailnull@capella2.gsfc.nasa.gov>'
-        )
-      )
-    ).toThrow("Expected From name to contain ' via '")
-  })
-
   test('returns the address verbatim for a normal email address', () => {
-    expect(getFromAddress(parseFrom('example@example.com'))).toEqual({
-      address: 'example@example.com',
-      submittedHow: 'email',
-    })
-  })
-
-  test('returns the original address for a rewritten address', () => {
-    expect(
-      getFromAddress(
-        parseFrom(
-          '"Example <example@example.com> via gcncirc" <mailnull@capella2.gsfc.nasa.gov>'
-        )
-      )
-    ).toEqual({ address: 'example@example.com', submittedHow: 'email-legacy' })
-  })
-
-  test('returns the original address for a rewritten address with an alternative "via" name', () => {
-    expect(
-      getFromAddress(
-        parseFrom(
-          '"Example <example@example.com> via my mind" <mailnull@capella2.gsfc.nasa.gov>'
-        )
-      )
-    ).toEqual({ address: 'example@example.com', submittedHow: 'email-legacy' })
+    expect(getFromAddress(parseFrom('example@example.com'))).toEqual(
+      'example@example.com'
+    )
   })
 })
 

--- a/app/email-incoming/circulars/index.ts
+++ b/app/email-incoming/circulars/index.ts
@@ -53,7 +53,7 @@ const fromName = 'GCN Circulars'
 export const handler = createEmailIncomingMessageHandler(
   async ({ content }) => {
     const parsed = await parseEmailContentFromSource(content)
-    const { address: userEmail, submittedHow } = getFromAddress(parsed.from)
+    const userEmail = getFromAddress(parsed.from)
     const to = getReplyToAddresses(parsed.replyTo) ?? [userEmail]
 
     const userData =
@@ -92,7 +92,7 @@ export const handler = createEmailIncomingMessageHandler(
       body: parsed.text,
       sub: userData.sub,
       submitter: formatAuthor(userData),
-      submittedHow,
+      submittedHow: 'email',
     }
 
     const eventId = parseEventFromSubject(parsed.subject)
@@ -204,7 +204,7 @@ If you have not already done so, we encourage you to make an account at ${origin
 - Your Circulars settings have been transferred automatically.
 - You are able to submit Circulars from the same email addresses registered in the legacy service.
 - Emails from GCN come from a new address, no-reply@${hostname}.
-- We encourage you to submit Circulars to the new address, circulars@${hostname}. The old GCN Circulars submission address, gcncirc@capella2.gsfc.nasa.gov, will be retired on December 31, 2024.
+- We encourage you to submit Circulars to the new address, circulars@${hostname}. The old address, gcncirc@capella2.gsfc.nasa.gov, has been retired.
 - The new archive, ${origin}/circulars, includes all past Circulars. We have frozen the old archive, https://gcn.gsfc.nasa.gov/gcn3_archive.html.
 
 For more information about the GCN Circulars, please see ${origin}/circulars.

--- a/app/email-incoming/circulars/parse.ts
+++ b/app/email-incoming/circulars/parse.ts
@@ -7,43 +7,12 @@
  */
 import type { AddressObject, Source } from 'mailparser'
 import { simpleParser } from 'mailparser'
-import addressparser from 'nodemailer/lib/addressparser'
 
-import type { SubmittedHow } from '~/routes/circulars/circulars.lib'
-
-const legacyAddress = 'mailnull@capella2.gsfc.nasa.gov'
-const legacyFromNameSplitter = ' via '
-
-/**
- * Parse rewritten From addresses from capella2.
- *
- * Messages forwarded by capella2 from non-NASA addresses have From headers
- * that are rewritten like this:
- *
- * From: Albert Einstein <albert.einstein@ligo.org>
- * --rewritten to--
- * From: "Albert Einstein <albert.einstein@ligo.org> via gcncirc" <mailnull@capella2.gsfc.nasa.gov>
- *
- */
 export function getFromAddress(fromAddressObject?: AddressObject) {
-  let from = fromAddressObject?.value[0]
-  let submittedHow: SubmittedHow
-  if (from?.address === legacyAddress) {
-    const i = from.name.lastIndexOf(legacyFromNameSplitter)
-    if (i === -1)
-      throw new Error(
-        `Expected From name to contain '${legacyFromNameSplitter}'`
-      )
-    from = addressparser(from.name.slice(0, i), {
-      flatten: true,
-    })[0]
-    submittedHow = 'email-legacy'
-  } else {
-    submittedHow = 'email'
-  }
+  const from = fromAddressObject?.value[0]
   const address = from?.address
   if (!address) throw new Error('From address is missing')
-  return { address, submittedHow }
+  return address
 }
 
 export function getReplyToAddresses(replyTo?: AddressObject) {

--- a/app/routes/docs.circulars.submitting.mdx
+++ b/app/routes/docs.circulars.submitting.mdx
@@ -71,11 +71,4 @@ To post a GCN Circular via the web form, simply go to the [GCN Circulars archive
 
 ### Post a GCN Circular by Email
 
-To submit a GCN Circular by email, send a message to: <CircularsEmailAddress/>.
-
-The legacy address gcncirc@capella2.gsfc.nasa.gov forwards emails to <CircularsEmailAddress/>. This forwarding will be retired on December 31, 2024. Note that the new address is stricter than the old address about the `From:` address matching the sender.
-
-<Alert type="warning" headingLevel="h4">
-  **Do not send your Circular to both email addresses.** If you send it to both
-  addresses, then it will be distributed twice as two different circulars.
-</Alert>
+To submit a GCN Circular by email, send a message to <CircularsEmailAddress/>.

--- a/app/routes/docs.contributing.email/route.mdx
+++ b/app/routes/docs.contributing.email/route.mdx
@@ -20,7 +20,7 @@ Note that each flow chart represents the email processing for a single one of GC
 
 <img src={circularsIngestionImg} alt="Flow chart of GCN Circulars ingestion" />
 
-Authorized GCN users can [submit GCN Circulars](/docs/circulars/submitting) in any one of three ways: by logging in and completing the [Web form](/circulars/new), by submitting an email to circulars@<i>stage</i>.gcn.nasa.gov, or by submitting an email to the legacy GCN Classic server at <span>gcncirc</span>@capella2.gsfc.nasa.gov.
+Authorized GCN users can [submit GCN Circulars](/docs/circulars/submitting) in either of two ways: by logging in and completing the [Web form](/circulars/new) or by submitting an email to circulars@<i>stage</i>.gcn.nasa.gov.
 
 ### By Web form
 
@@ -35,10 +35,6 @@ To submit a Circular via email, the user sends an email to circulars@<i>stage</i
 - Otherwise, the Lambda function checks that the From: address matches the email address of a user who belongs to the `circular-submitter` group.
 - The Lambda checks that the subject validates against a list of [allowed and disallowed keywords](/docs/circulars/styleguide#message-content).
 - If all of the above checks pass, then the Circular is accepted, stored in the database, and distributed to GCN Circulars subscribers.
-
-### By email to <span>gcncirc</span>@capella2.gsfc.nasa.gov
-
-The legacy, on-premise GCN Classic server at NASA Goddard Space Flight Center, capella2.gsfc.nasa.gov, is configured to forward messages addressed to <span>gcncirc</span>@capella2.gsfc.nasa.gov to <span>circulars</span>@gcn.nasa.gov. Once received by Amazon SES, processing proceeds the same as above.
 
 ## Support Requests
 


### PR DESCRIPTION
Reverts nasa-gcn/gcn.nasa.gov#2786; reapplies nasa-gcn/gcn.nasa.gov#2660. This patch was applied too early.