### PR TITLE
updated documentation for event groups

### DIFF
--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -336,10 +336,19 @@ export default function () {
         )}
       </ToolbarButtonGroup>
       <Hint id="searchHint">
-        Search for Circulars by submitter, subject, or body text (e.g. 'Fermi
-        GRB'). <br />
-        To navigate to a specific circular, enter the associated Circular ID
-        (e.g. 'gcn123', 'Circular 123', or '123').
+        {isGroupView ? (
+          <>
+            Search for Event Groups by event name (e.g. 'GRB 123456A',
+            'GRB123456A', '123456A'). <br />
+          </>
+        ) : (
+          <>
+            Search for Circulars by submitter, subject, or body text (e.g.
+            'Fermi GRB'). <br />
+            To navigate to a specific circular, enter the associated Circular ID
+            (e.g. 'gcn123', 'Circular 123', or '123').
+          </>
+        )}
       </Hint>
       {useFeature('CIRCULARS_LUCENE') && <LuceneAccordion />}
       {clean && (

--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -5,6 +5,8 @@ handle:
 
 import { Link } from '@remix-run/react'
 
+import { WithFeature } from '~/root'
+
 # Circulars Archive
 
 Upon successful submission and distribution, a GCN Circular is assigned a number and stored permanently in the [GCN Circulars archive](/circulars). The archive lists links to the full text of every GCN Circular in reverse chronological order. The archive has a full-text search feature that you can use to find all Circulars that contain a phrase or keyword.
@@ -17,7 +19,30 @@ Upon successful submission and distribution, a GCN Circular is assigned a number
 
 You can search the Circulars Archive by keywords or phrases in the subject, body, and submitter fields. By default, results will be returned in reverse chronological order, but you can also choose to sort the results by relevance. You can navigate through the search results using pagination controls and specify the number of results to display per page. By default, 100 results are displayed per page.
 
-You can also filter search results by submission date. Select the dropdown button labeled "Filter by date". From there, you can either select from a number of predefined time ranges (e.g., "Last Hour", "Last Day", etc.) or specify a custom date range, which can either be set as a start date, an end date, or both. All search filters can be cleared by clicking the 'x' button in the search bar.
+You can filter search results by submission date. Select the dropdown button labeled "Filter by date". From there, you can either select from a number of predefined time ranges (e.g., "Last Hour", "Last Day", etc.) or specify a custom date range, which can either be set as a start date, an end date, or both. All search filters can be cleared by clicking the 'x' button in the search bar.
+
+<WithFeature SYNONYMS>
+## Event View
+
+The Circulars archive provides an Event View that allows users to view all Circulars associated with a particular astronomical event.
+
+Each Circular is automatically assigned an event name derived from the subject (e.g. GRB 250109A, EP250109a). This assignment is done by matching against a regular expressions list.
+
+The event name is listed in the JSON format version of Circulars. The first event name used in the subject is associated automatically, and all Circulars with the same event name are grouped. GCN moderators can associate multiple event names with a group, such that all Circulars with these event names will be listed in the same event group.
+
+### Adding events to the same group
+
+GCN Team moderators can create or modify event groups. If you would like to suggest the creation or modification of an event group, submit a ticket via [the contact form](/support).
+
+### Searching by event name
+
+In the Event View search bar, enter in an event name and it will take you to the associated event group. It will recognize regular expressions associated with the event name (e.g. GRB 123456A, GRB123456A, 123456A).
+
+### Linking to an event name or event group
+
+To save a direct link to all Circulars assocaited with a particular event name or event group, you can point to any event name in that group, e.g. `https://gcn.nasa.gov/circulars/group/[event_name]'.
+
+</WithFeature>
 
 ## Citing GCN Circulars
 

--- a/app/routes/docs.circulars.corrections/route.mdx
+++ b/app/routes/docs.circulars.corrections/route.mdx
@@ -8,7 +8,7 @@ import versionButtonScreenshot from './version_button.png'
 
 # Corrections
 
-Circulars authors can request changes to archived Circulars to correct inaccurate information, especially when the correction is important for the follow-up community's activities. These may include author lists, subject corrections, typos, and incorrect citations. Do not use the corrections feature to add details of new observations or analyses. In such cases, submit a new Circular with an appropriate subject (e.g. "refined analysis" or "additional observations").
+Circulars authors can request changes to archived Circulars to correct inaccurate information, especially when the correction is important for the follow-up community's activities. These may include author lists, subject corrections, event name additions or corrections, typos, and incorrect citations. Do not use the corrections feature to add details of new observations or analyses. In such cases, submit a new Circular with an appropriate subject (e.g. "refined analysis" or "additional observations").
 
 ## Who can request corrections?
 


### PR DESCRIPTION
# Description
Documentation for event name and event groups, including how they are assigned, searched, modified, and cited.

# Related Issue(s)
Replaces #2837 because of a merge issue.
Resolves #2732.