### PR TITLE
normalizing subject matchers

### DIFF
--- a/__tests__/circulars.ts
+++ b/__tests__/circulars.ts
@@ -81,7 +81,7 @@ describe('parseEventFromSubject', () => {
   const snEventDoubleLetters = 'SN 2002ap'
   const xrfEvent = 'XRF 050509C'
   const xrfEventLetterless = 'XRF 050509'
-  const atEvent = 'AT 2023lcr'
+  const atEvent = 'AT2023lcr'
 
   test('handles nonsense subject cases', () => {
     expect(parseEventFromSubject('zawxdrcftvgbhnjm')).toBe(undefined)
@@ -97,9 +97,21 @@ describe('parseEventFromSubject', () => {
       expect(parseEventFromSubject(grbSubjectWithSpace)).toBe(grbEvent)
     })
 
+    test('handles GRB event names with incorrect casing', () => {
+      const grbSubjectWithSpace =
+        'GRB 230228a: Swift detection of a possibly short burst'
+      expect(parseEventFromSubject(grbSubjectWithSpace)).toBe(grbEvent)
+    })
+
     test('handles GRB event names in misc positions', () => {
       const grbSubjectWithSpace =
         'Swift detection of a possibly short burst for GRB 230228A'
+      expect(parseEventFromSubject(grbSubjectWithSpace)).toBe(grbEvent)
+    })
+
+    test('handles GRB event names with incorrect casing in misc positions', () => {
+      const grbSubjectWithSpace =
+        'Swift detection of a possibly short burst for GRB 230228a'
       expect(parseEventFromSubject(grbSubjectWithSpace)).toBe(grbEvent)
     })
 
@@ -268,6 +280,18 @@ describe('parseEventFromSubject', () => {
       expect(parseEventFromSubject(iceSubjectWithSpace)).toBe(iceEvent)
     })
 
+    test('handles IceCube event names with incorrect casing', () => {
+      const iceSubject =
+        'IceCube 221223a - IceCube observation of a high-energy neutrino candidate track-like event'
+      expect(parseEventFromSubject(iceSubject)).toBe(iceEvent)
+    })
+
+    test('handles IceCube event names with incorrect casing in misc positions', () => {
+      const iceSubjectWithSpace =
+        'IceCube observation of IceCube 221223a a high-energy neutrino candidate track-like event'
+      expect(parseEventFromSubject(iceSubjectWithSpace)).toBe(iceEvent)
+    })
+
     test('handles IceCube event names without space', () => {
       const iceSubjectWithNoSpace =
         'IceCube221223A - IceCube observation of a high-energy neutrino candidate track-like event'
@@ -315,6 +339,20 @@ describe('parseEventFromSubject', () => {
     test('handles IceCube-Cascade event names in misc positions', () => {
       const iceCascadeSubjectWithSpace =
         'IceCube observation of IceCube-Cascade 221223A a high-energy neutrino candidate track-like event'
+      expect(parseEventFromSubject(iceCascadeSubjectWithSpace)).toBe(
+        iceCasEvent
+      )
+    })
+
+    test('handles IceCube-Cascade event names with incorrect casing', () => {
+      const iceCascadeSubject =
+        'IceCube-Cascade 221223a - IceCube observation of a high-energy neutrino candidate track-like event'
+      expect(parseEventFromSubject(iceCascadeSubject)).toBe(iceCasEvent)
+    })
+
+    test('handles IceCube-Cascade event names with incorrect casing in misc positions', () => {
+      const iceCascadeSubjectWithSpace =
+        'IceCube observation of IceCube-Cascade 221223a a high-energy neutrino candidate track-like event'
       expect(parseEventFromSubject(iceCascadeSubjectWithSpace)).toBe(
         iceCasEvent
       )
@@ -388,6 +426,12 @@ describe('parseEventFromSubject', () => {
       expect(parseEventFromSubject(epSubjectWithSpace)).toBe(epEvent)
     })
 
+    test('handles EP event names with incorrect casing in misc positions', () => {
+      const epSubjectWithSpace =
+        'Global MASTER-Net EP 241119A observations report'
+      expect(parseEventFromSubject(epSubjectWithSpace)).toBe(epEvent)
+    })
+
     test('handles EP event names without space', () => {
       const epSubjectWithNoSpace = 'EP241119a EP detection'
       expect(parseEventFromSubject(epSubjectWithNoSpace)).toBe(epEvent)
@@ -433,6 +477,18 @@ describe('parseEventFromSubject', () => {
     test('handles ZTF event names with space in misc positions', () => {
       const ztfSubjectWithSpace =
         'Zwicky Transient Facility discovery of ZTF 23aabmzlp/AT2023azs a fast optical transient'
+      expect(parseEventFromSubject(ztfSubjectWithSpace)).toBe(ztfEvent)
+    })
+
+    test('handles ZTF event names with space and incorrect casing', () => {
+      const ztfSubject =
+        'ZTF 23aabmzlp/AT2023AZS: Zwicky Transient Facility discovery of a fast optical transient'
+      expect(parseEventFromSubject(ztfSubject)).toBe(ztfEvent)
+    })
+
+    test('handles ZTF event names with space and incorrect casing in misc positions', () => {
+      const ztfSubjectWithSpace =
+        'Zwicky Transient Facility discovery of ZTF 23aabmzlp/AT2023AZS a fast optical transient'
       expect(parseEventFromSubject(ztfSubjectWithSpace)).toBe(ztfEvent)
     })
 
@@ -718,6 +774,16 @@ describe('parseEventFromSubject', () => {
 
     test('handles ANTARES event names in misc positions', () => {
       const antSubjectWithSpace = 'Coincidence Fermi-LAT-ANTARES 200407a'
+      expect(parseEventFromSubject(antSubjectWithSpace)).toBe(antaresEvent)
+    })
+
+    test('handles ANTARES event names with incorrect casing', () => {
+      const antSubject = 'Fermi-LAT-ANTARES 200407A Coincidence'
+      expect(parseEventFromSubject(antSubject)).toBe(antaresEvent)
+    })
+
+    test('handles ANTARES event names with incorrect casing in misc positions', () => {
+      const antSubjectWithSpace = 'Coincidence Fermi-LAT-ANTARES 200407A'
       expect(parseEventFromSubject(antSubjectWithSpace)).toBe(antaresEvent)
     })
 
@@ -1088,6 +1154,17 @@ describe('parseEventFromSubject', () => {
       expect(parseEventFromSubject(xrfSubjectWithSpace)).toBe(xrfEvent)
     })
 
+    test('handles XRF event names with incorrect casing', () => {
+      const xrfSubjectWithSpace = 'XRF 050509c: Chandra Afterglow Detection'
+      expect(parseEventFromSubject(xrfSubjectWithSpace)).toBe(xrfEvent)
+    })
+
+    test('handles XRF event names with incorrect casing in misc positions', () => {
+      const xrfSubjectWithSpace =
+        'Chandra Afterglow Detection XRF 050509c follow up'
+      expect(parseEventFromSubject(xrfSubjectWithSpace)).toBe(xrfEvent)
+    })
+
     test('handles XRF event names without space', () => {
       const xrfSubjectWithNoSpace = 'XRF050509C: Chandra Afterglow Detection'
       expect(parseEventFromSubject(xrfSubjectWithNoSpace)).toBe(xrfEvent)
@@ -1189,13 +1266,23 @@ describe('parseEventFromSubject', () => {
     })
 
     test('handles AT event names with two letters', () => {
-      const atSubject = 'AT 2023lcd: VLA radio detection'
-      expect(parseEventFromSubject(atSubject)).toBe('AT 2023lcd')
+      const atSubject = 'AT 2023lc: VLA radio detection'
+      expect(parseEventFromSubject(atSubject)).toBe('AT2023lc')
     })
 
     test('handles AT event names with five letters', () => {
       const atSubject = 'AT 2023lcrsjq: VLA radio detection'
-      expect(parseEventFromSubject(atSubject)).toBe('AT 2023lcrsjq')
+      expect(parseEventFromSubject(atSubject)).toBe('AT2023lcrsjq')
+    })
+
+    test('handles AT event names with two letters and incorrect casing', () => {
+      const atSubject = 'AT 2023LC: VLA radio detection'
+      expect(parseEventFromSubject(atSubject)).toBe('AT2023lc')
+    })
+
+    test('handles AT event names with five letters and incorrect casing', () => {
+      const atSubject = 'AT 2023LCRSJQ: VLA radio detection'
+      expect(parseEventFromSubject(atSubject)).toBe('AT2023lcrsjq')
     })
 
     test('handles AT event names with incorrect casing', () => {

--- a/__tests__/circulars.ts
+++ b/__tests__/circulars.ts
@@ -78,6 +78,9 @@ describe('parseEventFromSubject', () => {
   const svomEvent = 'sb25021804'
   const gwEvent = 'GW250206'
   const snEvent = 'SN2002ap'
+  const xrfEvent = 'XRF 050509C'
+  const xrfEventLetterless = 'XRF 050509'
+  const atEvent = 'AT 2023lcr'
 
   test('handles nonsense subject cases', () => {
     expect(parseEventFromSubject('zawxdrcftvgbhnjm')).toBe(undefined)
@@ -1023,6 +1026,164 @@ describe('parseEventFromSubject', () => {
       const snSubjectWithHyphen =
         '(SN/GRB?): SN-2002ap optical spectrographic observations'
       expect(parseEventFromSubject(snSubjectWithHyphen)).toBe(snEvent)
+    })
+  })
+
+  describe('XRF', () => {
+    test('handles XRF event names', () => {
+      const xrfSubjectWithSpace = 'XRF 050509C: Chandra Afterglow Detection'
+      expect(parseEventFromSubject(xrfSubjectWithSpace)).toBe(xrfEvent)
+    })
+
+    test('handles XRF event names in misc positions', () => {
+      const xrfSubjectWithSpace =
+        'Chandra Afterglow Detection XRF 050509C follow up'
+      expect(parseEventFromSubject(xrfSubjectWithSpace)).toBe(xrfEvent)
+    })
+
+    test('handles XRF event names without space', () => {
+      const xrfSubjectWithNoSpace = 'XRF050509C: Chandra Afterglow Detection'
+      expect(parseEventFromSubject(xrfSubjectWithNoSpace)).toBe(xrfEvent)
+    })
+
+    test('handles XRF event names without spaces in misc positions', () => {
+      const xrfSubjectWithSpace = 'Chandra Afterglow Detection XRF050509C'
+      expect(parseEventFromSubject(xrfSubjectWithSpace)).toBe(xrfEvent)
+    })
+
+    test('handles XRF event name with an underscore', () => {
+      const xrfSubjectWithUnderscore =
+        'XRF_050509C: Chandra Afterglow Detection'
+      expect(parseEventFromSubject(xrfSubjectWithUnderscore)).toBe(xrfEvent)
+    })
+
+    test('handles XRF event names with an underscore in misc positions', () => {
+      const xrfSubjectWithUnderscore =
+        'Chandra Afterglow Detection XRF_050509C follow up'
+      expect(parseEventFromSubject(xrfSubjectWithUnderscore)).toBe(xrfEvent)
+    })
+
+    test('handles XRF event name with a hyphen', () => {
+      const xrfSubjectWithHyphen = 'XRF-050509C: Chandra Afterglow Detection'
+      expect(parseEventFromSubject(xrfSubjectWithHyphen)).toBe(xrfEvent)
+    })
+
+    test('handles XRF event name with a hyphen in misc positions', () => {
+      const xrfSubjectWithHyphen =
+        'Chandra Afterglow Detection XRF-050509C follow-up'
+      expect(parseEventFromSubject(xrfSubjectWithHyphen)).toBe(xrfEvent)
+    })
+
+    test('handles XRF event names without a letter', () => {
+      const xrfSubjectWithSpace = 'XRF 050509: Chandra Afterglow Detection'
+      expect(parseEventFromSubject(xrfSubjectWithSpace)).toBe(
+        xrfEventLetterless
+      )
+    })
+
+    test('handles XRF event names in misc positions without letter', () => {
+      const xrfSubjectWithSpace =
+        'Chandra Afterglow Detection XRF 050509 follow-up'
+      expect(parseEventFromSubject(xrfSubjectWithSpace)).toBe(
+        xrfEventLetterless
+      )
+    })
+
+    test('handles XRF event names without space without a letter', () => {
+      const xrfSubjectWithNoSpace = 'XRF050509: Chandra Afterglow Detection'
+      expect(parseEventFromSubject(xrfSubjectWithNoSpace)).toBe(
+        xrfEventLetterless
+      )
+    })
+
+    test('handles XRF event names without spaces in misc positions without a letter', () => {
+      const xrfSubjectWithSpace =
+        'Chandra Afterglow Detection XRF050509 follow-up'
+      expect(parseEventFromSubject(xrfSubjectWithSpace)).toBe(
+        xrfEventLetterless
+      )
+    })
+
+    test('handles XRF event name with an underscore without a letter', () => {
+      const xrfSubjectWithUnderscore = 'XRF_050509: Chandra Afterglow Detection'
+      expect(parseEventFromSubject(xrfSubjectWithUnderscore)).toBe(
+        xrfEventLetterless
+      )
+    })
+
+    test('handles XRF event names with an underscore in misc positions without a letter', () => {
+      const xrfSubjectWithUnderscore =
+        'Chandra Afterglow Detection XRF_050509 follow-up'
+      expect(parseEventFromSubject(xrfSubjectWithUnderscore)).toBe(
+        xrfEventLetterless
+      )
+    })
+
+    test('handles XRF event name with a hyphen without a letter', () => {
+      const xrfSubjectWithHyphen = 'XRF-050509: Chandra Afterglow Detection'
+      expect(parseEventFromSubject(xrfSubjectWithHyphen)).toBe(
+        xrfEventLetterless
+      )
+    })
+
+    test('handles XRF event name with a hyphen in misc positions without a letter', () => {
+      const xrfSubjectWithHyphen =
+        'Chandra Afterglow Detection XRF-050509 follow-up'
+      expect(parseEventFromSubject(xrfSubjectWithHyphen)).toBe(
+        xrfEventLetterless
+      )
+    })
+  })
+
+  describe('AT', () => {
+    test('handles AT event names', () => {
+      const atSubject = 'AT 2023lcr: VLA radio detection'
+      expect(parseEventFromSubject(atSubject)).toBe(atEvent)
+    })
+
+    test('handles AT event names with one letter', () => {
+      const atSubject = 'AT 2023lc: VLA radio detection'
+      expect(parseEventFromSubject(atSubject)).toBe('AT 2023lc')
+    })
+
+    test('handles AT event names with four letters', () => {
+      const atSubject = 'AT 2023lcrsj: VLA radio detection'
+      expect(parseEventFromSubject(atSubject)).toBe('AT 2023lcrsj')
+    })
+
+    test('handles AT event names with incorrect casing', () => {
+      const atSubject = 'at 2023LCR: VLA radio detection'
+      expect(parseEventFromSubject(atSubject)).toBe(atEvent)
+    })
+
+    test('handles AT event names in misc positions', () => {
+      const atSubjectWithSpace = 'VLA radio detection AT 2023lcr follow-up'
+      expect(parseEventFromSubject(atSubjectWithSpace)).toBe(atEvent)
+    })
+
+    test('handles AT event names with spaces in misc positions', () => {
+      const atSubjectWithSpace = 'VLA radio detection AT 2023lcr follow-up'
+      expect(parseEventFromSubject(atSubjectWithSpace)).toBe(atEvent)
+    })
+
+    test('handles AT event name with an underscore', () => {
+      const atSubjectWithUnderscore = 'AT_2023lcr: VLA radio detection'
+      expect(parseEventFromSubject(atSubjectWithUnderscore)).toBe(atEvent)
+    })
+
+    test('handles AT event names with an underscore in misc positions', () => {
+      const atSubjectWithUnderscore = 'VLA radio detection AT_2023lcr follow-up'
+      expect(parseEventFromSubject(atSubjectWithUnderscore)).toBe(atEvent)
+    })
+
+    test('handles AT event name with a hyphen', () => {
+      const atSubjectWithHyphen = 'AT-2023lcr: VLA radio detection'
+      expect(parseEventFromSubject(atSubjectWithHyphen)).toBe(atEvent)
+    })
+
+    test('handles AT event name with a hyphen in misc positions', () => {
+      const atSubjectWithHyphen = 'VLA radio detection AT-2023lcr follow-up'
+      expect(parseEventFromSubject(atSubjectWithHyphen)).toBe(atEvent)
     })
   })
 })

--- a/__tests__/circulars.ts
+++ b/__tests__/circulars.ts
@@ -77,7 +77,8 @@ describe('parseEventFromSubject', () => {
   const frbEvent = 'FRB 20250206A'
   const svomEvent = 'sb25021804'
   const gwEvent = 'GW250206'
-  const snEvent = 'SN2002ap'
+  const snEvent = 'SN 2002A'
+  const snEventDoubleLetters = 'SN 2002ap'
   const xrfEvent = 'XRF 050509C'
   const xrfEventLetterless = 'XRF 050509'
   const atEvent = 'AT 2023lcr'
@@ -971,61 +972,107 @@ describe('parseEventFromSubject', () => {
   })
 
   describe('SN', () => {
-    test('handles SN event names', () => {
-      const snSubject = 'SN2002ap (SN/GRB?) optical spectrographic observations'
+    test('handles first 26 SN event names', () => {
+      const snSubject = 'SN 2002A (SN/GRB?) optical spectrographic observations'
       expect(parseEventFromSubject(snSubject)).toBe(snEvent)
     })
 
-    test('handles SN event names with one letter', () => {
-      const snSubject = 'SN2002a (SN/GRB?) optical spectrographic observations'
-      expect(parseEventFromSubject(snSubject)).toBe('SN2002a')
+    test('handles double letter SN event names', () => {
+      const snSubject =
+        'SN 2002ap (SN/GRB?) optical spectrographic observations'
+      expect(parseEventFromSubject(snSubject)).toBe(snEventDoubleLetters)
     })
 
-    test('handles SN event names with incorrect casing', () => {
+    test('handles triple letter SN event names', () => {
+      const snSubject =
+        'SN 2002abc (SN/GRB?) optical spectrographic observations'
+      expect(parseEventFromSubject(snSubject)).toBe('SN 2002abc')
+    })
+
+    test('handles 5 letter SN event names', () => {
+      const snSubject =
+        'SN 2002abcde (SN/GRB?) optical spectrographic observations'
+      expect(parseEventFromSubject(snSubject)).toBe('SN 2002abcde')
+    })
+
+    test('handles SN event names with incorrect casing with two letters', () => {
       const snSubject = 'sn2002AP (SN/GRB?) optical spectrographic observations'
+      expect(parseEventFromSubject(snSubject)).toBe(snEventDoubleLetters)
+    })
+
+    test('handles SN event names with incorrect casing with many letters', () => {
+      const snSubject =
+        'sn 2002abcde (SN/GRB?) optical spectrographic observations'
+      expect(parseEventFromSubject(snSubject)).toBe('SN 2002abcde')
+    })
+
+    test('handles SN event names with incorrect casing with one letter', () => {
+      const snSubject = 'sn2002a (SN/GRB?) optical spectrographic observations'
       expect(parseEventFromSubject(snSubject)).toBe(snEvent)
     })
 
     test('handles SN event names in misc positions', () => {
       const snSubjectWithSpace =
-        '(SN/GRB?): SN 2002ap  optical spectrographic observations'
+        '(SN/GRB?): SN 2002A  optical spectrographic observations'
       expect(parseEventFromSubject(snSubjectWithSpace)).toBe(snEvent)
     })
 
     test('handles SN event names with space', () => {
       const snSubjectWithNoSpace =
-        'SN 2002ap (SN/GRB?) optical spectrographic observations'
+        'SN 2002A (SN/GRB?) optical spectrographic observations'
       expect(parseEventFromSubject(snSubjectWithNoSpace)).toBe(snEvent)
     })
 
-    test('handles SN event names with spaces in misc positions', () => {
+    test('handles SN event names with double letters and spaces in misc positions', () => {
       const snSubjectWithSpace =
         '(SN/GRB?): SN 2002ap  optical spectrographic observations'
-      expect(parseEventFromSubject(snSubjectWithSpace)).toBe(snEvent)
+      expect(parseEventFromSubject(snSubjectWithSpace)).toBe(
+        snEventDoubleLetters
+      )
     })
 
     test('handles SN event name with an underscore', () => {
       const snSubjectWithUnderscore =
         'SN_2002ap (SN/GRB?) optical spectrographic observations'
-      expect(parseEventFromSubject(snSubjectWithUnderscore)).toBe(snEvent)
+      expect(parseEventFromSubject(snSubjectWithUnderscore)).toBe(
+        snEventDoubleLetters
+      )
     })
 
     test('handles SN event names with an underscore in misc positions', () => {
       const snSubjectWithUnderscore =
-        '(SN/GRB?): SN_2002ap optical spectrographic observations'
+        '(SN/GRB?): SN_2002A optical spectrographic observations'
       expect(parseEventFromSubject(snSubjectWithUnderscore)).toBe(snEvent)
+    })
+
+    test('handles SN event names with an underscore and double letters in misc positions', () => {
+      const snSubjectWithUnderscore =
+        '(SN/GRB?): SN_2002ap optical spectrographic observations'
+      expect(parseEventFromSubject(snSubjectWithUnderscore)).toBe(
+        snEventDoubleLetters
+      )
     })
 
     test('handles SN event name with a hyphen', () => {
       const snSubjectWithHyphen =
         'SN-2002ap (SN/GRB?) optical spectrographic observations'
-      expect(parseEventFromSubject(snSubjectWithHyphen)).toBe(snEvent)
+      expect(parseEventFromSubject(snSubjectWithHyphen)).toBe(
+        snEventDoubleLetters
+      )
     })
 
     test('handles SN event name with a hyphen in misc positions', () => {
       const snSubjectWithHyphen =
-        '(SN/GRB?): SN-2002ap optical spectrographic observations'
+        '(SN/GRB?): SN-2002A optical spectrographic observations'
       expect(parseEventFromSubject(snSubjectWithHyphen)).toBe(snEvent)
+    })
+
+    test('handles SN event name with a hyphen and double letters in misc positions', () => {
+      const snSubjectWithHyphen =
+        '(SN/GRB?): SN-2002ap optical spectrographic observations'
+      expect(parseEventFromSubject(snSubjectWithHyphen)).toBe(
+        snEventDoubleLetters
+      )
     })
   })
 
@@ -1141,14 +1188,14 @@ describe('parseEventFromSubject', () => {
       expect(parseEventFromSubject(atSubject)).toBe(atEvent)
     })
 
-    test('handles AT event names with one letter', () => {
-      const atSubject = 'AT 2023lc: VLA radio detection'
-      expect(parseEventFromSubject(atSubject)).toBe('AT 2023lc')
+    test('handles AT event names with two letters', () => {
+      const atSubject = 'AT 2023lcd: VLA radio detection'
+      expect(parseEventFromSubject(atSubject)).toBe('AT 2023lcd')
     })
 
-    test('handles AT event names with four letters', () => {
-      const atSubject = 'AT 2023lcrsj: VLA radio detection'
-      expect(parseEventFromSubject(atSubject)).toBe('AT 2023lcrsj')
+    test('handles AT event names with five letters', () => {
+      const atSubject = 'AT 2023lcrsjq: VLA radio detection'
+      expect(parseEventFromSubject(atSubject)).toBe('AT 2023lcrsjq')
     })
 
     test('handles AT event names with incorrect casing', () => {

--- a/__tests__/circulars.ts
+++ b/__tests__/circulars.ts
@@ -69,12 +69,15 @@ describe('parseEventFromSubject', () => {
   const grbEventLetterless = 'GRB 230228'
   const hawcEvent = 'HAWC-221123A'
   const iceEvent = 'IceCube-221223A'
+  const iceCasEvent = 'IceCube-Cascade 221223A'
   const lvkEvent = 'LIGO/Virgo S200224ca'
   const sgrEvent = 'SGR 1935+2154'
   const ztfEvent = 'ZTF23aabmzlp'
   const epEvent = 'EP241119a'
   const frbEvent = 'FRB 20250206A'
   const svomEvent = 'sb25021804'
+  const gwEvent = 'GW250206'
+  const snEvent = 'SN2002ap'
 
   test('handles nonsense subject cases', () => {
     expect(parseEventFromSubject('zawxdrcftvgbhnjm')).toBe(undefined)
@@ -298,9 +301,80 @@ describe('parseEventFromSubject', () => {
     })
   })
 
+  describe('IceCube-Cascade', () => {
+    test('handles IceCube-Cascade event names', () => {
+      const iceCascadeSubject =
+        'IceCube-Cascade 221223A - IceCube observation of a high-energy neutrino candidate track-like event'
+      expect(parseEventFromSubject(iceCascadeSubject)).toBe(iceCasEvent)
+    })
+
+    test('handles IceCube-Cascade event names in misc positions', () => {
+      const iceCascadeSubjectWithSpace =
+        'IceCube observation of IceCube-Cascade 221223A a high-energy neutrino candidate track-like event'
+      expect(parseEventFromSubject(iceCascadeSubjectWithSpace)).toBe(
+        iceCasEvent
+      )
+    })
+
+    test('handles IceCube-Cascade event names without space', () => {
+      const iceCascadeSubjectWithNoSpace =
+        'IceCube-Cascade221223A - IceCube observation of a high-energy neutrino candidate track-like event'
+      expect(parseEventFromSubject(iceCascadeSubjectWithNoSpace)).toBe(
+        iceCasEvent
+      )
+    })
+
+    test('handles IceCube-Cascade event names without spaces in misc positions', () => {
+      const iceCascadeSubjectWithSpace =
+        'IceCube observation IceCubeCascade221223A of a high-energy neutrino candidate track-like event'
+      expect(parseEventFromSubject(iceCascadeSubjectWithSpace)).toBe(
+        iceCasEvent
+      )
+    })
+
+    test('handles IceCube event name with an underscore', () => {
+      const iceCascadeSubjectWithUnderscore =
+        'IceCube_Cascade_221223A - IceCube observation of a high-energy neutrino candidate track-like event'
+      expect(parseEventFromSubject(iceCascadeSubjectWithUnderscore)).toBe(
+        iceCasEvent
+      )
+    })
+
+    test('handles IceCube event names with an underscore in misc positions', () => {
+      const iceCascadeSubjectWithUnderscore =
+        'IceCube observation of a high-energy neutrino IceCube_Cascade_221223A candidate track-like event'
+      expect(parseEventFromSubject(iceCascadeSubjectWithUnderscore)).toBe(
+        iceCasEvent
+      )
+    })
+
+    test('handles IceCube event name with a hyphen', () => {
+      const iceSubjectWithHyphen =
+        'IceCube-Cascade-221223A - IceCube observation of a high-energy neutrino candidate track-like event'
+      expect(parseEventFromSubject(iceSubjectWithHyphen)).toBe(iceCasEvent)
+    })
+
+    test('handles IceCube event name with a hyphen in misc positions', () => {
+      const iceSubjectWithHyphen =
+        'IceCube observation of a high-energy IceCube-Cascade-221223A neutrino candidate track-like event'
+      expect(parseEventFromSubject(iceSubjectWithHyphen)).toBe(iceCasEvent)
+    })
+
+    test('handles IceCube event name with lower case', () => {
+      const iceCasLower =
+        'IceCube observation of a high-energy icecube-cascade-221223a neutrino candidate track-like event'
+      expect(parseEventFromSubject(iceCasLower)).toBe(iceCasEvent)
+    })
+  })
+
   describe('EP', () => {
     test('handles EP event names with space', () => {
       const epSubject = 'EP 241119a: Global MASTER-Net observations report'
+      expect(parseEventFromSubject(epSubject)).toBe(epEvent)
+    })
+
+    test('handles EP event names with incorrect casing', () => {
+      const epSubject = 'ep 241119A: Global MASTER-Net observations report'
       expect(parseEventFromSubject(epSubject)).toBe(epEvent)
     })
 
@@ -735,6 +809,24 @@ describe('parseEventFromSubject', () => {
       expect(parseEventFromSubject(frbSubject)).toBe(frbEvent)
     })
 
+    test('handles FRB event names with incorrect casing', () => {
+      const frbSubject =
+        'frb 20250206a: MASTER observations and possible mother galaxy'
+      expect(parseEventFromSubject(frbSubject)).toBe(frbEvent)
+    })
+
+    test('handles outdated FRB event naming convention without letter', () => {
+      const frbSubject =
+        'frb 250206: MASTER observations and possible mother galaxy'
+      expect(parseEventFromSubject(frbSubject)).toBe('FRB 250206')
+    })
+
+    test('handles outdated FRB event naming convention with letter', () => {
+      const frbSubject =
+        'frb 250206a: MASTER observations and possible mother galaxy'
+      expect(parseEventFromSubject(frbSubject)).toBe('FRB 250206A')
+    })
+
     test('handles FRB event names in misc positions', () => {
       const frbSubjectWithSpace =
         'MASTER observations:FRB 20250206A and possible mother galaxy'
@@ -825,6 +917,112 @@ describe('parseEventFromSubject', () => {
       const svomSubjectWithHyphen =
         'SVOM detection: SVOM/sb-25021804 a long X-ray transient'
       expect(parseEventFromSubject(svomSubjectWithHyphen)).toBe(svomEvent)
+    })
+  })
+
+  describe('GW', () => {
+    test('handles GW event names', () => {
+      const gwSubject = 'GW250206: Swift UVOT follow-up'
+      expect(parseEventFromSubject(gwSubject)).toBe(gwEvent)
+    })
+
+    test('handles GW event names with incorrect casing', () => {
+      const gwSubject = 'gw250206: Swift UVOT follow-up'
+      expect(parseEventFromSubject(gwSubject)).toBe(gwEvent)
+    })
+
+    test('handles GW event names in misc positions', () => {
+      const gwSubjectWithSpace = 'Swift UVOT:GW250206 follow-up'
+      expect(parseEventFromSubject(gwSubjectWithSpace)).toBe(gwEvent)
+    })
+
+    test('handles GW event names without space', () => {
+      const gwSubjectWithNoSpace = 'GW250206: Swift UVOT follow-up'
+      expect(parseEventFromSubject(gwSubjectWithNoSpace)).toBe(gwEvent)
+    })
+
+    test('handles GW event names without spaces in misc positions', () => {
+      const gwSubjectWithSpace = 'Swift UVOT: GW250206 follow-up'
+      expect(parseEventFromSubject(gwSubjectWithSpace)).toBe(gwEvent)
+    })
+
+    test('handles GW event name with an underscore', () => {
+      const gwSubjectWithUnderscore = 'GW_250206: Swift UVOT follow-up'
+      expect(parseEventFromSubject(gwSubjectWithUnderscore)).toBe(gwEvent)
+    })
+
+    test('handles GW event names with an underscore in misc positions', () => {
+      const gwSubjectWithUnderscore = 'Swift UVOT GW_250206: follow-up'
+      expect(parseEventFromSubject(gwSubjectWithUnderscore)).toBe(gwEvent)
+    })
+
+    test('handles GW event name with a hyphen', () => {
+      const gwSubjectWithHyphen = 'GW-250206: Swift UVOT follow-up'
+      expect(parseEventFromSubject(gwSubjectWithHyphen)).toBe(gwEvent)
+    })
+
+    test('handles GW event name with a hyphen in misc positions', () => {
+      const gwSubjectWithHyphen = 'Swift UVOT: GW-250206 follow-up'
+      expect(parseEventFromSubject(gwSubjectWithHyphen)).toBe(gwEvent)
+    })
+  })
+
+  describe('SN', () => {
+    test('handles SN event names', () => {
+      const snSubject = 'SN2002ap (SN/GRB?) optical spectrographic observations'
+      expect(parseEventFromSubject(snSubject)).toBe(snEvent)
+    })
+
+    test('handles SN event names with one letter', () => {
+      const snSubject = 'SN2002a (SN/GRB?) optical spectrographic observations'
+      expect(parseEventFromSubject(snSubject)).toBe('SN2002a')
+    })
+
+    test('handles SN event names with incorrect casing', () => {
+      const snSubject = 'sn2002AP (SN/GRB?) optical spectrographic observations'
+      expect(parseEventFromSubject(snSubject)).toBe(snEvent)
+    })
+
+    test('handles SN event names in misc positions', () => {
+      const snSubjectWithSpace =
+        '(SN/GRB?): SN 2002ap  optical spectrographic observations'
+      expect(parseEventFromSubject(snSubjectWithSpace)).toBe(snEvent)
+    })
+
+    test('handles SN event names with space', () => {
+      const snSubjectWithNoSpace =
+        'SN 2002ap (SN/GRB?) optical spectrographic observations'
+      expect(parseEventFromSubject(snSubjectWithNoSpace)).toBe(snEvent)
+    })
+
+    test('handles SN event names with spaces in misc positions', () => {
+      const snSubjectWithSpace =
+        '(SN/GRB?): SN 2002ap  optical spectrographic observations'
+      expect(parseEventFromSubject(snSubjectWithSpace)).toBe(snEvent)
+    })
+
+    test('handles SN event name with an underscore', () => {
+      const snSubjectWithUnderscore =
+        'SN_2002ap (SN/GRB?) optical spectrographic observations'
+      expect(parseEventFromSubject(snSubjectWithUnderscore)).toBe(snEvent)
+    })
+
+    test('handles SN event names with an underscore in misc positions', () => {
+      const snSubjectWithUnderscore =
+        '(SN/GRB?): SN_2002ap optical spectrographic observations'
+      expect(parseEventFromSubject(snSubjectWithUnderscore)).toBe(snEvent)
+    })
+
+    test('handles SN event name with a hyphen', () => {
+      const snSubjectWithHyphen =
+        'SN-2002ap (SN/GRB?) optical spectrographic observations'
+      expect(parseEventFromSubject(snSubjectWithHyphen)).toBe(snEvent)
+    })
+
+    test('handles SN event name with a hyphen in misc positions', () => {
+      const snSubjectWithHyphen =
+        '(SN/GRB?): SN-2002ap optical spectrographic observations'
+      expect(parseEventFromSubject(snSubjectWithHyphen)).toBe(snEvent)
     })
   })
 })

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -81,7 +81,10 @@ const subjectMatchers: SubjectMatcher[] = [
     ([, id]) => `Baksan Neutrino Observatory Alert ${id}`,
   ],
   [/EP[.\s_-]*(\d{6}[a-z])/i, ([, id]) => `EP${id.toLowerCase()}`],
-  [/SN[.\s_-]*(\d{4}[a-zA-Z]*)/i, ([, id]) => `SN${id.toLowerCase()}`],
+  [
+    /SN[.\s_-]*(\d{4}(?:[a-z]{2,}|[A-Z]))/i,
+    ([, id]) => `SN ${id.length == 5 ? id.toUpperCase() : id.toLowerCase()}`,
+  ],
   [/GW[.\s_-]*(\d{6})/i, ([, id]) => `GW${id}`],
   [/FRB[.\s_-]*(\d{8}[a-zA-Z])/i, ([, id]) => `FRB ${id}`.toUpperCase()],
   [/FRB[.\s_-]*(\d{6}[a-zA-Z]?)/i, ([, id]) => `FRB ${id}`.toUpperCase()],

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -86,6 +86,8 @@ const subjectMatchers: SubjectMatcher[] = [
   [/FRB[.\s_-]*(\d{8}[a-zA-Z])/i, ([, id]) => `FRB ${id}`.toUpperCase()],
   [/FRB[.\s_-]*(\d{6}[a-zA-Z]?)/i, ([, id]) => `FRB ${id}`.toUpperCase()],
   [/sb[.\s_-]*(\d{8})/i, ([, id]) => `sb${id}`],
+  [/XRF[.\s_-]*(\d{6}(?:[A-Za-z])?)/i, ([, id]) => `XRF ${id.toUpperCase()}`],
+  [/AT[.\s_-]*(\d{4}[a-zA-Z]*)/i, ([, id]) => `AT ${id.toLowerCase()}`],
 ]
 
 /** Format a Circular as plain text. */

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -82,7 +82,7 @@ const subjectMatchers: SubjectMatcher[] = [
   ],
   [/EP[.\s_-]*(\d{6}[a-z])/i, ([, id]) => `EP${id.toLowerCase()}`],
   [
-    /SN[.\s_-]*(\d{4}(?:[a-z]{2,}|[A-Z]))/i,
+    /SN[.\s_-]*(\d{4}[a-zA-Z]*)/i,
     ([, id]) => `SN ${id.length == 5 ? id.toUpperCase() : id.toLowerCase()}`,
   ],
   [/GW[.\s_-]*(\d{6})/i, ([, id]) => `GW${id}`],

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -49,6 +49,12 @@ export interface CircularChangeRequestKeys {
 
 type SubjectMatcher = [RegExp, (match: RegExpMatchArray) => string]
 
+// CAUTION:
+// If you use a wildcard or optional letter match, you MUST use [a-zA-Z]
+// even though we are using the case insensitive /i flag.
+// With wildcard and optional matchers, it will not be able to determine
+// the best match so it will default to the laziest match which will cut the
+// letters not matching the specified case off.
 const subjectMatchers: SubjectMatcher[] = [
   [
     /GRB[.\s_-]*(\d{6}(?:[a-z]|\.[0-9]+)?)/i,

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -60,6 +60,10 @@ const subjectMatchers: SubjectMatcher[] = [
     ([, id]) => `SGR Swift ${id.toUpperCase()}`,
   ],
   [/IceCube[.\s_-]*(\d{6}[a-z])/i, ([, id]) => `IceCube-${id.toUpperCase()}`],
+  [
+    /IceCube[.\s_-]*Cascade[.\s_-]*(\d{6}[a-z])/i,
+    ([, id]) => `IceCube-Cascade ${id.toUpperCase()}`,
+  ],
   [/ZTF[.\s_-]*(\d{2}[a-z]*)/i, ([, id]) => `ZTF${id.toLowerCase()}`],
   [/HAWC[.\s_-]*(\d{6}A)/i, ([, id]) => `HAWC-${id.toUpperCase()}`],
   [
@@ -76,8 +80,11 @@ const subjectMatchers: SubjectMatcher[] = [
     /Baksan\sNeutrino\sObservatory\sAlert[.\s_-]*(\d{6}.\d{2})/i,
     ([, id]) => `Baksan Neutrino Observatory Alert ${id}`,
   ],
-  [/EP[.\s_-]*(\d{6}[a-z])/i, ([, id]) => `EP${id}`],
-  [/FRB[.\s_-]*(\d{8}[a-z])/i, ([, id]) => `FRB ${id}`.toUpperCase()],
+  [/EP[.\s_-]*(\d{6}[a-z])/i, ([, id]) => `EP${id.toLowerCase()}`],
+  [/SN[.\s_-]*(\d{4}[a-zA-Z]*)/i, ([, id]) => `SN${id.toLowerCase()}`],
+  [/GW[.\s_-]*(\d{6})/i, ([, id]) => `GW${id}`],
+  [/FRB[.\s_-]*(\d{8}[a-zA-Z])/i, ([, id]) => `FRB ${id}`.toUpperCase()],
+  [/FRB[.\s_-]*(\d{6}[a-zA-Z]?)/i, ([, id]) => `FRB ${id}`.toUpperCase()],
   [/sb[.\s_-]*(\d{8})/i, ([, id]) => `sb${id}`],
 ]
 

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -49,12 +49,6 @@ export interface CircularChangeRequestKeys {
 
 type SubjectMatcher = [RegExp, (match: RegExpMatchArray) => string]
 
-// CAUTION:
-// If you use a wildcard or optional letter match, you MUST use [a-zA-Z]
-// even though we are using the case insensitive /i flag.
-// With wildcard and optional matchers, it will not be able to determine
-// the best match so it will default to the laziest match which will cut the
-// letters not matching the specified case off.
 const subjectMatchers: SubjectMatcher[] = [
   [
     /GRB[.\s_-]*(\d{6}(?:[a-z]|\.[0-9]+)?)/i,

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -82,15 +82,17 @@ const subjectMatchers: SubjectMatcher[] = [
   ],
   [/EP[.\s_-]*(\d{6}[a-z])/i, ([, id]) => `EP${id.toLowerCase()}`],
   [
-    /SN[.\s_-]*(\d{4}[a-zA-Z]*)/i,
+    /SN[.\s_-]*(\d{4}[a-z]*)/i,
     ([, id]) => `SN ${id.length == 5 ? id.toUpperCase() : id.toLowerCase()}`,
   ],
   [/GW[.\s_-]*(\d{6})/i, ([, id]) => `GW${id}`],
-  [/FRB[.\s_-]*(\d{8}[a-zA-Z])/i, ([, id]) => `FRB ${id}`.toUpperCase()],
-  [/FRB[.\s_-]*(\d{6}[a-zA-Z]?)/i, ([, id]) => `FRB ${id}`.toUpperCase()],
+  [
+    /FRB[.\s_-]*(\d{8}[a-z]|\d{6}[a-z]?)/i,
+    ([, id]) => `FRB ${id}`.toUpperCase(),
+  ],
   [/sb[.\s_-]*(\d{8})/i, ([, id]) => `sb${id}`],
-  [/XRF[.\s_-]*(\d{6}(?:[A-Za-z])?)/i, ([, id]) => `XRF ${id.toUpperCase()}`],
-  [/AT[.\s_-]*(\d{4}[a-zA-Z]*)/i, ([, id]) => `AT ${id.toLowerCase()}`],
+  [/XRF[.\s_-]*(\d{6}[a-z]?)/i, ([, id]) => `XRF ${id.toUpperCase()}`],
+  [/AT[.\s_-]*(\d{4}[a-z]*)/i, ([, id]) => `AT${id.toLowerCase()}`],
 ]
 
 /** Format a Circular as plain text. */


### PR DESCRIPTION
# Description
Some subject matchers were missing and others were not normalized. This change brings the subject matchers in line with what is expected.

### Subject matchers added:
'GW250206'
'SN2002ap'
'XRF 050509C'
'AT2023lcr'
'IceCube-Cascade 221223A'

### Subject matchers normalized:
'EP241119a'
'FRB 20250206A'
# Related Issue(s)
Resolves #2997

# Testing
Included unit tests to cover all changes
