### PR TITLE
Clean up eventbridge plugin

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -17,7 +17,8 @@ support
 app_clients
   src build/eventbridge/app-clients
   source aws.cognito-idp
-  detailType 'AWS Service Event via Eventbridge'
+  detailType 'AWS Service Event via CloudTrail'
+  eventName Token_POST
 
 @scheduled
 ads


### PR DESCRIPTION
- Fix CloudFormation resource dependency errors.
- Add permissions to invoke Lambda.
- Use `set.customLambdas` entry point instead of `set.events`, because are not using SNS for EventBridge events.
- Simplify configuration unpacking.