### PR TITLE
Save last used date as timestamp, not UTC string

### DIFF
--- a/app/eventbridge/app-clients/index.ts
+++ b/app/eventbridge/app-clients/index.ts
@@ -82,7 +82,7 @@ export async function handler(
       '#lastUsed': 'lastUsed',
     },
     ExpressionAttributeValues: {
-      ':lastUsed': event.detail.eventTime,
+      ':lastUsed': Date.parse(event.detail.eventTime),
     },
   })
 }


### PR DESCRIPTION
This is the format that we use for all other dates in our database.

This will fix errors rendering the client credentials cards.