### PR TITLE
try setting archive tests to have longer timeout

### DIFF
--- a/__playwright__/circulars/archive.spec.ts
+++ b/__playwright__/circulars/archive.spec.ts
@@ -9,6 +9,7 @@ test.describe('Circulars archive page', () => {
   test('responds to changes in the number of results per page', async ({
     page,
   }) => {
+    test.slow()
     await page.goto('/circulars')
     for (const expectedResultsPerPage of [10, 20]) {
       const locator = page.getByTestId('Select')
@@ -25,18 +26,21 @@ test.describe('Circulars archive page', () => {
   })
 
   test('search is functional via mouse click', async ({ page }) => {
+    test.slow()
     await page.goto('/circulars')
     await page.locator('#query').fill('GRB')
     await page.getByRole('button', { name: 'Search' }).click()
   })
 
   test('search is functional via keyboard input', async ({ page }) => {
+    test.slow()
     await page.goto('/circulars')
     await page.locator('#query').fill('GRB')
     await page.getByTestId('textInput').press('Enter')
   })
 
   test('search finds query string in body of circular', async ({ page }) => {
+    test.slow()
     await page.goto('/circulars?query=ATLAS23srq')
     await expect(
       page.locator('a[href="/circulars/34730?query=ATLAS23srq"]')
@@ -46,6 +50,7 @@ test.describe('Circulars archive page', () => {
   test('search finds all results related to a specific object', async ({
     page,
   }) => {
+    test.slow()
     await page.goto('/circulars?query=230812B')
     await page.waitForLoadState()
     await expect(page.locator('ol', { has: page.locator('li') })).toBeVisible()
@@ -54,6 +59,7 @@ test.describe('Circulars archive page', () => {
 
   test('search finds no results for query with typo', async ({ page }) => {
     // this highlights this search behavior does not capture cases where there is a minor typo
+    test.slow()
     await page.goto('/circulars?query=230812C')
     await page.waitForLoadState()
     await expect(

--- a/__playwright__/circulars/archive.spec.ts
+++ b/__playwright__/circulars/archive.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page }, testInfo) => {
+  testInfo.setTimeout(testInfo.timeout + 60_000)
   await page.goto('/circulars')
   await page.waitForSelector('#query')
 })

--- a/__playwright__/circulars/archive.spec.ts
+++ b/__playwright__/circulars/archive.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-test.beforeEach(async ({ page }) => {
+test.beforeAll(async ({ page }) => {
   await page.goto('/circulars')
   await page.waitForSelector('#query')
 })

--- a/__playwright__/circulars/archive.spec.ts
+++ b/__playwright__/circulars/archive.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-test.beforeAll(async ({ page }) => {
+test.beforeEach(async ({ page }) => {
   await page.goto('/circulars')
   await page.waitForSelector('#query')
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -66,7 +66,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: 'npm run dev && npx wait-on http://localhost:3333',
     url: 'http://localhost:3333',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
Attempting to solve the playwright test timeout. On first pass, it seems that the archive tests did not have the "slow" flag enabled like several of the other tests, which may be to blame.

# Related Issue(s)
Resolves #3163 

# Testing
1. Run Playwright Tests
