### PR TITLE
remove broken EP link

### DIFF
--- a/app/routes/missions.einstein-probe/route.mdx
+++ b/app/routes/missions.einstein-probe/route.mdx
@@ -35,10 +35,8 @@ The [Einstein Probe (EP)](https://ep.bao.ac.cn/ep/) is a mission of the Chinese 
 
 Einstein Probe distributes alerts for the detection of gamma-ray transients. These notices are published on the GCN Kafka topic `gcn.notices.einstein_probe.wxt.alert`.
 
-The [GCN schema](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) and
-example [JSON message](/schema/stable/gcn/notices/einstein_probe/wxt/alert.example.json) files are available to use for [Einstein Probe Schema](/schema/stable/gcn/notices/einstein_probe). See the [Schema Browser](/docs/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) for more information on the properties defined in the schema.
-
-Detailed description and examples of EP Notices are available in the [GCN Schema GitHub project](https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/einstein_probe/wxt).
+Einstein Probe [GCN schema](/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) and
+example [JSON message](/schema/stable/gcn/notices/einstein_probe/wxt/alert.example.json) files are available. See the [Schema Browser](/docs/schema/stable/gcn/notices/einstein_probe/wxt/alert.schema.json) for more information on the properties defined in the schema. Detailed description and examples of EP Notices are available in the [GCN Schema GitHub project](https://github.com/nasa-gcn/gcn-schema/tree/main/gcn/notices/einstein_probe/wxt).
 
 <div className="overflow-table">
 


### PR DESCRIPTION
# Description
Link to EP schema is broken and is really duplicative.

# Related Issue(s)
Resolves #2954 

# Testing
Local Dev