### PR TITLE
naming search term query to be consistent

### DIFF
--- a/app/routes/synonyms._index.tsx
+++ b/app/routes/synonyms._index.tsx
@@ -43,7 +43,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const page = parseInt(searchParams.get('page') || '1')
   const synonyms = await searchSynonymsByEventId({
     page: page - 1,
-    eventId: query,
+    query,
     limit,
   })
 

--- a/app/routes/synonyms/synonyms.server.ts
+++ b/app/routes/synonyms/synonyms.server.ts
@@ -44,11 +44,11 @@ export async function getSynonymsBySlug(slug: string) {
 export async function searchSynonymsByEventId({
   limit = 10,
   page,
-  eventId,
+  query,
 }: {
   limit?: number
   page: number
-  eventId?: string
+  query?: string
 }): Promise<{
   items: SynonymGroup[]
   totalItems: number
@@ -61,13 +61,12 @@ export async function searchSynonymsByEventId({
       bool: {},
     },
   }
-
-  if (eventId) {
+  if (query) {
     body.query.bool.filter = [
       {
         wildcard: {
           'eventIds.keyword': {
-            value: `*${eventId}*`,
+            value: `*${query}*`,
             case_insensitive: true,
           },
         },


### PR DESCRIPTION
# Description
search term wasn't passed in correctly


# Testing
local testing. searching on both the event page and on the synonym moderation page
