### PR TITLE
fixed LIGO length typo

### DIFF
--- a/app/routes/missions.lvk/route.mdx
+++ b/app/routes/missions.lvk/route.mdx
@@ -49,7 +49,7 @@ LIGO, Virgo, and KAGRA comprise the advanced gravitational wave detector network
 
 | Interferometers                                                                        | Location                                       | Size | Joined GW Network | BNS Range (O4) |
 | -------------------------------------------------------------------------------------- | ---------------------------------------------- | ---- | ----------------- | -------------- |
-| [Laser Interferometer Gravitational-Wave Observatory (LIGO)](https://www.ligo.org)     | Hanford, WA, USA Livingston, LA, USA           | 5 km | 2015              | 160-190 Mpc    |
+| [Laser Interferometer Gravitational-Wave Observatory (LIGO)](https://www.ligo.org)     | Hanford, WA, USA Livingston, LA, USA           | 4 km | 2015              | 160-190 Mpc    |
 | [Virgo Gravitational Wave Interferometer (Virgo)](https://www.virgo-gw.eu)             | Pisa, Italy                                    | 3 km | 2017              | 90-120 Mpc     |
 | [Kamioka Gravitational Wave Detector (KAGRA)](https://gwcenter.icrr.u-tokyo.ac.jp/en/) | Kamioka-cho, Hida-city, Gifu-prefecture, Japan | 3 km | 2020              | 25-230 Mpc     |
 


### PR DESCRIPTION
# Description
A user noted that we had a typo in the length of the LIGO arms.  I confirmed the number and made the correction.

# Related Issue(s)
Resolves #3160

# Testing
local dev