### PR TITLE
removing page return value from synonym search as it messes up pagina…

### DIFF
--- a/app/routes/synonyms/synonyms.server.ts
+++ b/app/routes/synonyms/synonyms.server.ts
@@ -53,7 +53,6 @@ export async function searchSynonymsByEventId({
   items: SynonymGroup[]
   totalItems: number
   totalPages: number
-  page: number
   queryFallback: boolean
 }> {
   const client = await getSearchClient()
@@ -128,7 +127,6 @@ export async function searchSynonymsByEventId({
     items: results,
     totalItems,
     totalPages,
-    page,
     queryFallback: false,
   }
 }


### PR DESCRIPTION
…tion

pagination for the group view was very wonky. 

<img width="901" alt="Screenshot 2025-05-27 at 2 23 15 PM" src="https://github.com/user-attachments/assets/9083b3e1-fc7e-44b2-9f5d-1da328fb620d" />

I discovered that the event search is returning a page variable. This is not how the regular circulars search works.

<img width="738" alt="page_overwrites" src="https://github.com/user-attachments/assets/6af58e19-e68a-4328-b661-7f8358b0d418" />

The page value that was returned from that search function was overwriting the page value that existed already within that function (which was correct).

Removing the page return fixed pagination.

<img width="671" alt="Screenshot 2025-05-27 at 2 26 06 PM" src="https://github.com/user-attachments/assets/2f15082e-c586-4c70-9197-86f5fb6cefe7" />

Resolves #3125 