### PR TITLE
add SVOM source name subject matcher

### DIFF
--- a/__tests__/circulars.ts
+++ b/__tests__/circulars.ts
@@ -73,6 +73,7 @@ describe('parseEventFromSubject', () => {
   const ztfEvent = 'ZTF23aabmzlp'
   const epEvent = 'EP241119a'
   const frbEvent = 'FRB 20250206A'
+  const svomEvent = 'sb25021804'
 
   test('handles nonsense subject cases', () => {
     expect(parseEventFromSubject('zawxdrcftvgbhnjm')).toBe(undefined)
@@ -621,6 +622,56 @@ describe('parseEventFromSubject', () => {
       const frbSubjectWithHyphen =
         'MASTER observations: FRB-20250206A and possible mother galaxy'
       expect(parseEventFromSubject(frbSubjectWithHyphen)).toBe(frbEvent)
+    })
+  })
+
+  describe('SVOM', () => {
+    test('handles SVOM event names', () => {
+      const svomSubject =
+        'SVOM/sb25021804: SVOM detection of a long X-ray transient'
+      expect(parseEventFromSubject(svomSubject)).toBe(svomEvent)
+    })
+
+    test('handles SVOM event names in misc positions', () => {
+      const svomSubjectWithNoSpace =
+        'SVOM detection: SVOM/sb25021804 a long X-ray transient'
+      expect(parseEventFromSubject(svomSubjectWithNoSpace)).toBe(svomEvent)
+    })
+
+    test('handles SVOM event names with space', () => {
+      const svomSubjectWithSpace =
+        'SVOM/sb 25021804: SVOM detection of a long X-ray transient'
+      expect(parseEventFromSubject(svomSubjectWithSpace)).toBe(svomEvent)
+    })
+
+    test('handles SVOM event names with spaces in misc positions', () => {
+      const svomSubjectWithSpace =
+        'SVOM detection: SVOM/sb25021804 a long X-ray transient'
+      expect(parseEventFromSubject(svomSubjectWithSpace)).toBe(svomEvent)
+    })
+
+    test('handles SVOM event name with an underscore', () => {
+      const svomSubjectWithUnderscore =
+        'SVOM/sb_25021804: SVOM detection of a long X-ray transient'
+      expect(parseEventFromSubject(svomSubjectWithUnderscore)).toBe(svomEvent)
+    })
+
+    test('handles SVOM event names with an underscore in misc positions', () => {
+      const svomSubjectWithUnderscore =
+        'SVOM detection: SVOM/sb25021804 a long X-ray transient'
+      expect(parseEventFromSubject(svomSubjectWithUnderscore)).toBe(svomEvent)
+    })
+
+    test('handles SVOM event name with a hyphen', () => {
+      const svomSubjectWithHyphen =
+        'SVOM/sb-25021804: SVOM detection of a long X-ray transient'
+      expect(parseEventFromSubject(svomSubjectWithHyphen)).toBe(svomEvent)
+    })
+
+    test('handles SVOM event name with a hyphen in misc positions', () => {
+      const svomSubjectWithHyphen =
+        'SVOM detection: SVOM/sb-25021804 a long X-ray transient'
+      expect(parseEventFromSubject(svomSubjectWithHyphen)).toBe(svomEvent)
     })
   })
 })

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -72,6 +72,7 @@ const subjectMatchers: SubjectMatcher[] = [
   ],
   [/EP[.\s_-]*(\d{6}[a-z])/i, ([, id]) => `EP${id}`],
   [/FRB[.\s_-]*(\d{8}[a-z])/i, ([, id]) => `FRB ${id}`.toUpperCase()],
+  [/sb[.\s_-]*(\d{8})/i, ([, id]) => `sb${id}`],
 ]
 
 /** Format a Circular as plain text. */


### PR DESCRIPTION
# Description
SVOM has recently started using sbYYMMDDFF source designations in their Circulars.  We need to add this to the subject matcher to get the correct eventID.

e.g. https://gcn.nasa.gov/circulars/39363

# Related Issue(s)