### PR TITLE
don't delete change request or send email on correction failure

### DIFF
--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -573,7 +573,7 @@ export async function approveChangeRequest(
     eventId: changeRequest.eventId,
   }
 
-  const newVersionNumber = await autoincrementVersion.put(newVersion)
+  await autoincrementVersion.put(newVersion)
   const promises = [
     deleteChangeRequestRaw(circularId, requestorSub),
     sendEmail({
@@ -591,9 +591,7 @@ export async function approveChangeRequest(
   if (changeRequest.zendeskTicketId)
     promises.push(closeZendeskTicket(changeRequest.zendeskTicketId))
 
-  if (newVersionNumber) {
-    await Promise.all(promises)
-  }
+  await Promise.all(promises)
 }
 
 /**


### PR DESCRIPTION
# Description
We don't want to delete the change request or send any emails or kafka messages if the correction fails. When the promise to update is in the array of promises and gets called with promise.all, it fails after the change request is deleted and emails are sent. This means that no correction has persisted, but the request is gone.

What this branch does is calls the put alone. It then only calls promise.all if that put has succeeded. This means that if there is a failure to create the update, nothing will be sent and the correction request will remain. It may fail again if there is a bug that prevents it from succeeding, but it will hang around till we can fix the bug and try the approval again.

# Testing
I tested this locally by:
1. adding a test case to the seed.json file. I used one from branch #3126 so I did not leave it in this branch since it would be a duplication. I used this test case because I knew it would fail without the corrections also included in that branch.
2. I tested the order that the functions were called within promise.all and found that the failure occurred after the approval was deleted and email sent.
3. I then made my corrections and retested the scenario.
4. The error occurred before anything else was called, so only the put was called and the error was thrown upon failure.
5. I was able to confirm the change request still exists after failure