### PR TITLE
add "draft" to circular subject checker

### DIFF
--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -233,6 +233,7 @@ export const emailAutoReplyChecklist = [
   ' r: ',
   ' ris: ',
   'subject:',
+  'draft',
 ]
 
 export function formatAuthor({


### PR DESCRIPTION
# Description
An issue came up with a recent circular where the author accidentally sent out a draft email meant for the instrument team to the circular submission address.  He immediately submitted a revision and contacted me directly to approve it quickly.  I've seen this happen occasionally before, and we might as well prevent it, so I added "draft" to the `emailAutoReplyChecklist`.  It's not an auto reply, but should serve the same function.