### PR TITLE
VOEvent Broker retirement announcement

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -247,10 +247,10 @@ export function Layout({ children }: { children?: ReactNode }) {
         <DevBanner />
         <Header />
         <NewsBanner>
-          GCN at AAS 245, Legacy Circulars Address Retirement. See{' '}
+          Planned Retirement of VOEvent Brokers. See{' '}
           <Link
             className="usa-link"
-            to="/news#--gcn-at-aas-245-legacy-circulars-address-retirement"
+            to="/news#-planned-retirement-of-voevent-brokers-"
           >
             news and announcements
           </Link>

--- a/app/routes/news._index/route.mdx
+++ b/app/routes/news._index/route.mdx
@@ -30,6 +30,23 @@ import { Anchor } from '~/components/Anchor'
     <CollectionItem
       className="maxw-none grid-container"
       variantComponent={
+        <CollectionCalendarDate datetime={'February 20, 2025'} />
+      }
+    >
+      <CollectionHeading headingLevel="h3">
+        <Anchor> Retirement of VOEvent Brokers </Anchor>
+      </CollectionHeading>
+      <CollectionDescription>
+       #### Planned Retirement of GCN Classic VOEvent Brokers
+        The result of the November 2024 user survey of those utilizing the GCN VOEvent Brokers to receive VOEvent-format Notices with the VOEvent Transport Protocol is overwhelmingly in favor of retiring the brokers and users migrating to receive VOEvent Notices over Kafka.  This service is already available for all GCN Classic Notice types with self-subscription via the [Start Streaming Notices Guide](/quickstart).  The [GCN Classic VOEvent brokers](https://gcn.gsfc.nasa.gov/voevent.html) will be retired shortly after the conclusion of the O4 gravitational wave network observing run, [currently scheduled for October 7, 2025](https://observing.docs.ligo.org/plan/). We recommend the following actions for users currently utilizing VOEvent via GCN Classic.
+          - Sign up to receive VOEvent format Notices via [Kafka or email](/docs/notices/consuming)
+          - [Let the GCN Team know](/contact) when you're ready to unsubscribe from receiving them via the GCN Classic brokers.  All GCN Classic VOEvent subscribers will be unsubscribed after the end of O4 and the brokers will be taken offline.
+      </CollectionDescription>
+    </CollectionItem>
+
+    <CollectionItem
+      className="maxw-none grid-container"
+      variantComponent={
         <CollectionCalendarDate datetime={'January 7, 2025'} />
       }
     >


### PR DESCRIPTION
# Description
Announcement for VTP VOEvent broker retirement after end of O4.

# Related Issue(s)
Resolves #2746

DO NOT DEPLOY - I plan to merge this with the SVOM announcement #2868.
