### PR TITLE
Drop @architect/sandbox override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "usehooks-ts": "^3.0.2"
       },
       "devDependencies": {
-        "@architect/architect": "^11.2.2",
+        "@architect/architect": "^11.3.0",
         "@architect/plugin-lambda-invoker": "^2.0.2",
         "@architect/utils": "^4.0.6",
         "@aws-sdk/client-cognito-identity-provider": "3.632.0",
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@architect/architect": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/@architect/architect/-/architect-11.2.2.tgz",
-      "integrity": "sha512-tHwDUqJPI2TN7O3o4nhBb494eZ3GPOdQjBhmIhxLxDIkv1FRB3QIpISs46/oS9rJs308pFL7d7NMvxxKf9m7PA==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@architect/architect/-/architect-11.3.0.tgz",
+      "integrity": "sha512-psZd7tRNkKak2hNDx73SXfjpN9u123F+t09WPv3By6bcsWyhTu04Ox/cMN4oQmQqGtoCDHghWKx3TVhE55Is7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -204,7 +204,7 @@
         "@architect/hydrate": "4.0.8",
         "@architect/inventory": "~4.0.8",
         "@architect/logs": "5.0.5",
-        "@architect/sandbox": "6.0.5",
+        "@architect/sandbox": "7.1.0",
         "@architect/utils": "~4.0.6",
         "@aws-lite/client": "^0.22.2",
         "chalk": "4.1.2",
@@ -570,8 +570,9 @@
       }
     },
     "node_modules/@architect/sandbox": {
-      "version": "7.0.0",
-      "resolved": "git+ssh://git@github.com/architect/sandbox.git#fade7572c8228e482b04324888468d0700284001",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@architect/sandbox/-/sandbox-7.1.0.tgz",
+      "integrity": "sha512-qob0h5EsDM9kr4VfF2DtI6iWeXGHcZ1Y2cC8YDt6xvS9Ufj0gsCDGI7W2msj5ab9NhcboDzNoj5kPQbZx/CHaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -33816,9 +33817,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "usehooks-ts": "^3.0.2"
   },
   "devDependencies": {
-    "@architect/architect": "^11.2.2",
+    "@architect/architect": "^11.3.0",
     "@architect/plugin-lambda-invoker": "^2.0.2",
     "@architect/utils": "^4.0.6",
     "@aws-sdk/client-cognito-identity-provider": "3.632.0",
@@ -156,8 +156,7 @@
   },
   "overrides": {
     "@architect/deploy": "github:DocLM/deploy#d3116f41d5fda00337ebfda543a69d3b3d4546be",
-    "@architect/inventory": "github:lpsinger/inventory#allow-set-env-plugin-to-return-empty-object",
-    "@architect/sandbox": "github:architect/sandbox"
+    "@architect/inventory": "github:lpsinger/inventory#allow-set-env-plugin-to-return-empty-object"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
This dependency was overriden because of an issue with the `external-db` setting that was fixed in Architect 11.3.0.

See https://github.com/architect/architect/blob/main/changelog.md#1130-2025-07-01.