### PR TITLE
Require Node.js >= 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "@architect/inventory": "github:lpsinger/inventory#esm-graph-with-top-level-await"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "sideEffects": false,
   "prettier": {

--- a/sandbox-search.js
+++ b/sandbox-search.js
@@ -6,12 +6,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readFile } from 'fs/promises'
-import groupBy from 'lodash/groupBy.js'
 
 export default async function () {
   const text = await readFile('sandbox-seed.json', { encoding: 'utf-8' })
   const { circulars, synonyms } = JSON.parse(text)
-  const groups = Object.entries(groupBy(synonyms, 'synonymId')).flatMap(
+  const groups = Object.entries(Object.groupBy(synonyms, 'synonymId')).flatMap(
     ([synonymId, values]) => [
       {
         synonymId,


### PR DESCRIPTION
This is the version we deploy to now.

Note: remove lodash.groupBy, which now has a builtin alternative Object.groupBy.