### PR TITLE
allow non-subject matcher eventIds in circular edit form

### DIFF
--- a/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
+++ b/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
@@ -30,6 +30,7 @@ import {
 import { RichEditor } from './RichEditor'
 import { CircularsKeywords } from '~/components/CircularsKeywords'
 import CollapsableInfo from '~/components/CollapsableInfo'
+import Hint from '~/components/Hint'
 import Spinner from '~/components/Spinner'
 import { AstroDataContext } from '~/components/circularDisplay/AstroDataContext'
 import { MarkdownBody } from '~/components/circularDisplay/Body'
@@ -148,8 +149,7 @@ export function CircularEditForm({
   const bodyValid = bodyIsValid(body)
   const dateTimeValid = circularId ? dateTimeIsValid(dateTime) : true
   const sending = Boolean(useNavigation().formData)
-  const valid =
-    subjectValid && bodyValid && dateTimeValid && submitterValid && eventIdValid
+  const valid = subjectValid && bodyValid && dateTimeValid && submitterValid
 
   let headerText, saveButtonText
 
@@ -278,21 +278,33 @@ export function CircularEditForm({
           <CircularsKeywords />
         </CollapsableInfo>
         {intent !== 'new' && (
-          <InputGroup className="maxw-full">
-            <InputPrefix className="wide-input-prefix">Event ID</InputPrefix>
-            <TextInput
-              autoFocus
-              className="maxw-full"
-              name="eventId"
-              id="eventId"
-              type="text"
-              defaultValue={defaultEventId}
-              onChange={({ target: { value } }) => {
-                setEventId(value)
-                setEventIdValid(!value || eventIdIsValid(value))
-              }}
-            />
-          </InputGroup>
+          <>
+            <InputGroup
+              className={classnames('maxw-full', {
+                'usa-input--error': eventIdValid === false,
+                'usa-input--success': eventIdValid,
+              })}
+            >
+              <InputPrefix className="wide-input-prefix">Event ID</InputPrefix>
+              <TextInput
+                autoFocus
+                className="maxw-full"
+                name="eventId"
+                id="eventId"
+                type="text"
+                defaultValue={defaultEventId}
+                onChange={({ target: { value } }) => {
+                  setEventId(value)
+                  setEventIdValid(!value || eventIdIsValid(value))
+                }}
+              />
+            </InputGroup>
+            <Hint className="text-secondary">
+              {eventIdValid
+                ? '\u00A0'
+                : 'EventId does not match any existing subject matchers!'}
+            </Hint>
+          </>
         )}
         <label hidden htmlFor="body">
           Body


### PR DESCRIPTION
# Description
Judy would like to be able to add eventIds that are not in the subject matchers. She would like a visual indication when it doesn't match a subject matcher so moderators can be aware of typos and accidental use of non-matched eventIds. A non-matched eventId should not prevent save.

# Related Issue(s)
Resolves #2999 

# Testing
This was tested locally.

Hint shows up as you are typing:
<img width="1117" alt="Screenshot 2025-04-11 at 10 31 40 AM" src="https://github.com/user-attachments/assets/8978fcd9-ab9a-438e-88ff-d59e7b34e2f8" />
Input group is highlighted in red when the moderator clicks outside of the input:
<img width="1089" alt="Screenshot 2025-04-11 at 10 31 46 AM" src="https://github.com/user-attachments/assets/fac07bca-22a3-4621-9262-60ae56bb1dee" />
