### PR TITLE
Docs update events links

### DIFF
--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -40,7 +40,7 @@ In the Event View search bar, enter in an event name and it will take you to the
 
 ### Linking to an event name or event group
 
-To save a direct link to all Circulars associated with a particular event name or event group, you can point to any event name in that group, e.g. `https://gcn.nasa.gov/circulars/group/[event_name]'.
+To save a direct link to all Circulars associated with a particular event name or event group, you can point to any event name in that group, e.g. `https://gcn.nasa.gov/circulars/group/[event_name]'. Event names are also available in the headers of Circulars that are part of an event group under the 'Event' label.
 
 </WithFeature>
 


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
Corrects a minor typo and adds a sentence on the presence of the event link in the Circulars header.

# Related Issue(s)


Resolves #3162

# Testing
1. Navigate to Archive Documentation page
2. Go to the 'Linking to an event name or event group' section
3. The typo should be corrected and there should be an additional sentence present.
