### PR TITLE
Replace aws-lambda-ses-forwarder fork with release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@remix-run/react": "~2.15.0",
         "@trussworks/react-uswds": "github:lpsinger/react-uswds#gcn",
         "@xmldom/xmldom": "^0.9.6",
-        "aws-lambda-ses-forwarder": "github:lpsinger/aws-lambda-ses-forwarder#aws-sdk-v3",
+        "aws-lambda-ses-forwarder": "^6.0.0",
         "classnames": "^2.5.1",
         "color-convert": "^2.0.1",
         "cross-env": "^7.0.3",
@@ -10267,16 +10267,16 @@
       }
     },
     "node_modules/aws-lambda-ses-forwarder": {
-      "version": "5.0.0",
-      "resolved": "git+ssh://git@github.com/lpsinger/aws-lambda-ses-forwarder.git#f72bb794c18494cc5e1384a751d47656ab28c623",
-      "integrity": "sha512-iRq/vhvLj20YhIf44OgEB9xgsX7SXFLUtc9YCPSeTVqqnRbJTQGpbTT8e0Q4hwllEtkW13fRwbksca5YW8b56A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/aws-lambda-ses-forwarder/-/aws-lambda-ses-forwarder-6.0.0.tgz",
+      "integrity": "sha512-1jqYpZXoUUYuMoGcDkTz9yxlZ0fkzSwRrR057kei4ZBgEfhTDs/EW94MBakoO7auPDDrOFDroGy0/sievGLjYQ==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.188.0",
         "@aws-sdk/client-sesv2": "^3.188.0"
       },
       "engines": {
-        "node": ">=8.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/aws-sdk": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@remix-run/react": "~2.15.0",
     "@trussworks/react-uswds": "github:lpsinger/react-uswds#gcn",
     "@xmldom/xmldom": "^0.9.6",
-    "aws-lambda-ses-forwarder": "github:lpsinger/aws-lambda-ses-forwarder#aws-sdk-v3",
+    "aws-lambda-ses-forwarder": "^6.0.0",
     "classnames": "^2.5.1",
     "color-convert": "^2.0.1",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
This was a workaround for https://github.com/arithmetric/aws-lambda-ses-forwarder/pull/146, which has now been fixed upstream.

# Testing
This can't be tested locally. We'll need to deploy it to dev to make sure that it works.