### PR TITLE
Remove autofocus from event ID

### DIFF
--- a/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
+++ b/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
@@ -283,7 +283,6 @@ export function CircularEditForm({
             >
               <InputPrefix className="wide-input-prefix">Event ID</InputPrefix>
               <TextInput
-                autoFocus
                 className="maxw-full"
                 name="eventId"
                 id="eventId"


### PR DESCRIPTION
There is no reason that the event ID should automatically receive focus. This looks like it was a copy-paste error.