### PR TITLE
Import only needed part of lodash

### DIFF
--- a/app/components/UserLookup.tsx
+++ b/app/components/UserLookup.tsx
@@ -10,7 +10,7 @@ import type { action } from 'app/routes/api.users'
 import classnames from 'classnames'
 import type { UseComboboxProps, UseComboboxStateChange } from 'downshift'
 import { useCombobox } from 'downshift'
-import { debounce } from 'lodash'
+import debounce from 'lodash/debounce.js'
 import { useCallback, useEffect, useState } from 'react'
 
 import { formatAuthor } from '~/routes/circulars/circulars.lib'


### PR DESCRIPTION
Don't import all of lodash; only import the module for the function that we are using.

This decreases the server bundle size.