### PR TITLE
Gracefully handle build errors in esbuild script

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -31,16 +31,22 @@ const options = {
     {
       name: 'copy Node API modules to output directories',
       setup(build) {
-        build.onEnd(async ({ metafile: { outputs } }) => {
-          await Promise.all(
-            Object.entries(outputs).flatMap(([entryPoint, { inputs }]) =>
-              Object.keys(inputs)
-                .filter((input) => extname(input) === '.node')
-                .map((input) =>
-                  copyFile(input, join(dirname(entryPoint), basename(input)))
-                )
+        build.onEnd(async ({ metafile }) => {
+          if (metafile) {
+            await Promise.all(
+              Object.entries(metafile.outputs).flatMap(
+                ([entryPoint, { inputs }]) =>
+                  Object.keys(inputs)
+                    .filter((input) => extname(input) === '.node')
+                    .map((input) =>
+                      copyFile(
+                        input,
+                        join(dirname(entryPoint), basename(input))
+                      )
+                    )
+              )
             )
-          )
+          }
         })
       },
     },
@@ -48,10 +54,12 @@ const options = {
       name: 'write metafile to output directory',
       setup(build) {
         build.onEnd(async ({ metafile }) => {
-          await writeFile(
-            join(build.initialOptions.outdir, 'metafile.lambda.json'),
-            JSON.stringify(metafile)
-          )
+          if (metafile) {
+            await writeFile(
+              join(build.initialOptions.outdir, 'metafile.lambda.json'),
+              JSON.stringify(metafile)
+            )
+          }
         })
       },
     },


### PR DESCRIPTION
We have two plugins which each take the metafile as an argument. However, if the build fails, then the metafile arguemnt will not be set. In this case esbuild will print the original and hopefully helpful error message, but also unhelpful error messages about the metafile being undefined. Suppress the latter error messages by checking first that the metafile is defined.