### PR TITLE
Synonyms: add link for objects with eventId

### DIFF
--- a/app/components/circularDisplay/FrontMatter.tsx
+++ b/app/components/circularDisplay/FrontMatter.tsx
@@ -8,6 +8,7 @@
 import { Grid } from '@trussworks/react-uswds'
 import { slug } from 'github-slugger'
 import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
 
 import TimeAgo from '~/components/TimeAgo'
 import { type Circular, formatDateISO } from '~/routes/circulars/circulars.lib'
@@ -58,7 +59,9 @@ export function FrontMatter({
     <>
       <FrontMatterItem label="Subject">{subject}</FrontMatterItem>
       {eventId && (
-        <FrontMatterItem label="Event"><Link to={`/circulars/events/${slug(eventId)}`}>{eventId}</Link></FrontMatterItem>
+        <FrontMatterItem label="Event">
+          <Link to={`/circulars/events/${slug(eventId)}`}>{eventId}</Link>
+        </FrontMatterItem>
       )}
       <FrontMatterItem label="Date">
         {formatDateISO(createdOn)}{' '}

--- a/app/components/circularDisplay/FrontMatter.tsx
+++ b/app/components/circularDisplay/FrontMatter.tsx
@@ -54,17 +54,11 @@ export function FrontMatter({
   | 'editedBy'
   | 'editedOn'
 >) {
-  const eventSlug = slug(eventId || '')
-  const eventIdLink = eventId ? (
-    <a href={`/circulars/events/${eventSlug}`}>{eventId}</a>
-  ) : (
-    ''
-  )
   return (
     <>
       <FrontMatterItem label="Subject">{subject}</FrontMatterItem>
       {eventId && (
-        <FrontMatterItem label="Event">{eventIdLink}</FrontMatterItem>
+        <FrontMatterItem label="Event"><Link to={`/circulars/events/${slug(eventId)}`}>{eventId}</Link></FrontMatterItem>
       )}
       <FrontMatterItem label="Date">
         {formatDateISO(createdOn)}{' '}

--- a/app/components/circularDisplay/FrontMatter.tsx
+++ b/app/components/circularDisplay/FrontMatter.tsx
@@ -8,7 +8,7 @@
 import { Grid } from '@trussworks/react-uswds'
 import { slug } from 'github-slugger'
 import type { ReactNode } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from '@remix-run/react'
 
 import TimeAgo from '~/components/TimeAgo'
 import { type Circular, formatDateISO } from '~/routes/circulars/circulars.lib'

--- a/app/components/circularDisplay/FrontMatter.tsx
+++ b/app/components/circularDisplay/FrontMatter.tsx
@@ -5,10 +5,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+import { Link } from '@remix-run/react'
 import { Grid } from '@trussworks/react-uswds'
 import { slug } from 'github-slugger'
 import type { ReactNode } from 'react'
-import { Link } from '@remix-run/react'
 
 import TimeAgo from '~/components/TimeAgo'
 import { type Circular, formatDateISO } from '~/routes/circulars/circulars.lib'

--- a/app/components/circularDisplay/FrontMatter.tsx
+++ b/app/components/circularDisplay/FrontMatter.tsx
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { Grid } from '@trussworks/react-uswds'
+import { slug } from 'github-slugger'
 import type { ReactNode } from 'react'
 
 import TimeAgo from '~/components/TimeAgo'
@@ -38,6 +39,7 @@ function FrontMatterItem({
 export function FrontMatter({
   subject,
   createdOn,
+  eventId,
   submitter,
   submittedHow,
   editedBy,
@@ -46,14 +48,24 @@ export function FrontMatter({
   Circular,
   | 'subject'
   | 'createdOn'
+  | 'eventId'
   | 'submitter'
   | 'submittedHow'
   | 'editedBy'
   | 'editedOn'
 >) {
+  const eventSlug = slug(eventId || '')
+  const eventIdLink = eventId ? (
+    <a href={`/circulars/events/${eventSlug}`}>{eventId}</a>
+  ) : (
+    ''
+  )
   return (
     <>
       <FrontMatterItem label="Subject">{subject}</FrontMatterItem>
+      {eventId && (
+        <FrontMatterItem label="Event">{eventIdLink}</FrontMatterItem>
+      )}
       <FrontMatterItem label="Date">
         {formatDateISO(createdOn)}{' '}
         <small className="text-base-light">


### PR DESCRIPTION
# Description
If a circular is associated with an event, the event is listed in the header and hyperlinks to the event page.
![image](https://github.com/user-attachments/assets/8f1ecbdf-967e-4fd3-aff7-2af4788712ab)

# Related Issue(s)

Resolves #3141 

# Testing
1. Navigate to the circulars archive
2. Select a circular with an associated event
3. On the circular page, there should be an item labeled "event" in the header. Upon clicking the hyperlink, it should direct to the event view
4. Go back to the archive
5.  Select a circular that does not have an associated event
6. The event item should not be in the header
