### PR TITLE
add link to public documentation & SVOM mission tab on the notice page

### DIFF
--- a/app/routes/missions.svom/route.mdx
+++ b/app/routes/missions.svom/route.mdx
@@ -22,7 +22,9 @@ import logo from './logo_svom_black.svg'
 
 **End of Operations:** Mission duration of 3 years
 
-**Notices Archive:** [SVOM French Science Center](https://fsc.svom.org/alerts)
+**Notices Archive:** [SVOM French Science Center (FSC)](https://fsc.svom.org/alerts)
+
+**Notices Documentation:** [FSC readthedocs](https://fsc.svom.org/readthedocs/svom/notices_and_circulars/index.html)
 
 The [Space-based multi-band astronomical Variable Objects Monitor (SVOM)](https://www.svom.eu/en/the-svom-mission/) is a French-Chinese mission, result of a collaboration between the two national space agencies, [China National Space Administration (CNSA)](https://www.cnsa.gov.cn/english/index.html) and [Centre national d'études spatiales (CNES)](https://cnes.fr/en/projects/svom). SVOM is dedicated to the study of the most powerful transient phenomena, with a particular emphasis on gamma-ray bursts (GRBs).
 
@@ -81,6 +83,8 @@ of the localization:
  - `qf2`&#8594; 60'' < R90 < 120''<br/>
  - `qf3`&#8594; 30'' < R90 < 60''<br/>
  - `qf4`&#8594; R90 < 30''<br/>
+
+A more extensive documentation can be found on the [FSC website](https://fsc.svom.org)
 
 #### VOEvent examples
 

--- a/app/routes/notices.tsx
+++ b/app/routes/notices.tsx
@@ -453,6 +453,14 @@ export default function () {
         >
           Status of the CGRO spacecraft.
         </NoticeCard>
+        <NoticeCard
+          name="SVOM"
+          href="https://fsc.svom.org/home"
+          tags={['gamma', 'x-ray', 'optical']}
+          selectedTags={tagNames}
+        >
+          GRBs and other X-ray transients detected by SVOM.
+        </NoticeCard>
       </CardGroup>
     </GridContainer>
   )


### PR DESCRIPTION
This is a new pull request to update the svom mission page.
I also add a SVOM card in the notices tab that is linked to the French Science center website