### PR TITLE
Circulars: Enable advanced search

### DIFF
--- a/app/routes/circulars._archive._index/LuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/LuceneMenu.tsx
@@ -14,7 +14,7 @@ export function LuceneAccordion() {
     <details>
       <summary>Advanced Search</summary>
       <p className="usa-paragraph">
-        To narrow the search results, use Lucene search syntax. This allows for
+        To narrow the search results, use advanced search syntax. This allows for
         specifying which circular field to search (submitter, subject, and/or
         body). For additional information, refer to{' '}
         <Link className="usa-link" to="/docs/circulars/archive#advanced-search">

--- a/app/routes/circulars._archive._index/LuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/LuceneMenu.tsx
@@ -32,7 +32,7 @@ export function LuceneAccordion() {
         <Highlight language="sh" code='body:"GRB"' className="grid-col-4" />
         <Highlight
           language="sh"
-          code='submitter:"Tomas Ahumada Mena"'
+          code='submitter:"Judith Racusin"'
           className="grid-col-4"
         />
       </div>

--- a/app/routes/circulars._archive._index/LuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/LuceneMenu.tsx
@@ -14,9 +14,9 @@ export function LuceneAccordion() {
     <details>
       <summary>Advanced Search</summary>
       <p className="usa-paragraph">
-        To narrow the search results, use advanced search syntax. This allows for
-        specifying which circular field to search (submitter, subject, and/or
-        body). For additional information, refer to{' '}
+        To narrow the search results, use advanced search syntax. This allows
+        for specifying which circular field to search (submitter, subject,
+        and/or body). For additional information, refer to{' '}
         <Link className="usa-link" to="/docs/circulars/archive#advanced-search">
           the advanced search documentation
         </Link>

--- a/app/routes/circulars._archive._index/LuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/LuceneMenu.tsx
@@ -16,9 +16,9 @@ export function LuceneAccordion() {
       <p className="usa-paragraph">
         To narrow the search results, use Lucene search syntax. This allows for
         specifying which circular field to search (submitter, subject, and/or
-        body). Further documentation can be found{' '}
+        body). For additional information, refer to{' '}
         <Link className="usa-link" to="/docs/circulars/archive#advanced-search">
-          here
+          the advanced search documentation
         </Link>
         {'. '}
       </p>

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -366,7 +366,7 @@ export default function () {
           </>
         )}
       </Hint>
-      {useFeature('CIRCULARS_LUCENE') && <LuceneAccordion />}
+      <LuceneAccordion />
 
       {clean && (
         <>

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -39,7 +39,7 @@ import type {
   CircularMetadata,
 } from './circulars.lib'
 import { sendEmail, sendEmailBulk } from '~/lib/email.server'
-import { feature, origin } from '~/lib/env.server'
+import { origin } from '~/lib/env.server'
 import { closeZendeskTicket } from '~/lib/zendesk.server'
 
 // A type with certain keys required.

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -172,20 +172,13 @@ export async function search({
         }
 
   const queryObj = query
-    ? queryFallback
-      ? {
-          multi_match: {
-            query,
-            fields: ['submitter', 'subject', 'body'],
-          },
-        }
-      : {
-          query_string: {
-            query,
-            fields: ['submitter', 'subject', 'body'],
-            lenient: true,
-          },
-        }
+    ? {
+        [queryFallback ? 'multi_match' : 'query_string']: {
+          query,
+          fields: ['submitter', 'subject', 'body'],
+          ...(queryFallback ? {} : { lenient: true }),
+        },
+      }
     : undefined
 
   const searchBody = {

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -172,18 +172,18 @@ export async function search({
         }
 
   const queryObj = query
-    ? feature('CIRCULARS_LUCENE')
+    ? queryFallback
       ? {
+          multi_match: {
+            query,
+            fields: ['submitter', 'subject', 'body'],
+          },
+        }
+      : {
           query_string: {
             query,
             fields: ['submitter', 'subject', 'body'],
             lenient: true,
-          },
-        }
-      : {
-          multi_match: {
-            query,
-            fields: ['submitter', 'subject', 'body'],
           },
         }
     : undefined

--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -44,7 +44,6 @@ To save a direct link to all Circulars assocaited with a particular event name o
 
 </WithFeature>
 
-<WithFeature CIRCULARS_LUCENE>
 ## Advanced Search
 
 The advanced search feature allows for searching keywords in a specific field of the circular. The search feature uses the [Lucene query syntax](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html) to specify the field and search term.
@@ -93,8 +92,6 @@ there are a number of reserved characters that have special meaning in the Lucen
 - `subject:"LIGO" AND NOT body:"GRB"`: Matches circulars where the subject contains 'LIGO' and the body does not contain 'GRB'.
 - `subject:"GRB21*"`: Matches circulars where the subject contains 'GRB21' followed by any number of characters.
 - `subject:"GRB21?"`: Matches circulars where the subject contains 'GRB21' followed by a single character.
-
-</WithFeature>
 
 ## Citing GCN Circulars
 

--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -70,13 +70,6 @@ It is also possible to combine these operator keywords to form more complex quer
 
 Using one of these operators without an additional field query will result in an error. For example, `subject:"Swift" AND` will raise an error. For queries that do not adhere to the Lucene query syntax, GCN will fall back onto a more basic search method that matches the query against all fields with a warning message.
 
-### Wildcards
-
-Wildcards can be used to match a patterned search term to a field, such as searching for all Circulars related to GRBs detected in a given year by using the query `subject:"GRB21*"`. The following wildcards are supported:
-
-- `*`: Matches any number of characters.
-- `?`: Matches a single character.
-
 ### Reserved Characters
 
 there are a number of reserved characters that have special meaning in the Lucene query syntax. These characters must be escaped using a backslash (`\`) to be treated as a literal character. Including these characters in a query without escaping them will raise an error.The reserved characters are: `+`, `-`, `=`, `&&`, `||`, `>`, `<`, `!`, `(`, `)`, `{`, `}`, `[`, `]`, `^`, `"`, `~`, `*`, `?`, `:`, `/`, `\`.
@@ -90,8 +83,6 @@ there are a number of reserved characters that have special meaning in the Lucen
 - `subject:"Swift" OR body:"GRB"`: Matches circulars where the subject contains 'Swift' or the body contains 'GRB'.
 - `subject:"Swift" AND (body:"GRB" OR body:"Gamma-ray burst")`: Matches circulars where the subject contains 'Swift' and the body contains either 'GRB' or 'Gamma-ray burst'.
 - `subject:"LIGO" AND NOT body:"GRB"`: Matches circulars where the subject contains 'LIGO' and the body does not contain 'GRB'.
-- `subject:"GRB21*"`: Matches circulars where the subject contains 'GRB21' followed by any number of characters.
-- `subject:"GRB21?"`: Matches circulars where the subject contains 'GRB21' followed by a single character.
 
 ## Citing GCN Circulars
 


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
This enables the advanced search functionality, which allows for lucene style searches, along with the associated documentation.

# Related Issue(s)
Resolves #2288 

# Testing
1. Navigate to Circulars archive
2. submit a lucene style query (example: `subject:GRB`)
3. Results should differ from current production results
4. Submit an invalid lucene style query (example: `subject:GRB OR`)
5. Results should still load but with a warning that it is an invalid search. Results should be similar to searching `subject:GRB or` on production since it is falling back on `multi_match`
6. Clicking links to the documentation in the Advanced Search dropdown or the search warning should direct to the subsection in the docs on advanced search.
