### PR TITLE
update circular api endpoint creates new version

### DIFF
--- a/app/routes/api.circulars.ts
+++ b/app/routes/api.circulars.ts
@@ -196,7 +196,7 @@ export async function action({ request }: ActionFunctionArgs) {
       break
 
     default:
-      throw new Response(null, { status: 405 })
+      throw new Error('this code should not be reached')
   }
 
   const [{ existingIdp, ...attrs }, groups] = await Promise.all([

--- a/app/routes/api.circulars.ts
+++ b/app/routes/api.circulars.ts
@@ -172,7 +172,7 @@ async function getUserAttributes(Username: string) {
  */
 export async function action({ request }: ActionFunctionArgs) {
   if (!['PUT', 'POST'].includes(request.method))
-    throw new Response(null, { status: 405 })
+    throw new Response('unsupported method', { status: 405 })
 
   const bearer = getBearer(request)
   if (!bearer) throw new Response('Bearer missing', { status: 403 })

--- a/app/routes/api.circulars.ts
+++ b/app/routes/api.circulars.ts
@@ -172,7 +172,7 @@ async function getUserAttributes(Username: string) {
  */
 export async function action({ request }: ActionFunctionArgs) {
   if (!['PUT', 'POST'].includes(request.method))
-    throw new Response('unsupported method', { status: 405 })
+    throw new Response(null, { status: 405 })
 
   const bearer = getBearer(request)
   if (!bearer) throw new Response('Bearer missing', { status: 403 })
@@ -242,6 +242,6 @@ export async function action({ request }: ActionFunctionArgs) {
       return await putVersion(circularVersion, user)
 
     default:
-      throw new Response('unknown intent', { status: 400 })
+      throw new Error('this code should not be reached')
   }
 }

--- a/app/routes/api.circulars.ts
+++ b/app/routes/api.circulars.ts
@@ -15,7 +15,13 @@ import invariant from 'tiny-invariant'
 
 import { getOpenIDClient } from './_auth/auth.server'
 import { type User, parseGroups, parseIdp } from './_auth/user.server'
-import { put, submitterGroup } from './circulars/circulars.server'
+import type { Circular } from './circulars/circulars.lib'
+import {
+  moderatorGroup,
+  put,
+  putVersion,
+  submitterGroup,
+} from './circulars/circulars.server'
 import {
   cognito,
   extractAttribute,
@@ -101,8 +107,6 @@ async function getUserAttributes(Username: string) {
 }
 
 /**
- * GCN Circulars submission by third parties on behalf of users via an API.
- *
  * Here's how this works.
  *
  * 1. We configure a Cognito user pool [app client] for the third party.
@@ -127,7 +131,7 @@ async function getUserAttributes(Username: string) {
  *    application does the following:
  *
  *    a. Do the [authorization code flow] to sign the user in with GCN's IdP.
- *       When requesting the authorization endpoint, be sure to reuqest
+ *       When requesting the authorization endpoint, be sure to request
  *       scope="openid profile gcn.nasa.gov/circular-submitter". (Note: the
  *       name of the last scope may change in the future.)
  *
@@ -141,20 +145,33 @@ async function getUserAttributes(Username: string) {
  *
  *    c. Save the resulting refresh token and auth token on the server side in
  *       a record associated with the user's account.
- *
- *    d. To post a GCN Circular on behalf of the user, make a POST request to
- *       https://<stage>.gcn.nasa.gov/api/circulars. Provide the access token
- *       in the Authorization: Bearer header. The request body should be a JSON
- *       document of the form '{"subject": "...", "body": "..."}'.
- *
  *    e. The application is responsible for renewing the access token as needed
  *       using the refreshing token.
  *
  * [app client]: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-client-apps.html
  * [authorization code flow]: https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow
+ *
+ * METHOD: POST
+ * GCN Circulars submission by third parties on behalf of users via an API.
+ * To post a GCN Circular on behalf of the user, make a POST request to
+ *       https://<stage>.gcn.nasa.gov/api/circulars. Provide the access token
+ *       in the Authorization: Bearer header. The request body should be a JSON
+ *       document of the form '{"subject": "...", "body": "..."}'.
+ *
+ * METHOD: PUT
+ * GCN Circulars edit by moderators via the API.
+ * To edit a GCN Circular as a moderator, make a PUT request to
+ *       https://<stage>.gcn.nasa.gov/api/circulars. Provide the access token
+ *       in the Authorization: Bearer header. The request body should be a JSON
+ *       document of the form '{"subject": "...", "body": "..."}'.
+ * Edits may be made to the subject, body, or eventId.
+ * The subject and body are required, even if no changes are made.
+ * EventId is optional.
+ * A new circular version will be created.
  */
 export async function action({ request }: ActionFunctionArgs) {
-  if (request.method !== 'POST') throw new Response(null, { status: 405 })
+  if (!['PUT', 'POST'].includes(request.method))
+    throw new Response(null, { status: 405 })
 
   const bearer = getBearer(request)
   if (!bearer) throw new Response('Bearer missing', { status: 403 })
@@ -166,8 +183,15 @@ export async function action({ request }: ActionFunctionArgs) {
   } = await parseAccessToken(bearer)
 
   // Make sure that the access token contains the required scope for this API
-  if (!scope.split(' ').includes(submitterGroup))
-    throw new Response('Invalid scope', { status: 403 })
+  switch (request.method) {
+    case 'POST':
+      if (!scope.split(' ').includes(submitterGroup))
+        throw new Response('Invalid scope', { status: 403 })
+
+    case 'PUT':
+      if (!scope.split(' ').includes(moderatorGroup))
+        throw new Response('Invalid scope', { status: 403 })
+  }
 
   const [{ existingIdp, ...attrs }, groups] = await Promise.all([
     getUserAttributes(cognitoUserName),
@@ -182,7 +206,7 @@ export async function action({ request }: ActionFunctionArgs) {
     ...attrs,
   }
 
-  const { subject, body, format } = await request.json()
+  const { subject, body, format, eventId, circularId } = await request.json()
   if (
     !(
       typeof subject === 'string' &&
@@ -192,12 +216,26 @@ export async function action({ request }: ActionFunctionArgs) {
   )
     throw new Response(null, { status: 400 })
 
-  const circular = {
-    submittedHow: 'api',
-    subject,
-    body,
-    ...(format ? { format } : {}),
-  } as const
+  switch (request.method) {
+    case 'POST':
+      const circular = {
+        submittedHow: 'api',
+        subject,
+        body,
+        eventId,
+        ...(format ? { format } : {}),
+      } as const
 
-  return await put(circular, user)
+      return await put(circular, user)
+
+    case 'PUT':
+      const circularVersion = {
+        circularId,
+        subject,
+        body,
+        eventId,
+      } as Circular
+
+      return await putVersion(circularVersion, user)
+  }
 }

--- a/app/routes/api.circulars.ts
+++ b/app/routes/api.circulars.ts
@@ -188,10 +188,15 @@ export async function action({ request }: ActionFunctionArgs) {
     case 'POST':
       if (!scope.split(' ').includes(submitterGroup))
         throw new Response('Invalid scope', { status: 403 })
+      break
 
     case 'PUT':
       if (!scope.split(' ').includes(moderatorGroup))
         throw new Response('Invalid scope', { status: 403 })
+      break
+
+    default:
+      throw new Response(null, { status: 405 })
   }
 
   const [{ existingIdp, ...attrs }, groups] = await Promise.all([

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -615,7 +615,7 @@ export async function getChangeRequest(
   return changeRequest
 }
 
-function validateCircular({
+export function validateCircular({
   body,
   subject,
   format,


### PR DESCRIPTION
# Description
This adds a PUT path to the circulars api endpoint. 
It requires moderator permissions.
The subject, body, and/or eventId can be edited.
It creates a new version of the circular.

# Related Issue(s)
Resolves #3060 

# Testing
I tested locally by commenting out the cognito portion of the api endpoint and putting in a hard coded user.
I tested:
- being able to edit with an existing eventId to change it.
- editing a circular without an eventId to add one
- editing a circular without an eventId to change the subject and body without any addition of an eventId.
- POSTing a new circular without an eventId
- POSTing a new circular with an eventId