### PR TITLE
Circulars: Remove references to Lucene where not appropriate

### DIFF
--- a/app/routes/circulars._archive._index/LuceneMenu.tsx
+++ b/app/routes/circulars._archive._index/LuceneMenu.tsx
@@ -22,7 +22,7 @@ export function LuceneAccordion() {
         </Link>
         {'. '}
       </p>
-      <h4>Lucene Examples (click to copy):</h4>
+      <h4>Advanced Search Examples (click to copy):</h4>
       <div>
         <Highlight
           language="sh"

--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -54,7 +54,7 @@ Searches can be performed by specifying the field and search term. The syntax fo
 
 The following fields are supported: `subject`, `body`, and `submitter`.
 
-By default, a query that does not contain lucene syntax will attempt to match the query against all 3 fields. For example, the query `Swift` will match any circular that contains the word 'Swift' in the subject, body, or submitter fields, whereas the query `subject:"Swift"` will only match circulars where the subject contains the word 'Swift'.
+By default, a query that does not contain the advanced search syntax will attempt to match the query against all 3 fields. For example, the query `Swift` will match any circular that contains the word 'Swift' in the subject, body, or submitter fields, whereas the query `subject:"Swift"` will only match circulars where the subject contains the word 'Swift'.
 
 ### Compound Queries
 
@@ -68,11 +68,11 @@ By default, the AND operator is used if no operator is specified. For example, `
 
 It is also possible to combine these operator keywords to form more complex queries. For example, `subject:"Swift" AND (body:"GRB" OR body:"Gamma-ray burst")` will match circulars where the subject contains 'Swift' and the body contains either 'GRB' or 'Gamma-ray burst'.
 
-Using one of these operators without an additional field query will result in an error. For example, `subject:"Swift" AND` will raise an error. For queries that do not adhere to the Lucene query syntax, GCN will fall back onto a more basic search method that matches the query against all fields with a warning message.
+Using one of these operators without an additional field query will result in an error. For example, `subject:"Swift" AND` will raise an error. For queries that do not adhere to the advanced search syntax, GCN will fall back onto a more basic search method that matches the query against all fields with a warning message.
 
 ### Reserved Characters
 
-there are a number of reserved characters that have special meaning in the Lucene query syntax. These characters must be escaped using a backslash (`\`) to be treated as a literal character. Including these characters in a query without escaping them will raise an error.The reserved characters are: `+`, `-`, `=`, `&&`, `||`, `>`, `<`, `!`, `(`, `)`, `{`, `}`, `[`, `]`, `^`, `"`, `~`, `*`, `?`, `:`, `/`, `\`.
+There are a number of reserved characters that have special meaning in the advanced search syntax. These characters must be escaped using a backslash (`\`) to be treated as a literal character. Including these characters in a query without escaping them will raise an error.The reserved characters are: `+`, `-`, `=`, `&&`, `||`, `>`, `<`, `!`, `(`, `)`, `{`, `}`, `[`, `]`, `^`, `"`, `~`, `*`, `?`, `:`, `/`, `\`.
 
 ### Examples
 


### PR DESCRIPTION


<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
Switches language in documentation to refer to search syntax as advanced search syntax rather than Lucene for consistency. We retain one reference to Lucene syntax when linking to the official Lucene documentation

# Related Issue(s)
#2288 

# Testing
1. Navigate to Circulars Archive
2. There should only be references to advanced search rather than lucene syntax
3. The same should also be true in the archive docs, save for the link to the official Lucene documentation
