### PR TITLE
Event id not required

### DIFF
--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -120,7 +120,7 @@ export async function action({ request }: ActionFunctionArgs) {
       }
       const eventId = getFormDataString(data, 'eventId')
 
-      if (!createdOnDate || !createdOn || !eventId)
+      if (!createdOnDate || !createdOn)
         throw new Response(null, { status: 400 })
 
       let zendeskTicketId: number | undefined

--- a/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
+++ b/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
@@ -149,11 +149,7 @@ export function CircularEditForm({
   const dateTimeValid = circularId ? dateTimeIsValid(dateTime) : true
   const sending = Boolean(useNavigation().formData)
   const valid =
-    subjectValid &&
-    bodyValid &&
-    dateTimeValid &&
-    submitterValid &&
-    (!eventId || eventIdValid)
+    subjectValid && bodyValid && dateTimeValid && submitterValid && eventIdValid
 
   let headerText, saveButtonText
 

--- a/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
+++ b/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
@@ -149,7 +149,11 @@ export function CircularEditForm({
   const dateTimeValid = circularId ? dateTimeIsValid(dateTime) : true
   const sending = Boolean(useNavigation().formData)
   const valid =
-    subjectValid && bodyValid && dateTimeValid && submitterValid && eventIdValid
+    subjectValid &&
+    bodyValid &&
+    dateTimeValid &&
+    submitterValid &&
+    (!eventId || eventIdValid)
 
   let headerText, saveButtonText
 
@@ -278,12 +282,7 @@ export function CircularEditForm({
           <CircularsKeywords />
         </CollapsableInfo>
         {intent !== 'new' && (
-          <InputGroup
-            className={classnames('maxw-full', {
-              'usa-input--error': eventIdValid === false,
-              'usa-input--success': eventIdValid,
-            })}
-          >
+          <InputGroup className="maxw-full">
             <InputPrefix className="wide-input-prefix">Event ID</InputPrefix>
             <TextInput
               autoFocus
@@ -292,10 +291,9 @@ export function CircularEditForm({
               id="eventId"
               type="text"
               defaultValue={defaultEventId}
-              required
               onChange={({ target: { value } }) => {
                 setEventId(value)
-                setEventIdValid(eventIdIsValid(value))
+                setEventIdValid(!value || eventIdIsValid(value))
               }}
             />
           </InputGroup>


### PR DESCRIPTION
# Description
Updates the edit/correction pages to make the event id not a required field

# Related Issue(s)
Resolves #2876

# Testing
Signed in
Edit a circular via edit button and also via correction submission
