### PR TITLE
Disable text wrap in tab bar button text

### DIFF
--- a/app/components/tabs/index.module.scss
+++ b/app/components/tabs/index.module.scss
@@ -20,6 +20,7 @@
       border: 2px solid;
       padding-bottom: 14px;
       width: auto;
+      text-wrap: nowrap;
 
       &:not(.checked) {
         margin-top: 2px;


### PR DESCRIPTION
Before:

![Screenshot 2025-07-03 at 17 02 31](https://github.com/user-attachments/assets/bc0bc6e5-d4ec-464c-850e-ecf21a770a52)

After:

![Screenshot 2025-07-03 at 17 02 56](https://github.com/user-attachments/assets/7fbaeb6c-3474-4a35-9d2b-4774001cc78c)
