### PR TITLE
limit concurrency to one invocation in table-stream lambdas

### DIFF
--- a/build/table-streams/circulars/config.arc
+++ b/build/table-streams/circulars/config.arc
@@ -1,0 +1,2 @@
+@aws
+concurrency 1

--- a/build/table-streams/synonyms/config.arc
+++ b/build/table-streams/synonyms/config.arc
@@ -1,0 +1,2 @@
+@aws
+concurrency 1


### PR DESCRIPTION
# Description
currently concurrent invocations of table streams are not limited. This means that during backfills you can have upwards of 78 concurrent invocations to keep up with the fire hose of data coming through at the same time.

# Related Issue(s)
relates to backfills but does not close the tickets, so I'm leaving them unlinked.

# Testing
I am unsure how to test this.
