### PR TITLE
Fix breadcrumb

### DIFF
--- a/app/routes/docs.notices._index.mdx
+++ b/app/routes/docs.notices._index.mdx
@@ -1,6 +1,6 @@
 ---
 handle:
-  breadcrumb: Notices Documentation
+  breadcrumb: Notices
 ---
 
 import { Link } from '@remix-run/react'


### PR DESCRIPTION
Change the page title from `GCN - Documentation - Notices Documentation` to `GCN - Documentation - Notices`.