### PR TITLE
remove agile and burstcube from mission menu

### DIFF
--- a/app/routes/missions.tsx
+++ b/app/routes/missions.tsx
@@ -24,12 +24,6 @@ export default function () {
               <NavLink key="." to="." end>
                 Missions, Instruments, and Facilities
               </NavLink>,
-              <NavLink key="agile" to="agile">
-                AGILE
-              </NavLink>,
-              <NavLink key="burstcube" to="burstcube">
-                BurstCube
-              </NavLink>,
               <NavLink key="calet" to="calet">
                 CALET
               </NavLink>,


### PR DESCRIPTION
# Description
In dealing with merge conflicts, somehow AGILE & BurstCube ended up both in the main Mission pages menu and the Mission archive sub-menu.  This PR removes them from the main list, so they are only in the archive list.  Page forwarding is maintained.