### PR TITLE
Explicitly limit workflow permissions to read-only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Node.js

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
This fixes the following code scanning alerts:
- https://github.com/nasa-gcn/gcn.nasa.gov/security/code-scanning/22
- https://github.com/nasa-gcn/gcn.nasa.gov/security/code-scanning/23
- https://github.com/nasa-gcn/gcn.nasa.gov/security/code-scanning/24
- https://github.com/nasa-gcn/gcn.nasa.gov/security/code-scanning/25