### PR TITLE
Parse JSON Section in Sample Code

### DIFF
--- a/app/routes/docs.client.samples.md
+++ b/app/routes/docs.client.samples.md
@@ -204,7 +204,7 @@ for message in consumer.consume(timeout=1):
 
 ## Decoding Embedded Data
 
-Some GCN notices include HEALPix sky maps encoded in base64.
+Some GCN notices include HEALPix sky maps encoded in [base64](https://datatracker.ietf.org/doc/html/rfc4648.html), a way of encoding binary data into text.
 The following code demonstrates how to extract, decode, and save the HEALPix data as a `.fits` file from a received notice. Python's built-in [`base64`](https://docs.python.org/3/library/base64.html#base64.b64encode) module provides the `b64decode` method to simplify the decoding process.
 
 ```python

--- a/app/routes/docs.client.samples.md
+++ b/app/routes/docs.client.samples.md
@@ -239,7 +239,7 @@ If you want to include a FITS file in a Notice, add a property to your schema de
 }
 ```
 
-JSON Schema supports embedding non-JSON media within strings using the `contentMediaType` and `contentEncoding`, which enable the distribution of diverse data types. For further details, refer to [non-JSON data](https://json-schema.org/understanding-json-schema/reference/non_json_data.html).
+JSON Schema supports embedding non-Unicode media within strings using the `contentMediaType` and `contentEncoding`, which enable the distribution of diverse data types. For further details, refer to [non-JSON data](https://json-schema.org/understanding-json-schema/reference/non_json_data.html).
 
 ## Encoding Embedded Data
 

--- a/app/routes/docs.client.samples.md
+++ b/app/routes/docs.client.samples.md
@@ -196,7 +196,7 @@ for message in consumer.consume(timeout=1):
     # Print the topic and message ID
     print(f"topic={message.topic()}, offset={message.offset()}")
 
-    # Kafka message value as a Base64-encoded string
+    # Kafka message value as a JSON dictionary encoded as a string or byte array
     value = message.value()
 ```
 

--- a/app/routes/docs.client.samples.md
+++ b/app/routes/docs.client.samples.md
@@ -232,8 +232,9 @@ data = {
 ```json
 "healpix_file": {
     type: 'string',
-	contentEncoding: 'base64',
-	contentMediaType: 'image/fits',
+    contentEncoding: 'base64',
+    contentMediaType: 'image/fits',
+    "description": "Base 64 encoded content of a FITS file"
 }
 ```
 

--- a/app/routes/docs.client.samples.md
+++ b/app/routes/docs.client.samples.md
@@ -204,7 +204,7 @@ for message in consumer.consume(timeout=1):
 
 ## Decoding Embedded Data
 
-Some GCN notices include HEALPix sky maps encoded in `base64`.
+Some GCN notices include HEALPix sky maps encoded in base64.
 The following code demonstrates how to extract, decode, and save the HEALPix data as a `.fits` file from a received notice. Python's built-in [`base64`](https://docs.python.org/3/library/base64.html#base64.b64encode) module provides the `b64decode` method to simplify the decoding process.
 
 ```python

--- a/app/routes/docs.client.samples.md
+++ b/app/routes/docs.client.samples.md
@@ -169,9 +169,9 @@ for message in consumer.consume(end[0].offset - start[0].offset, timeout=1):
 
 ## Parsing JSON
 
-GCN Notices are distributed through Kafka topics and for new missions are typically distributed in JSON format. This guide explains how to programmatically read the JSON schema.
+GCN Notices are distributed through Kafka topics and, for new missions, are typically provided in JSON format. This guide explains how to programmatically read the JSON schema.
 
-Start with subscribing to a Kafka topic and parsing the JSON data
+Start by subscribing to a Kafka topic and parsing the JSON data.
 
 ```python
 from gcn_kafka import Consumer
@@ -204,8 +204,8 @@ for message in consumer.consume(timeout=1):
 
 ## Decoding Embedded Data
 
-Some GCN notices contain HEALPix sky maps encoded as `base64`.
-The following code demonstrates how to extract, decode, and save the HEALPix FITS file from a received notice. Python's built-in [`base64`](https://docs.python.org/3/library/base64.html#base64.b64encode) module provides the `b64decode` method to simplify this task.
+Some GCN notices include HEALPix sky maps encoded in `base64`.
+The following code demonstrates how to extract, decode, and save the HEALPix data as a `.fits` file from a received notice. Python's built-in [`base64`](https://docs.python.org/3/library/base64.html#base64.b64encode) module provides the `b64decode` method to simplify the decoding process.
 
 ```python
 import base64
@@ -228,22 +228,22 @@ with fits.open("skymap.fits") as hdul:
 
 ## JSON Schema Example for Embedding a FITS File
 
-If you want to include a FITS file in a Notice, you add a property to your schema definition in the following format:
+If you want to include a FITS file in a Notice, add a property to your schema definition in the following format:
 
 ```json
 "healpix_file": {
-    type: 'string',
-    contentEncoding: 'base64',
-    contentMediaType: 'image/fits',
+    "type": 'string',
+    "contentEncoding": 'base64',
+    "contentMediaType": 'image/fits',
     "description": "Base 64 encoded content of a FITS file"
 }
 ```
 
-JSON Schema supports embedding non-JSON media within strings using `contentMediaType` and `contentEncoding` keywords, which enable the distribution of diverse data types. For further details, refer to [non-JSON data](https://json-schema.org/understanding-json-schema/reference/non_json_data.html).
+JSON Schema supports embedding non-JSON media within strings using the `contentMediaType` and `contentEncoding`, which enable the distribution of diverse data types. For further details, refer to [non-JSON data](https://json-schema.org/understanding-json-schema/reference/non_json_data.html).
 
 ## Encoding Embedded Data
 
-For producer data production pipelines, the following encoding steps convert an input file to a bytestring. This guide demonstrates how to encode a file (e.g., skymap.fits) into a `base64` encoded string and submit it to the GCN Kafka broker.
+For producer data production pipelines, the following encoding steps convert an input file to a byte string. This guide demonstrates how to encode a file (e.g., skymap.fits) into a `base64` encoded string and submit it to the GCN Kafka broker.
 
 ```python
 from gcn_kafka import Producer

--- a/app/routes/docs.client.samples.md
+++ b/app/routes/docs.client.samples.md
@@ -223,8 +223,14 @@ with open("skymap.fits", "wb") as fits_file:
 
 If you want to include a FITS file in a Notice, you add a property to your schema definition in the following format:
 
-```python
-{
+data = {
+"type": "string",
+"contentEncoding": "base64",
+"contentMediaType": "image/fits"
+}
+
+```json
+"healpix_file": {
     type: 'string',
 	contentEncoding: 'base64',
 	contentMediaType: 'image/fits',

--- a/app/routes/docs.client.samples.md
+++ b/app/routes/docs.client.samples.md
@@ -232,6 +232,8 @@ If you want to include a FITS file in a Notice, you add a property to your schem
 }
 ```
 
+JSON Schema supports embedding non-JSON media within strings by leveraging the `contentMediaType` and `contentEncoding` keywords, which enable the distribution of diverse data types. For further details, refer to [non-JSON data](https://json-schema.org/understanding-json-schema/reference/non_json_data.html).
+
 ## Encoding Embedded Data
 
 For producer data production pipelines, the following encoding steps convert an input file to a bytestring. This guide demonstrates how to encode a file (e.g., skymap.fits) into a `base64` encoded string and submit it to the GCN Kafka broker.
@@ -265,8 +267,6 @@ producer.produce(
 
 producer.flush()
 ```
-
-JSON Schema supports embedding non-JSON media within strings by leveraging the `contentMediaType` and `contentEncoding` keywords, which enable the distribution of diverse data types. For further details, refer to [non-JSON data](https://json-schema.org/understanding-json-schema/reference/non_json_data.html).
 
 ## HEALPix Sky Maps
 

--- a/app/routes/docs.client.samples.md
+++ b/app/routes/docs.client.samples.md
@@ -232,9 +232,9 @@ If you want to include a FITS file in a Notice, add a property to your schema de
 
 ```json
 "healpix_file": {
-    "type": 'string',
-    "contentEncoding": 'base64',
-    "contentMediaType": 'image/fits',
+    "type": "string",
+    "contentEncoding": "base64",
+    "contentMediaType": "image/fits",
     "description": "Base 64 encoded content of a FITS file"
 }
 ```

--- a/app/routes/docs.client.samples.md
+++ b/app/routes/docs.client.samples.md
@@ -223,12 +223,6 @@ with open("skymap.fits", "wb") as fits_file:
 
 If you want to include a FITS file in a Notice, you add a property to your schema definition in the following format:
 
-data = {
-"type": "string",
-"contentEncoding": "base64",
-"contentMediaType": "image/fits"
-}
-
 ```json
 "healpix_file": {
     type: 'string',


### PR DESCRIPTION
# Description
This document is in continuation of Parse JSON PR: https://github.com/nasa-gcn/gcn.nasa.gov/pull/2669.
While resolving merge conflicts, earlier PR was mistakenly closed.

# Requirement
Pick an example of an actual notice type that contains embedded HEALPix data. Show how to:

subscribe to and receive that notice type
decode the Kafka message as JSON
decode base64 text to bytes
read the bytes as a FITS file

And then the user is ready to go on to the sky maps section! (I think that this is turning into a step-by-step tutorial, which will be awesome.)

Fixes #2149.