### PR TITLE
normalize Virgo in subject matcher

### DIFF
--- a/__tests__/circulars.ts
+++ b/__tests__/circulars.ts
@@ -515,6 +515,24 @@ describe('parseEventFromSubject', () => {
       expect(parseEventFromSubject(ligoVirgo)).toBe('LIGO/Virgo S231127cg')
     })
 
+    test('handles ligo/virgo normalization', () => {
+      const ligoVirgo =
+        'ligo/virgo S231127cg: Identification of a GW compact binary merger candidate'
+      expect(parseEventFromSubject(ligoVirgo)).toBe('LIGO/Virgo S231127cg')
+    })
+
+    test('handles ligo/virgo flag normalization', () => {
+      const ligoVirgo =
+        'ligo/virgo s231127cg: Identification of a GW compact binary merger candidate'
+      expect(parseEventFromSubject(ligoVirgo)).toBe('LIGO/Virgo S231127cg')
+    })
+
+    test('handles ligo/virgo id normalization', () => {
+      const ligoVirgo =
+        'ligo/virgo S231127CG: Identification of a GW compact binary merger candidate'
+      expect(parseEventFromSubject(ligoVirgo)).toBe('LIGO/Virgo S231127cg')
+    })
+
     test('handles LIGO alert', () => {
       const ligoVirgoKagra =
         'LIGO S231127cg: Identification of a GW compact binary merger candidate'

--- a/__tests__/circulars.ts
+++ b/__tests__/circulars.ts
@@ -533,6 +533,62 @@ describe('parseEventFromSubject', () => {
       expect(parseEventFromSubject(ligoVirgo)).toBe('LIGO/Virgo S231127cg')
     })
 
+    test('handles LIGO/Virgo instrument odd casing', () => {
+      const ligoVirgo =
+        'LiGo/viRgo s231127Cg: Identification of a GW compact binary merger candidate'
+      expect(parseEventFromSubject(ligoVirgo)).toBe('LIGO/Virgo S231127cg')
+    })
+
+    test('handles Ligo/Virgo instrument odd casing', () => {
+      const ligoVirgo =
+        'Ligo/Virgo S231127cg: Identification of a GW compact binary merger candidate'
+      expect(parseEventFromSubject(ligoVirgo)).toBe('LIGO/Virgo S231127cg')
+    })
+
+    test('handles Ligo/Virgo flag casing', () => {
+      const ligoVirgo =
+        'LIGO/Virgo s231127cg: Identification of a GW compact binary merger candidate'
+      expect(parseEventFromSubject(ligoVirgo)).toBe('LIGO/Virgo S231127cg')
+    })
+
+    test('handles Ligo/Virgo id casing', () => {
+      const ligoVirgo =
+        'LIGO/Virgo S231127CG: Identification of a GW compact binary merger candidate'
+      expect(parseEventFromSubject(ligoVirgo)).toBe('LIGO/Virgo S231127cg')
+    })
+
+    test('handles ligo/VIRGO id casing', () => {
+      const ligoVirgo =
+        'ligo/VIRGO S231127CG: Identification of a GW compact binary merger candidate'
+      expect(parseEventFromSubject(ligoVirgo)).toBe('LIGO/Virgo S231127cg')
+    })
+
+    test('handles ligo/VIRGO/kAgRa odd kagra casing', () => {
+      const ligoVirgo =
+        'ligo/VIRGo/kAgRa S231127cg: Identification of a GW compact binary merger candidate'
+      expect(parseEventFromSubject(ligoVirgo)).toBe(
+        'LIGO/Virgo/KAGRA S231127cg'
+      )
+    })
+
+    test('handles LIGO odd casing', () => {
+      const ligo =
+        'lIgO S231127cg: Identification of a GW compact binary merger candidate'
+      expect(parseEventFromSubject(ligo)).toBe('LIGO S231127cg')
+    })
+
+    test('handles KAGRA odd casing', () => {
+      const ligo =
+        'kAgRa S231127cg: Identification of a GW compact binary merger candidate'
+      expect(parseEventFromSubject(ligo)).toBe('KAGRA S231127cg')
+    })
+
+    test('handles full ligo/virgo/kagra inconsistent casing', () => {
+      const ligo =
+        'LiGo/ViRGo/kAgRa s231127cG: Identification of a GW compact binary merger candidate'
+      expect(parseEventFromSubject(ligo)).toBe('LIGO/Virgo/KAGRA S231127cg')
+    })
+
     test('handles LIGO alert', () => {
       const ligoVirgoKagra =
         'LIGO S231127cg: Identification of a GW compact binary merger candidate'

--- a/__tests__/circulars.ts
+++ b/__tests__/circulars.ts
@@ -510,9 +510,9 @@ describe('parseEventFromSubject', () => {
     })
 
     test('handles LIGO/Virgo normalization', () => {
-      const ligoVirgoKagra =
+      const ligoVirgo =
         'LIGO/VIRGO S231127cg: Identification of a GW compact binary merger candidate'
-      expect(parseEventFromSubject(ligoVirgoKagra)).toBe('LIGO/Virgo S231127cg')
+      expect(parseEventFromSubject(ligoVirgo)).toBe('LIGO/Virgo S231127cg')
     })
 
     test('handles LIGO alert', () => {

--- a/__tests__/circulars.ts
+++ b/__tests__/circulars.ts
@@ -501,6 +501,20 @@ describe('parseEventFromSubject', () => {
       )
     })
 
+    test('handles LIGO/Virgo/KAGRA normalization', () => {
+      const ligoVirgoKagra =
+        'LIGO/VIRGO/KAGRA S231127cg: Identification of a GW compact binary merger candidate'
+      expect(parseEventFromSubject(ligoVirgoKagra)).toBe(
+        'LIGO/Virgo/KAGRA S231127cg'
+      )
+    })
+
+    test('handles LIGO/Virgo normalization', () => {
+      const ligoVirgoKagra =
+        'LIGO/VIRGO S231127cg: Identification of a GW compact binary merger candidate'
+      expect(parseEventFromSubject(ligoVirgoKagra)).toBe('LIGO/Virgo S231127cg')
+    })
+
     test('handles LIGO alert', () => {
       const ligoVirgoKagra =
         'LIGO S231127cg: Identification of a GW compact binary merger candidate'

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -63,7 +63,7 @@ const subjectMatchers: SubjectMatcher[] = [
   [/ZTF[.\s_-]*(\d{2}[a-z]*)/i, ([, id]) => `ZTF${id.toLowerCase()}`],
   [/HAWC[.\s_-]*(\d{6}A)/i, ([, id]) => `HAWC-${id.toUpperCase()}`],
   [
-    /((?:LIGO|Virgo|KAGRA)(?:[/-](?:LIGO|Virgo|KAGRA))*)[-_ \s]?(S|G|GW)(\d{5,}[a-z]*)/i,
+    /((?:LIGO|Virgo|KAGRA)(?:[/-](?:LIGO|Virgo|KAGRA))*)[-_ \s]?(S|G|GW)(\d{5,}[a-zA-Z]*)/i,
     ([, instrument, flag, id]) => {
       const normalizedInstrument = instrument
         .toUpperCase()

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -65,7 +65,9 @@ const subjectMatchers: SubjectMatcher[] = [
   [
     /((?:LIGO|Virgo|KAGRA)(?:[/-](?:LIGO|Virgo|KAGRA))*)[-_ \s]?(S|G|GW)(\d{5,}[a-z]*)/i,
     ([, instrument, flag, id]) => {
-      const normalizedInstrument = instrument.replace('VIRGO', 'Virgo')
+      const normalizedInstrument = instrument
+        .toUpperCase()
+        .replace('VIRGO', 'Virgo')
       return `${normalizedInstrument} ${flag.toUpperCase()}${id.toLowerCase()}`
     },
   ],

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -65,7 +65,8 @@ const subjectMatchers: SubjectMatcher[] = [
   [
     /((?:LIGO|Virgo|KAGRA)(?:[/-](?:LIGO|Virgo|KAGRA))*)[-_ \s]?(S|G|GW)(\d{5,}[a-z]*)/i,
     ([, instrument, flag, id]) => {
-      return `${instrument} ${flag.toUpperCase()}${id.toLowerCase()}`
+      const normalizedInstrument = instrument.replace('VIRGO', 'Virgo')
+      return `${normalizedInstrument} ${flag.toUpperCase()}${id.toLowerCase()}`
     },
   ],
   [/ANTARES[.\s_-]*(\d{6}[a-z])/i, ([, id]) => `ANTARES ${id}`.toUpperCase()],


### PR DESCRIPTION
# Description
This normalizes:
 `LIGO/Virgo G298048` `LIGO/VIRGO G298048` `LIGO/VIRGO/KAGRA G298048` `LIGO/Virgo/KAGRA G298048`
So they all have virgo with a capital V and the rest lowercase:
`LIGO/Virgo G298048` `LIGO/Virgo/KAGRA G298048`

# Related Issue(s)
Resolves #2984

# Testing
This was tested locally by running the following variations through the subject matcher and examining the results:
 `LIGO/Virgo G298048` `LIGO/VIRGO G298048` `LIGO/VIRGO/KAGRA G298048` `LIGO/Virgo/KAGRA G298048`

Test cases were also added for the following cases:
`LIGO/VIRGO G298048` 
`LIGO/VIRGO/KAGRA G298048`
