### PR TITLE
Use released version of @architect/inventory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -405,8 +405,9 @@
       }
     },
     "node_modules/@architect/inventory": {
-      "version": "4.0.5",
-      "resolved": "git+ssh://git@github.com/lpsinger/inventory.git#50f4f31d7aee291b6a80983576f2000a44762ffa",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@architect/inventory/-/inventory-4.0.6.tgz",
+      "integrity": "sha512-vCKfoogAQmHPXDgCU76lvHsmmMdMoLDOEi21f6kq31G++lpqhY6+68fsOxnV1iakDY6tXV5YeZ0WGLOBa37/fA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -415,7 +416,7 @@
         "@architect/utils": "~4.0.6",
         "@aws-lite/client": "^0.21.1",
         "@aws-lite/ssm": "^0.2.3",
-        "lambda-runtimes": "~2.0.2"
+        "lambda-runtimes": "~2.0.5"
       },
       "engines": {
         "node": ">=16"
@@ -18727,9 +18728,9 @@
       }
     },
     "node_modules/lambda-runtimes": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/lambda-runtimes/-/lambda-runtimes-2.0.3.tgz",
-      "integrity": "sha512-kctr26kT0sJoBU7OQTcuCbY1KQYpEm3GoeTMMHsud6ALemF8LNoWxkChDInwStZ9l6Vtae2PkNahY6JClT4LDA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/lambda-runtimes/-/lambda-runtimes-2.0.5.tgz",
+      "integrity": "sha512-6BoLX9xuvr+B/f05MOhJnzRdF8Za5YYh82n45ndun9EU3uhJv9kIwnYrOrvuA7MoGwZgCMI7RUhBRzfw/l63SQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -150,8 +150,7 @@
     "yarn": "^1.22.21"
   },
   "overrides": {
-    "@architect/deploy": "github:DocLM/deploy#d3116f41d5fda00337ebfda543a69d3b3d4546be",
-    "@architect/inventory": "github:lpsinger/inventory#esm-graph-with-top-level-await"
+    "@architect/deploy": "github:DocLM/deploy#d3116f41d5fda00337ebfda543a69d3b3d4546be"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
We no longer need our branch because https://github.com/architect/inventory/pull/77 has been merged and released upstream.