### PR TITLE
Courey/fix synonym search

### DIFF
--- a/app/routes/synonyms/synonyms.server.ts
+++ b/app/routes/synonyms/synonyms.server.ts
@@ -61,54 +61,29 @@ export async function searchSynonymsByEventId({
 }> {
   const client = await getSearchClient()
   const body: any = {
-    query: {},
+    query: {
+      bool: {},
+    },
   }
 
   if (eventId) {
-    body.query = {
-      function_score: {
-        query: {
-          bool: {
-            should: [
-              {
-                wildcard: {
-                  'eventIds.keyword': {
-                    value: `*${eventId}*`,
-                  },
-                },
-              },
-            ],
-            minimum_should_match: 1,
+    body.query.bool.filter = [
+      {
+        regexp: {
+          'eventIds.keyword': {
+            value: `.*${eventId}.*`,
+            case_insensitive: true,
           },
         },
-        functions: [
-          {
-            script_score: {
-              script: {
-                source: `
-                  int idx = doc['eventIds.keyword'].value.indexOf(params.query);
-                  if (idx == -1) return 0;
-                  return 1.0 / (1 + idx);
-                `,
-                params: { query: eventId },
-              },
-            },
-          },
-        ],
-        boost_mode: 'replace',
       },
-    }
+    ]
   } else {
-    body.query = {
-      bool: {
-        should: [
-          {
-            match_all: {},
-          },
-        ],
-        minimum_should_match: 1,
+    body.query.bool.should = [
+      {
+        match_all: {},
       },
-    }
+    ]
+    body.query.bool.minimum_should_match = 1
     body.sort = [
       {
         initialDate: {

--- a/app/routes/synonyms/synonyms.server.ts
+++ b/app/routes/synonyms/synonyms.server.ts
@@ -60,24 +60,33 @@ export async function searchSynonymsByEventId({
   page: number
 }> {
   const client = await getSearchClient()
-  const query: any = {
-    bool: {
-      should: [
-        {
-          match_all: {},
-        },
-      ],
-      minimum_should_match: 1,
+  const body: any = {
+    query: {
+      bool: {
+        should: [
+          {
+            match_all: {},
+          },
+        ],
+        minimum_should_match: 1,
+      },
     },
+    sort: [],
   }
 
   if (eventId) {
-    query.bool.should.push({
+    body.query.bool.should.push({
       match: {
         eventIds: {
           query: eventId,
           fuzziness: '1',
         },
+      },
+    })
+  } else {
+    body.sort.push({
+      initialDate: {
+        order: 'desc',
       },
     })
   }
@@ -93,16 +102,7 @@ export async function searchSynonymsByEventId({
     index: 'synonym-groups',
     from: page * limit,
     size: limit,
-    body: {
-      query,
-      sort: [
-        {
-          initialDate: {
-            order: 'desc',
-          },
-        },
-      ],
-    },
+    body,
   })
 
   const totalPages: number = Math.ceil(totalItems / limit)


### PR DESCRIPTION
# Description
Adding sorting behavior wiped out the relevance search. When you are not searching for a match, the results should be sorted by the initialDate, but when you are using a search term, it should sort by relevance. 

This branch changes the behavior of the search so that it does NOT sort by initialDate when using a query. Instead it will sort by relevance. When a query is not provided, the results are sorted by initialDate (as there is no relevance to sort by).

I fine tuned the results for a query search because the fuzziness search was not returning them in what I would see as an appropriate order. by changing it to a wildcard regex match search, it is returning only results that fit the query and in an appropriate order of relevance. 

# Related Issue(s)

Resolves #2981

# NOTE:
the sort order when sorting by initialDate is still not exact. I am working on this and will include improvements to that in a different branch. I made minimal improvements by making my sort more explicit in its behavior. This did not resolve the issue fully (though did help some).
i added the following fields to the sort for that:
```          
missing: '_last',
unmapped_type: 'long',
```
So the order of the index is slightly off, but not grossly off.

I want to unblock Judy and Vidushi, so further improvements will be in a different branch.

# Testing
This has been tested locally.
<img width="449" alt="Screenshot 2025-04-07 at 4 33 19 PM" src="https://github.com/user-attachments/assets/c6a95909-a3c4-4166-b512-d8628df33a63" />
<img width="571" alt="Screenshot 2025-04-07 at 4 33 13 PM" src="https://github.com/user-attachments/assets/df3c39a8-3280-4c8f-84fd-3f1c3c4a16e1" />
