### PR TITLE
fix sandbox-search locally for synonyms with initialDate field

### DIFF
--- a/sandbox-search.js
+++ b/sandbox-search.js
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readFile } from 'fs/promises'
+import orderBy from 'lodash/orderBy.js'
 
 export default async function () {
   const text = await readFile('sandbox-seed.json', { encoding: 'utf-8' })
@@ -17,6 +18,7 @@ export default async function () {
       synonymId,
       eventIds: values.map(({ eventId }) => eventId),
       slugs: values.map(({ slug }) => slug),
+      initialDate: orderBy(values, ['initialDate'], ['asc'])[0].initialDate,
     },
   ])
   return [


### PR DESCRIPTION
# Description
This just fixes the sandbox-search so that it adds an appropriate value for initialDate locally

# Testing
Ran dev and was able to load search in circulars grouped view
