### PR TITLE
Refactors the maybe throw function to be general and reusable, with a new wrapper function that does just that

### DIFF
--- a/app/lib/cognito.server.ts
+++ b/app/lib/cognito.server.ts
@@ -27,6 +27,7 @@ import {
   paginateListUsersInGroup,
 } from '@aws-sdk/client-cognito-identity-provider'
 
+import { maybeThrow } from './utils'
 import type { User } from '~/routes/_auth/user.server'
 
 export const gcnGroupPrefix = 'gcn.nasa.gov/'
@@ -142,24 +143,14 @@ export async function listUsersInGroup(GroupName: string) {
   return users
 }
 
-export function maybeThrow(e: any, warning: string) {
-  const errorsAllowedInDev = [
+export function maybeThrowCognito(e: any, warning: string) {
+  const formattedWarning = `Cognito threw ${(e as CognitoIdentityProviderServiceException).name}. This would be an error in production. Since we are in ${process.env.NODE_ENV}, ${warning}.`
+
+  maybeThrow<CognitoIdentityProviderServiceException>(e, formattedWarning, [
     'ExpiredTokenException',
     'NotAuthorizedException',
     'UnrecognizedClientException',
-  ]
-  const { name } = e as CognitoIdentityProviderServiceException
-
-  if (
-    !errorsAllowedInDev.includes(name) ||
-    process.env.NODE_ENV === 'production'
-  ) {
-    throw e
-  } else {
-    console.warn(
-      `Cognito threw ${name}. This would be an error in production. Since we are in ${process.env.NODE_ENV}, ${warning}.`
-    )
-  }
+  ])
 }
 
 export async function createGroup(GroupName: string, Description: string) {

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -77,3 +77,24 @@ export function throwForStatus(response: Response) {
     throw new Error('Request failed', { cause: response })
   }
 }
+
+interface ErrorType {
+  name: string
+}
+
+export function maybeThrow<Type extends ErrorType>(
+  e: Type,
+  warning: string,
+  errorsAllowedInDev: string[]
+) {
+  const { name } = e as Type
+
+  if (
+    !errorsAllowedInDev.includes(name) ||
+    process.env.NODE_ENV === 'production'
+  ) {
+    throw e
+  } else {
+    console.warn(warning)
+  }
+}

--- a/app/routes/user._index.tsx
+++ b/app/routes/user._index.tsx
@@ -23,7 +23,7 @@ import { getUser, updateSession } from './_auth/user.server'
 import { formatAuthor } from './circulars/circulars.lib'
 import Hint from '~/components/Hint'
 import Spinner from '~/components/Spinner'
-import { cognito, maybeThrow } from '~/lib/cognito.server'
+import { cognito, maybeThrowCognito } from '~/lib/cognito.server'
 import { getFormDataString } from '~/lib/utils'
 import type { BreadcrumbHandle } from '~/root/Title'
 
@@ -68,7 +68,7 @@ export async function action({ request }: ActionFunctionArgs) {
   try {
     await cognito.send(command)
   } catch (e) {
-    maybeThrow(e, 'not saving name and affiliation permanently')
+    maybeThrowCognito(e, 'not saving name and affiliation permanently')
   }
 
   user.name = name

--- a/app/routes/user.credentials/client_credentials.server.ts
+++ b/app/routes/user.credentials/client_credentials.server.ts
@@ -14,7 +14,7 @@ import {
 } from '@aws-sdk/client-cognito-identity-provider'
 import { generators } from 'openid-client'
 
-import { cognito, maybeThrow } from '~/lib/cognito.server'
+import { cognito, maybeThrowCognito } from '~/lib/cognito.server'
 import { getUser } from '~/routes/_auth/user.server'
 
 export interface RedactedClientCredential {
@@ -155,7 +155,7 @@ export class ClientCredentialVendingMachine {
     try {
       response = await cognito.send(command)
     } catch (e) {
-      maybeThrow(e, 'creating fake client credentials')
+      maybeThrowCognito(e, 'creating fake client credentials')
       const client_id = generators.random(26)
       const client_secret = generators.random(51)
       return { client_id, client_secret }
@@ -178,7 +178,7 @@ export class ClientCredentialVendingMachine {
     try {
       response = await cognito.send(command)
     } catch (e) {
-      maybeThrow(e, 'creating fake client secret')
+      maybeThrowCognito(e, 'creating fake client secret')
       const client_secret = generators.random(51)
       return client_secret
     }
@@ -197,7 +197,7 @@ export class ClientCredentialVendingMachine {
     try {
       await cognito.send(command)
     } catch (e) {
-      maybeThrow(e, 'deleting fake client credentials')
+      maybeThrowCognito(e, 'deleting fake client credentials')
     }
   }
 
@@ -215,7 +215,7 @@ export class ClientCredentialVendingMachine {
     try {
       response = await cognito.send(command)
     } catch (e) {
-      maybeThrow(e, 'not getting group descriptions')
+      maybeThrowCognito(e, 'not getting group descriptions')
     }
 
     const groupsMap: { [key: string]: string | undefined } = Object.fromEntries(

--- a/app/routes/user.endorsements/endorsements.server.ts
+++ b/app/routes/user.endorsements/endorsements.server.ts
@@ -21,7 +21,7 @@ import {
   extractAttributeRequired,
   getCognitoUserFromSub,
   listUsersInGroup,
-  maybeThrow,
+  maybeThrowCognito,
 } from '~/lib/cognito.server'
 import { sendEmail } from '~/lib/email.server'
 import { origin } from '~/lib/env.server'
@@ -373,7 +373,7 @@ async function getUsersInGroup(): Promise<EndorsementUser[]> {
   try {
     users = await listUsersInGroup(submitterGroup)
   } catch (error) {
-    maybeThrow(error, 'returning fake users')
+    maybeThrowCognito(error, 'returning fake users')
     return [
       {
         sub: crypto.randomUUID(),


### PR DESCRIPTION
As requested: https://github.com/nasa-gcn/gcn.nasa.gov/pull/2918/files#r1974012097

I moved the maybeThrow function to utils, and updated the cognito server to have a wrapper function that is implemented in a similar way to the original. And updated the places where it is used
