### PR TITLE
when a blank value is passed in, it should be undefined or it breaks …

### DIFF
--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -127,7 +127,6 @@ export async function action({ request }: ActionFunctionArgs) {
         submitter = getFormDataString(data, 'submitter')
         if (!submitter) throw new Response(null, { status: 400 })
       }
-      const eventId = getFormDataString(data, 'eventId')
 
       if (!createdOnDate || !createdOn)
         throw new Response(null, { status: 400 })

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -570,7 +570,7 @@ export async function approveChangeRequest(
     format: changeRequest.format,
     submitter: changeRequest.submitter,
     createdOn: changeRequest.createdOn ?? circular.createdOn, // This is temporary while there are some requests without this property
-    eventId: changeRequest.eventId,
+    eventId: changeRequest.eventId || undefined,
   }
 
   const promises = [

--- a/seed.json
+++ b/seed.json
@@ -5635,6 +5635,15 @@
       "requestorEmail": "example@example.com",
       "subject": "Optical Observations for GRB 971227",
       "submitter": "Example User at Example <example@example.com>"
+    },
+    {
+      "subject": "AMON Coincidence Alert from the sub-threshold IceCube-HAWC search NuEm-230927A Original",
+      "circularId": 34776,
+      "submitter": "Hugo Ayala at Pennsylvania State University <hgayala@psu.edu>",
+      "body": "The AMON,  IceCube, and HAWC collaborations report:\n\nThe AMON NuEm stream channel found a coincidence alert from the\nIceCube online neutrino selection + HAWC daily monitoring analysis.\nThe analysis looks for IceCube neutrino events -mostly atmospheric\nin origin- around the position and transit time of a HAWC cluster of\nlikely gamma rays, as identified in the integrated observations from\na single transit, in this case having a duration of 6.06 hours.\n\nThe HAWC transit interval starts from 2023/09/27 01:10:10 UT  to\n2023/09/27 07:20:17 UT\n(End of the HAWC transit time)\n\nThe location of the coincidence is reported as\nRA (J2000): 331.92 deg\nDec (J2000): 12.44 deg\nLocation uncertainty (50% containment): 0.13 deg (statistical only).\nLocation uncertainty (90% containment): 0.24 deg (statistical only).\n\nThe false alarm rate (FAR) of this coincidence is 3.9 per year.\nWe encourage follow-up observations of the alert region contingent on\nthe availability of resources and interest, given the quoted FAR.\n\nAMON seeks to perform a real-time correlation analysis of the\nhigh-energy signals across all known astronomical messengers. More\ninformation about AMON can be found in https://www.amon.psu.edu/\nInformation on the IceCube collaboration: http://icecube.wisc.edu/\nInformation on the HAWC collaboration: https://www.hawc-observatory.org\n",
+      "requestorEmail": "example@example.com",
+      "requestorSub": "12345678-abcd-1234-abcd-1234abcd1234",
+      "eventId": ""
     }
   ]
 }


### PR DESCRIPTION
…dynamodb

# Description
If someone creates a correction, it grabs the eventId from the form data. But if the eventId is blank, the form data sends an empty string. This was corrected for edits, but in corrections the original line was left which overwrote the correction. 

This creates a correction request with a blank string for eventId.

This branch does 2 things. it corrects the original issue so that the blank string is undefined instead of blank. It also does a second check when the approval is trying to create the new version. this is so that if any more correction requests exist with the issue, they will not fail.

I added a seed change that adds an approval that would trigger the issue.

# Testing
This was tested locally.
1. First I added the seed file change. I was able to trigger the error:
```
ValidationException: One or more parameter values are not valid. A value specified for a secondary index key is not supported. The AttributeValue for a key attribute cannot contain an empty string value. IndexName: circularsByEventId, IndexKey: eventId
```
2. I then logged where eventId was being pulled from the correction data when making a correction request. I could see that it was indeed an empty string. 
3. I then added in the change for the approval (so it checks to see if the change request has an empty string)
4. I was able to successfully approve the added seed case
5. I then removed the line that was overwriting the eventId when the approval request was created
6. I then tested creating an approval request and confirmed that the value is now undefined if the string is empty.

