### PR TITLE
Fix Object.groupBy callback arg

### DIFF
--- a/sandbox-search.js
+++ b/sandbox-search.js
@@ -10,15 +10,15 @@ import { readFile } from 'fs/promises'
 export default async function () {
   const text = await readFile('sandbox-seed.json', { encoding: 'utf-8' })
   const { circulars, synonyms } = JSON.parse(text)
-  const groups = Object.entries(Object.groupBy(synonyms, 'synonymId')).flatMap(
-    ([synonymId, values]) => [
-      {
-        synonymId,
-        eventIds: values.map(({ eventId }) => eventId),
-        slugs: values.map(({ slug }) => slug),
-      },
-    ]
-  )
+  const groups = Object.entries(
+    Object.groupBy(synonyms, ({ synonymId }) => ({ synonymId }))
+  ).flatMap(([synonymId, values]) => [
+    {
+      synonymId,
+      eventIds: values.map(({ eventId }) => eventId),
+      slugs: values.map(({ slug }) => slug),
+    },
+  ])
   return [
     ...circulars.flatMap((item) => [
       { index: { _index: 'circulars', _id: item.circularId.toString() } },


### PR DESCRIPTION
`Object.groupBy` takes as an argument a callback to return the grouping keys.

Fixes the following error introduced in #2792:

```
TypeError: synonymId is not a function
    at Function.groupBy (<anonymous>)
    at default (file:///Users/lpsinger/src/gcn.nasa.gov/sandbox-search.js:13:40)
    at async getData (file:///Users/lpsinger/src/gcn.nasa.gov/node_modules/@nasa-gcn/architect-plugin-search/index.js:318:16)
    at async populate (file:///Users/lpsinger/src/gcn.nasa.gov/node_modules/@nasa-gcn/architect-plugin-search/index.js:327:16)
    at async start (file:///Users/lpsinger/src/gcn.nasa.gov/node_modules/@nasa-gcn/architect-plugin-search/index.js:628:5)
    at async runPlugins (/Users/lpsinger/src/gcn.nasa.gov/node_modules/@architect/sandbox/src/sandbox/plugins/index.js:25:9)
```