### PR TITLE
Circulars: Update Advanced Search Documentation

### DIFF
--- a/app/routes/docs.circulars.advanced-search.mdx
+++ b/app/routes/docs.circulars.advanced-search.mdx
@@ -12,7 +12,7 @@ export function loader() {
 
 # Advanced Search
 
-The full-text search feature allows for searching keywords in a specific field of the circular. The search feature uses the [Lucene query syntax](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html) to specify the field and search term.
+The advanced search feature allows for searching keywords in a specific field of the circular. The search feature uses the [Lucene query syntax](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html) to specify the field and search term.
 
 ## Searching by Field
 
@@ -24,12 +24,17 @@ By default, a query that does not contain lucene syntax will attempt to match th
 
 ## Compound Queries
 
-These separate field queries can be combined using additional keywords to form compound queries. The following keywords are supported:
+These separate field queries can be combined using additional keywords to form compound queries. The following boolean keywords are supported:
 
-- `AND`: The AND operator requires that both conditions are met. For example, `subject:"Swift" AND body:"GRB"` will match circulars where the subject contains 'Swift' and the body contains 'GRB'.
-- `OR`: The OR operator requires that at least one condition is met. For example, `subject:"Swift" OR body:"GRB"` will match circulars where the subject contains 'Swift' or the body contains 'GRB'.
+- `AND`/`&&`: The `AND`/`||` operator requires that both conditions are met. For example, `subject:"Swift" AND body:"GRB"` will match circulars where the subject contains 'Swift' and the body contains 'GRB'.
+- `OR`/`||`: The `OR`/`||` operator requires that at least one condition is met. For example, `subject:"Swift" OR body:"GRB"` will match circulars where the subject contains 'Swift' or the body contains 'GRB'.
+- `NOT`/`!`: The `NOT`/`!` operator requires that the condition is not met and is commonly used with the `AND`/`&&` operator. For example, `subject:"LIGO" AND NOT body:"GRB"` will match circulars where the subject contains 'LIGO' and the body does not contain 'GRB'.
 
 By default, the AND operator is used if no operator is specified. For example, `subject:"Swift" body:"GRB"` is equivalent to `subject:"Swift" AND body:"GRB"`.
+
+It is also possible to combine these operator keywords to form more complex queries. For example, `subject:"Swift" AND (body:"GRB" OR body:"Gamma-ray burst")` will match circulars where the subject contains 'Swift' and the body contains either 'GRB' or 'Gamma-ray burst'.
+
+Using one of these operators without an additional field query will result in an error. For example, `subject:"Swift" AND` will raise an error. For queries that do not adhere to the Lucene query syntax, GCN will fall back onto a more basic search method that matches the query against all fields with a warning message.
 
 ## Wildcards
 
@@ -38,6 +43,10 @@ Wildcards can be used to match a patterned search term to a field, such as searc
 - `*`: Matches any number of characters.
 - `?`: Matches a single character.
 
+## Reserved Characters
+
+there are a number of reserved characters that have special meaning in the Lucene query syntax. These characters must be escaped using a backslash (`\`) to be treated as a literal character. Including these characters in a query without escaping them will raise an error.The reserved characters are: `+`, `-`, `=`, `&&`, `||`, `>`, `<`, `!`, `(`, `)`, `{`, `}`, `[`, `]`, `^`, `"`, `~`, `*`, `?`, `:`, `/`, `\`.
+
 ## Examples
 
 - `Swift`: Matches circulars where the subject, body, or submitter contains 'Swift'.
@@ -45,5 +54,7 @@ Wildcards can be used to match a patterned search term to a field, such as searc
 - `body:"Swift"`: Matches circulars where the body contains 'Swift'.
 - `subject:"Swift" AND body:"GRB"`: Matches circulars where the subject contains 'Swift' and the body contains 'GRB'.
 - `subject:"Swift" OR body:"GRB"`: Matches circulars where the subject contains 'Swift' or the body contains 'GRB'.
+- `subject:"Swift" AND (body:"GRB" OR body:"Gamma-ray burst")`: Matches circulars where the subject contains 'Swift' and the body contains either 'GRB' or 'Gamma-ray burst'.
+- `subject:"LIGO" AND NOT body:"GRB"`: Matches circulars where the subject contains 'LIGO' and the body does not contain 'GRB'.
 - `subject:"GRB21*"`: Matches circulars where the subject contains 'GRB21' followed by any number of characters.
 - `subject:"GRB21?"`: Matches circulars where the subject contains 'GRB21' followed by a single character.

--- a/app/routes/docs.circulars.advanced-search.mdx
+++ b/app/routes/docs.circulars.advanced-search.mdx
@@ -26,7 +26,7 @@ By default, a query that does not contain lucene syntax will attempt to match th
 
 These separate field queries can be combined using additional keywords to form compound queries. The following boolean keywords are supported:
 
-- `AND`/`&&`: The `AND`/`||` operator requires that both conditions are met. For example, `subject:"Swift" AND body:"GRB"` will match circulars where the subject contains 'Swift' and the body contains 'GRB'.
+- `AND`/`&&`: The `AND`/`&&` operator requires that both conditions are met. For example, `subject:"Swift" AND body:"GRB"` will match circulars where the subject contains 'Swift' and the body contains 'GRB'.
 - `OR`/`||`: The `OR`/`||` operator requires that at least one condition is met. For example, `subject:"Swift" OR body:"GRB"` will match circulars where the subject contains 'Swift' or the body contains 'GRB'.
 - `NOT`/`!`: The `NOT`/`!` operator requires that the condition is not met and is commonly used with the `AND`/`&&` operator. For example, `subject:"LIGO" AND NOT body:"GRB"` will match circulars where the subject contains 'LIGO' and the body does not contain 'GRB'.
 


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
This adds more language to the advanced search documentation describing forbidden behaviour that will cause errors when included in queries. This compliments the fallback method of #2930. Additionally, the compound queries section is expanded upon to describe the NOT operator, which can be used in tandem with the AND and OR operators.

# Related Issue(s)
Related to #2288 

# Testing
1. Add `CIRCULARS_LUCENE` flag to `.env` file
2. Navigate to Circulars section of documentation
3. Select "Advanced Search" Page
4. The page should exist
