### PR TITLE
Circulars in page navigation

### DIFF
--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -164,7 +164,7 @@ export default function () {
       <FrontMatter {...frontMatter} />
       <Body className="margin-y-2">{body}</Body>
       <div className="margin-top-4 display-flex flex-justify-center gap-2">
-        {previousCircular ? (
+        {Number.isFinite(previousCircular) ? (
           <Link
             to={`/circulars/${previousCircular}${searchString}`}
             className="usa-button flex-align-stretch"
@@ -193,7 +193,7 @@ export default function () {
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Previous Circular
           </Button>
         )}
-        {nextCircular ? (
+        {Number.isFinite(nextCircular) ? (
           <Link
             to={`/circulars/${nextCircular}${searchString}`}
             className="usa-button flex-align-stretch"

--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -36,7 +36,7 @@ export const handle: BreadcrumbHandle<typeof loader> = {
 }
 
 export async function loader({
-  params: { circularId, version, next, previous },
+  params: { circularId, version },
 }: LoaderFunctionArgs) {
   invariant(circularId)
   const result = await get(

--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -43,14 +43,10 @@ export async function loader({
     parseFloat(circularId),
     version ? parseFloat(version) : undefined
   )
-  const nextCircular = await findAdjacentCircular(
-    parseFloat(circularId),
-    'next'
-  )
-  const previousCircular = await findAdjacentCircular(
-    parseFloat(circularId),
-    'previous'
-  )
+  const [nextCircular, previousCircular] = await Promise.all([
+    findAdjacentCircular(parseFloat(circularId), 'next'),
+    findAdjacentCircular(parseFloat(circularId), 'previous'),
+  ])
 
   return json(
     { ...result, nextCircular, previousCircular },

--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -14,7 +14,7 @@ import invariant from 'tiny-invariant'
 import { useOnClickOutside } from 'usehooks-ts'
 
 import type { loader as parentLoader } from '../circulars.$circularId/route'
-import { get } from '../circulars/circulars.server'
+import { findAdjacentCircular, get } from '../circulars/circulars.server'
 import DetailsDropdownButton from '~/components/DetailsDropdownButton'
 import DetailsDropdownContent from '~/components/DetailsDropdownContent'
 import { ToolbarButtonGroup } from '~/components/ToolbarButtonGroup'
@@ -36,19 +36,30 @@ export const handle: BreadcrumbHandle<typeof loader> = {
 }
 
 export async function loader({
-  params: { circularId, version },
+  params: { circularId, version, next, previous },
 }: LoaderFunctionArgs) {
   invariant(circularId)
   const result = await get(
     parseFloat(circularId),
     version ? parseFloat(version) : undefined
   )
+  const nextCircular = await findAdjacentCircular(
+    parseFloat(circularId),
+    'next'
+  )
+  const previousCircular = await findAdjacentCircular(
+    parseFloat(circularId),
+    'previous'
+  )
 
-  return json(result, {
-    headers: {
-      ...getCanonicalUrlHeaders(new URL(`/circulars/${circularId}`, origin)),
-    },
-  })
+  return json(
+    { ...result, nextCircular, previousCircular },
+    {
+      headers: {
+        ...getCanonicalUrlHeaders(new URL(`/circulars/${circularId}`, origin)),
+      },
+    }
+  )
 }
 
 export function shouldRevalidate() {
@@ -59,11 +70,18 @@ export const headers: HeadersFunction = ({ loaderHeaders }) =>
   pickHeaders(loaderHeaders, ['Link'])
 
 export default function () {
-  const { circularId, body, bibcode, version, format, ...frontMatter } =
-    useLoaderData<typeof loader>()
+  const {
+    circularId,
+    body,
+    bibcode,
+    version,
+    format,
+    nextCircular,
+    previousCircular,
+    ...frontMatter
+  } = useLoaderData<typeof loader>()
   const searchString = useSearchString()
   const Body = format === 'text/markdown' ? MarkdownBody : PlainTextBody
-
   const result = useRouteLoaderData<typeof parentLoader>(
     'routes/circulars.$circularId'
   )
@@ -72,6 +90,7 @@ export default function () {
   const linkString = `/circulars/${circularId}${
     !latest && version ? `/${version}` : ''
   }`
+
   return (
     <>
       <ToolbarButtonGroup className="flex-wrap">
@@ -144,6 +163,68 @@ export default function () {
       <h1 className="margin-bottom-0">GCN Circular {circularId}</h1>
       <FrontMatter {...frontMatter} />
       <Body className="margin-y-2">{body}</Body>
+      <div className="margin-top-4 display-flex flex-justify-center gap-2">
+        {previousCircular ? (
+          <Link
+            to={`/circulars/${previousCircular}${searchString}`}
+            className="usa-button flex-align-stretch"
+          >
+            <div className="position-relative">
+              <Icon.ArrowBack
+                role="presentation"
+                className="position-absolute top-0 left-0"
+              />
+            </div>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Previous Circular
+          </Link>
+        ) : (
+          <Button
+            type="button"
+            className="usa-button flex-align-stretch"
+            disabled
+            aria-disabled
+          >
+            <div className="position-relative">
+              <Icon.ArrowBack
+                role="presentation"
+                className="position-absolute top-0 left-0"
+              />
+            </div>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Previous Circular
+          </Button>
+        )}
+        {nextCircular ? (
+          <Link
+            to={`/circulars/${nextCircular}${searchString}`}
+            className="usa-button flex-align-stretch"
+          >
+            Next Circular
+            <div className="position-relative">
+              <Icon.ArrowForward
+                role="presentation"
+                className="position-absolute top-0 left-0"
+              />
+            </div>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          </Link>
+        ) : (
+          <Button
+            type="button"
+            className="usa-button flex-align-stretch"
+            disabled
+            aria-disabled
+          >
+            Next Circular
+            <div className="position-relative">
+              <Icon.ArrowForward
+                role="presentation"
+                className="position-absolute top-0 left-0"
+              />
+            </div>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          </Button>
+        )}
+      </div>
     </>
   )
 }

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -295,7 +295,6 @@ export async function findAdjacentCircular(
   let nextCircular = circularId + increment
   for (let i = 0; i < 10; i++) {
     if (await exists(nextCircular)) {
-      console.log(`Found ${direction} circular: ${nextCircular}`)
       return nextCircular
     }
     nextCircular += increment

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -272,6 +272,37 @@ export async function get(
   return result as Circular
 }
 
+/** Check if a Circular exists by ID. */
+export async function exists(
+  circularId: number,
+  version?: number
+): Promise<boolean> {
+  const circularVersions = await getDynamoDBVersionAutoIncrement(circularId)
+  const result = await circularVersions.get(version)
+  return Boolean(result)
+}
+
+/** Find the next or previous circular by ID.
+ * Returns false if no circular is found.
+ * Checks for 10 circulars in the given direction.
+ * Iterates by 0.5 to account for non-integer circular IDs.
+ */
+export async function findAdjacentCircular(
+  circularId: number,
+  direction: 'next' | 'previous'
+): Promise<number | false> {
+  const increment = direction === 'next' ? 0.5 : -0.5
+  let nextCircular = circularId + increment
+  for (let i = 0; i < 10; i++) {
+    if (await exists(nextCircular)) {
+      console.log(`Found ${direction} circular: ${nextCircular}`)
+      return nextCircular
+    }
+    nextCircular += increment
+  }
+  return false
+}
+
 /** Delete a circular by ID.
  * Throws an HTTP error if:
  *  - The current user is not signed in

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -274,9 +274,14 @@ export async function get(
 
 /** Check if a Circular exists by ID. */
 export async function exists(circularId: number): Promise<boolean> {
-  const circularVersions = await getDynamoDBVersionAutoIncrement(circularId)
-  const result = await circularVersions.get()
-  return Boolean(result)
+  const db = await tables()
+  const doc = db._doc as unknown as DynamoDBDocument
+  const result = await doc.get({
+    TableName: db.name('circulars'),
+    Key: { circularId },
+    ProjectionExpression: 'circularId',
+  })
+  return Boolean(result.Item)
 }
 
 /** Find the next or previous circular by ID.

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -273,12 +273,9 @@ export async function get(
 }
 
 /** Check if a Circular exists by ID. */
-export async function exists(
-  circularId: number,
-  version?: number
-): Promise<boolean> {
+export async function exists(circularId: number): Promise<boolean> {
   const circularVersions = await getDynamoDBVersionAutoIncrement(circularId)
-  const result = await circularVersions.get(version)
+  const result = await circularVersions.get()
   return Boolean(result)
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
Adds navigation buttons inside specific circular pages to navigate to previous and next circulars. 

# Related Issue(s)
Resolves #2226 

# Testing
Testing for basic navigation:

1. Navigate to a specific circular
2. Scroll to bottom of page
3. Click 'Next Circular' or 'Previous Circular' buttons
4. Page for next or previous circular should load
