### PR TITLE
Fix alignment of InputGroups with no editable fields

### DIFF
--- a/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
+++ b/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
@@ -211,7 +211,7 @@ export function CircularEditForm({
             </InputGroup>
           </>
         )}
-        <InputGroup className="border-0 maxw-full">
+        <InputGroup className="maxw-full usa-input---not-editable">
           <InputPrefix className="wide-input-prefix">
             {circularId === undefined ? 'From' : 'Editor'}
           </InputPrefix>

--- a/app/theme.scss
+++ b/app/theme.scss
@@ -134,6 +134,14 @@ a[rel~='external'] {
 }
 
 /*
+ * Outlines for input groups that do not contain input elements
+ */
+.usa-input---not-editable {
+  border: 0;
+  padding: units($theme-input-state-border-width);
+}
+
+/*
  * Styles for notice cards
  */
 


### PR DESCRIPTION
Fixes #3235.

# Before

<img width="1187" height="1062" alt="Screenshot 2025-08-11 at 13 41 12" src="https://github.com/user-attachments/assets/6d04bd3c-a345-4b04-81e3-d8fc96f061dc" />

# After

<img width="1187" height="1062" alt="Screenshot 2025-08-11 at 13 40 39" src="https://github.com/user-attachments/assets/f3284565-5440-490d-a244-6c67cca3166f" />
