### PR TITLE
fixing grouping locally

### DIFF
--- a/sandbox-search.js
+++ b/sandbox-search.js
@@ -11,7 +11,7 @@ export default async function () {
   const text = await readFile('sandbox-seed.json', { encoding: 'utf-8' })
   const { circulars, synonyms } = JSON.parse(text)
   const groups = Object.entries(
-    Object.groupBy(synonyms, ({ synonymId }) => ({ synonymId }))
+    Object.groupBy(synonyms, ({ synonymId }) => synonymId)
   ).flatMap(([synonymId, values]) => [
     {
       synonymId,


### PR DESCRIPTION

before change:
<img width="1067" alt="Screenshot 2025-02-06 at 12 39 19 PM" src="https://github.com/user-attachments/assets/b9f6aafc-ca57-4a22-b84c-97af599f90c2" />
after change:
<img width="1061" alt="Screenshot 2025-02-06 at 12 39 58 PM" src="https://github.com/user-attachments/assets/c5555356-df43-4382-90d6-ccbc9de2e3d0" />

This fixes an issue with local development where all the synonyms were being loaded into the local stand in for the opensearch index as one mega group. 