### PR TITLE
add Circulars Kafka documentation

### DIFF
--- a/app/routes/docs.circulars._index.mdx
+++ b/app/routes/docs.circulars._index.mdx
@@ -12,7 +12,7 @@ Circulars allow the GRB community to post messages (by email, or by submitting a
 
 ### For more details on how to use GCN Circulars, see:
 
-- [Subscribing](circulars/subscribing) to receive GCN Circulars by email
+- [Subscribing](circulars/subscribing) to receive GCN Circulars by email or Kafka
 - [Submitting](circulars/submitting) to post your own GCN Circulars
 - [Style Guide](circulars/styleguide) for how to write an effective GCN Circular
 - [Corrections](circulars/corrections) for how to make minor corrections to archived GCN Circulars

--- a/app/routes/docs.circulars.subscribing.mdx
+++ b/app/routes/docs.circulars.subscribing.mdx
@@ -12,7 +12,9 @@ import {
 
 # Subscribing to Circulars
 
-Follow these simple steps to receive GCN Circulars via email.
+Most users prefer to receive GCN Circulars by email. Automated systems may benefit from utilization of the Circulars Kafka stream.
+
+## Receive Circulars by Email
 
 <ProcessList>
   <ProcessListItem>
@@ -39,3 +41,11 @@ Follow these simple steps to receive GCN Circulars via email.
     Toggle the "On/Off" button next to Circulars to enable or disable GCN Circulars by email.
   </ProcessListItem>
 </ProcessList>
+
+## Stream Circulars over Kafka
+
+If you have an existing Kafka listener generated from the [Start Streaming GCN Notices interface](quickstart), simply add the Kafka topic `gcn.circulars`.
+
+Alternatively, visit the [Start Streaming GCN Notices interface](quickstart), select JSON, and the Circulars topic.
+
+Note that upon [corrections](corrections), all revised Circular versions will be distributed over the Kafka stream.


### PR DESCRIPTION
# Description
Adds documentation to the Circulars subscribing page explaining how to subscribe to Circulars via Kafka.

# Related Issue(s)
Issue came up after sending announcement about #2803.
Resolves #2962.