### PR TITLE
Use builtin Web Fetch; polyfill not needed in Node.js >= 20

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -45,6 +45,15 @@ const esmOnlyModules = [
   /^vfile/,
 ]
 
+// These packages should never be bundled.
+const neverBundledModules = [
+  // Included in AWS Lambda base image
+  /@?aws-sdk(?:\/|$)/,
+  // Used to polyfill Web Fetch; not needed for Node.js >= 20
+  'undici',
+  '@remix-run/web-fetch',
+]
+
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
   mdx: {
@@ -80,7 +89,15 @@ export default {
   serverModuleFormat: 'cjs',
   serverDependenciesToBundle: [
     ...esmOnlyModules,
-    ...(isProduction ? [/^(?!@?aws-sdk(\/|$))/] : []),
+    ...(isProduction
+      ? [
+          new RegExp(
+            `^(?!${neverBundledModules
+              .map((item) => (item instanceof RegExp ? item.source : item))
+              .join('|')})`
+          ),
+        ]
+      : []),
   ],
   future: { v3_relativeSplatPath: true },
 }

--- a/server.ts
+++ b/server.ts
@@ -1,11 +1,9 @@
 import { type RequestHandler, createRequestHandler } from '@remix-run/architect'
 import * as build from '@remix-run/dev/server-build'
-import { installGlobals } from '@remix-run/node'
 import { type APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
 import sourceMapSupport from 'source-map-support'
 
 sourceMapSupport.install()
-installGlobals({ nativeFetch: true })
 
 const remixHandler = createRequestHandler({
   build,


### PR DESCRIPTION
Note that we must manually exclude the two polyfill libraries, unidici and @remix-run/web-fetch, because they are not properly tree-shaken.