### PR TITLE
Add documentation on client credential expiration

### DIFF
--- a/app/routes/docs.client._index.mdx
+++ b/app/routes/docs.client._index.mdx
@@ -7,7 +7,7 @@ import { ClientSampleCode } from '~/components/ClientSampleCode'
 
 # Kafka Client Setup
 
-See our [Start Streaming GCN Notices quick start guide](/quickstart) for a step-by-step walkthrough to begin streaming alerts now!
+See our [Start Streaming GCN Notices quick start guide](/quickstart) for a step-by-step walkthrough to begin streaming alerts now! See [documentation](/docs/faq#why-are-my-kafka-client-credentials-expiring) on Client Credential expiration for more details.
 
 ## Python
 

--- a/app/routes/docs.faq/route.mdx
+++ b/app/routes/docs.faq/route.mdx
@@ -100,6 +100,10 @@ This was a [known issue](https://github.com/nasa-gcn/gcn-kafka-python/issues/49)
 
 To get started, [sign in or sign up](https://gcn.nasa.gov/login) and then select 'Email Notifications' from account dropdown menu. See also [GCN Circular 32517](/circulars/32517).
 
+### Why are my Kafka client credentials expiring?
+
+GCN has updated our security practices to disable disused Kafka client credentials that have not connected to one of our Kafka brokers within the last month. The [client credentials page](/user/credentials) lists the date that the credential was last used to connect to one of the GCN Kafka brokers. Users will receive an email warning in advance of the expiration date. Connecting that client credential to one of the GCN Kafka brokers after the warning email will update the last used date and postpone the expiration. Users may delete expired client credentials and generate new client credentials at any time in the [client credential page](/user/credentials).
+
 ## Circulars
 
 ### Why do GCN Circulars that I submit by email appear to be double spaced?

--- a/app/routes/quickstart.credentials.tsx
+++ b/app/routes/quickstart.credentials.tsx
@@ -7,7 +7,7 @@
  */
 import type { SEOHandle } from '@nasa-gcn/remix-seo'
 import type { ActionFunctionArgs } from '@remix-run/node'
-import { useLoaderData } from '@remix-run/react'
+import { Link, useLoaderData } from '@remix-run/react'
 
 import CredentialCard from '~/components/CredentialCard'
 import {
@@ -45,7 +45,15 @@ export default function () {
         <>
           <p className="usa-paragraph">
             {explanation} Select one of your existing client credentials, or
-            create a new one.
+            create a new one. For more information about Client Credential
+            expiration see the{' '}
+            <Link
+              className="usa-link"
+              to="/docs/faq#why-are-my-kafka-client-credentials-expiring"
+            >
+              documentation
+            </Link>
+            .
           </p>
           <SegmentedCards>
             {client_credentials.map((credential) => (

--- a/app/routes/user.credentials._index.tsx
+++ b/app/routes/user.credentials._index.tsx
@@ -61,6 +61,13 @@ export default function () {
         <Link className="usa-link" to="/docs/client">
           client documentation
         </Link>
+        . For more information on Client Credential expiration, see the{' '}
+        <Link
+          className="usa-link"
+          to="/docs/faq#why-are-my-kafka-client-credentials-expiring"
+        >
+          documentation
+        </Link>
         .
       </p>
       <SegmentedCards>


### PR DESCRIPTION
# Description
Adds description of client credential expiration policy and implementation, including links from various client credential pages.

# Related Issue(s)
Resolves #3193 

# Testing
Local dev