### PR TITLE
DO NOT MERGE/gather event ids to repair

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ auth.json
 
 # Draw.io auto-save files
 *.bkp
+
+/app/archive.json
+/event_id_updates.json

--- a/app/migrations/updates/index.ts
+++ b/app/migrations/updates/index.ts
@@ -7,6 +7,9 @@
  * 4. Run `npm run build`
  * 5. Run `node build/migrations/updates/index.mjs`
  * 6. Your file with circulars that need to be updated will be at the top level directory.
+ *
+ * If you are using visual studio code, you can open the `event_id_updates.json` and make it more readable
+ * by pushing command + shift + P and typing `Format Document`.
  */
 import * as fs from 'fs'
 import * as path from 'path'

--- a/app/migrations/updates/index.ts
+++ b/app/migrations/updates/index.ts
@@ -1,0 +1,57 @@
+/**
+ * STEPS:
+ * You do NOT need to have the app running.
+ * 1. Download a fresh copy of the archive
+ * 2. Unzip it
+ * 3. Move it into the `app` folder. it should be named archive.json
+ * 4. Run `npm run build`
+ * 5. Run `node build/migrations/updates/index.mjs`
+ * 6. Your file with circulars that need to be updated will be at the top level directory.
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+
+import { parseEventFromSubject } from '~/routes/circulars/circulars.lib'
+
+interface UpdateData {
+  circularId: number
+  eventId: string
+  oldEventId: string
+}
+
+function processFiles() {
+  const folderPath = './app/archive.json'
+  const results = [] as UpdateData[]
+  fs.readdir(folderPath, (err, files) => {
+    if (err) {
+      console.error('Error reading directory:', err)
+      return
+    }
+    files.forEach((file) => {
+      const filePath = path.join(folderPath, file)
+      const fileContent = fs.readFileSync(filePath, 'utf-8')
+
+      const circular = JSON.parse(fileContent)
+      const eventId = parseEventFromSubject(circular.subject)
+      const previousEventId = circular.eventId ? circular.eventId : undefined
+      if (eventId && eventId != previousEventId) {
+        results.push({
+          circularId: circular.circularId,
+          eventId,
+          oldEventId: previousEventId,
+        })
+      }
+    })
+    const updates = { updates: results }
+
+    fs.writeFile('./event_id_updates.json', JSON.stringify(updates), (err) => {
+      if (err) {
+        console.log('Error writing file:', err)
+      } else {
+        console.log('Successfully wrote file')
+      }
+    })
+  })
+}
+
+processFiles()

--- a/app/migrations/updates/index.ts
+++ b/app/migrations/updates/index.ts
@@ -38,11 +38,13 @@ function processFiles() {
       const eventId = parseEventFromSubject(circular.subject)
       const previousEventId = circular.eventId ? circular.eventId : undefined
       if (eventId && eventId != previousEventId) {
-        results.push({
-          circularId: circular.circularId,
-          eventId,
-          oldEventId: previousEventId,
-        })
+        if (!previousEventId || previousEventId.split(' ')[0] != 'GRB') {
+          results.push({
+            circularId: circular.circularId,
+            eventId,
+            oldEventId: previousEventId,
+          })
+        }
       }
     })
     const updates = { updates: results }

--- a/app/migrations/updates/index.ts
+++ b/app/migrations/updates/index.ts
@@ -7,6 +7,10 @@
  * 4. Run `npm run build`
  * 5. Run `node build/migrations/updates/index.mjs`
  * 6. Your file with circulars that need to be updated will be at the top level directory.
+ * 7. MAKE SURE TO REMOVE THE ARCHIVE FOLDER FROM THE APP WHEN YOU ARE DONE!
+ *    If you forget, it will break local dev in a very difficult to debug way. The container will start,
+ *    but will crash and be removed. It does this because the watcher tries to watch all the files in
+ *    the archive directory and it gets overwhelmed and OOMs.
  *
  * If you are using visual studio code, you can open the `event_id_updates.json` and make it more readable
  * by pushing command + shift + P and typing `Format Document`.
@@ -38,6 +42,7 @@ function processFiles() {
       const eventId = parseEventFromSubject(circular.subject)
       const previousEventId = circular.eventId ? circular.eventId : undefined
       if (eventId && eventId != previousEventId) {
+        // if it already has a GRB eventId, don't worry about updating it
         if (!previousEventId || previousEventId.split(' ')[0] != 'GRB') {
           results.push({
             circularId: circular.circularId,

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -7,7 +7,7 @@ import { basename, dirname, join } from 'path'
 const args = process.argv.slice(2)
 const dev = args.includes('--dev')
 const entryPoints = await glob(
-  './app/{email-incoming,scheduled,table-streams}/*/index.ts'
+  './app/{email-incoming,scheduled,table-streams,migrations}/*/index.ts'
 )
 
 /**
@@ -19,8 +19,9 @@ const options = {
   logLevel: 'info',
   outdir: 'build',
   outbase: 'app',
-  outExtension: { '.js': '.cjs' },
+  outExtension: { '.js': '.mjs' },
   external: ['@aws-sdk/*', 'aws-sdk'],
+  format: 'esm',
   platform: 'node',
   target: ['node20'],
   minify: !dev,


### PR DESCRIPTION
# Description
This is a script that uses the subject matchers in the app to go through the archive and find circulars that need to have their eventId's updated or corrected. Detailed instructions on how to use this script are found at the top of the script file.

# Related Issue(s)
Resolves #3061

# Testing
I have run this locally.
