### PR TITLE
changing search to use filter and wildcard

### DIFF
--- a/app/routes/synonyms/synonyms.server.ts
+++ b/app/routes/synonyms/synonyms.server.ts
@@ -314,12 +314,13 @@ export async function autoCompleteEventIds({
     body: {
       query: {
         bool: {
-          must: [
+          filter: [
             {
-              query_string: {
-                query: `*${cleanedQuery}*`,
-                fields: ['eventId'],
-                fuzziness: 'AUTO',
+              regexp: {
+                'eventId.keyword': {
+                  value: `.*${cleanedQuery}.*`,
+                  case_insensitive: true,
+                },
               },
             },
           ],

--- a/app/routes/synonyms/synonyms.server.ts
+++ b/app/routes/synonyms/synonyms.server.ts
@@ -71,7 +71,7 @@ export async function searchSynonymsByEventId({
       {
         wildcard: {
           'eventIds.keyword': {
-            value: `*${eventId.replace('-', ' ')}*`,
+            value: `*${eventId}*`,
             case_insensitive: true,
           },
         },
@@ -303,7 +303,6 @@ export async function autoCompleteEventIds({
 }): Promise<{
   options: string[]
 }> {
-  const cleanedQuery = query.replace('-', ' ')
   const client = await getSearchClient()
   const {
     body: {
@@ -318,7 +317,7 @@ export async function autoCompleteEventIds({
             {
               wildcard: {
                 'eventId.keyword': {
-                  value: `*${cleanedQuery}*`,
+                  value: `*${query}*`,
                   case_insensitive: true,
                 },
               },

--- a/app/routes/synonyms/synonyms.server.ts
+++ b/app/routes/synonyms/synonyms.server.ts
@@ -69,9 +69,9 @@ export async function searchSynonymsByEventId({
   if (eventId) {
     body.query.bool.filter = [
       {
-        regexp: {
+        wildcard: {
           'eventIds.keyword': {
-            value: `.*${eventId}.*`,
+            value: `*${eventId.replace('-', ' ')}*`,
             case_insensitive: true,
           },
         },
@@ -316,9 +316,9 @@ export async function autoCompleteEventIds({
         bool: {
           filter: [
             {
-              regexp: {
+              wildcard: {
                 'eventId.keyword': {
-                  value: `.*${cleanedQuery}.*`,
+                  value: `*${cleanedQuery}*`,
                   case_insensitive: true,
                 },
               },


### PR DESCRIPTION
# Description
They way the search worked seemed to have an issue with lucene syntax (which is odd as it has never had that issue before). It still is not repeatable locally. I changed the query to match how the search for synonyms functions, using a filter and regexp.

# Related Issue(s)

Resolves #2983

# Testing
This has been tested locally since that's the only way to test it. Since the issue is not repeatable locally, that makes it difficult to properly test. I have manually tested locally that the change to the query works locally.
<img width="257" alt="Screenshot 2025-04-08 at 1 01 51 PM" src="https://github.com/user-attachments/assets/d434d99a-5d18-483a-8f1f-99b53de7eb43" />
<img width="274" alt="Screenshot 2025-04-08 at 1 01 46 PM" src="https://github.com/user-attachments/assets/8c0c57d2-2e30-4e9c-8a22-4e48d799e63a" />
