### PR TITLE
Truncate Circular text to fit in SES request limits

### DIFF
--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { joinListWithOxfordComma } from '~/lib/utils'
+import { joinListWithOxfordComma, truncateJsonMaxBytes } from '~/lib/utils'
 import { stripTags } from '~/lib/utils.server'
 
 describe('stripTags', () => {
@@ -40,5 +40,28 @@ describe('joinListWithOxfordComma', () => {
     expect(joinListWithOxfordComma(['foo', 'bar', 'bat', 'baz'])).toBe(
       'foo, bar, bat, and baz'
     )
+  })
+})
+
+describe('truncateJsonMaxBytes', () => {
+  test('handles strings with no escsaped characters', () => {
+    const text = 'The quick brown fox jumped over the lazy dog.'
+    expect(truncateJsonMaxBytes(text, 100)).toEqual({ text, truncated: false })
+    expect(truncateJsonMaxBytes(text, 30)).toEqual({
+      text: 'The quick brown fox ju',
+      truncated: true,
+    })
+  })
+  test('truncates pathological text with escape sequences', () => {
+    const letters = 'a'.repeat(50)
+    expect(truncateJsonMaxBytes(letters, 52)).toEqual({
+      text: letters,
+      truncated: false,
+    })
+    const backslashes = '\\'.repeat(50)
+    expect(truncateJsonMaxBytes(backslashes, 52)).toEqual({
+      text: '\\'.repeat(25),
+      truncated: true,
+    })
   })
 })

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -114,3 +114,17 @@ export function joinListWithOxfordComma(
     return `${list.join(', ')}, ${conjunction} ${last}`
   }
 }
+
+const encoder = new TextEncoder()
+
+/**
+ * Truncate a string so that its JSON serialization has a maximum byte length.
+ */
+export function truncateJsonMaxBytes(text: string, maxBytes: number) {
+  let truncated = false
+  while (encoder.encode(JSON.stringify(text)).byteLength > maxBytes) {
+    text = text.substring(0, text.length / 2)
+    truncated = true
+  }
+  return { text, truncated }
+}

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -40,6 +40,7 @@ import type {
 } from './circulars.lib'
 import { sendEmail, sendEmailBulk } from '~/lib/email.server'
 import { origin } from '~/lib/env.server'
+import { truncateJsonMaxBytes } from '~/lib/utils'
 import { closeZendeskTicket } from '~/lib/zendesk.server'
 
 // A type with certain keys required.
@@ -673,13 +674,19 @@ export async function send(circular: Circular) {
     getLegacyEmails(),
   ])
   const to = [...emails, ...legacyEmails]
+
+  // There is a limit of 262144 bytes for the Amazon SES API's TemplateData argument.
+  // See https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_Template.html#SES-Type-Template-TemplateData
+  const { text, truncated } = truncateJsonMaxBytes(
+    formatCircularText(circular),
+    200_000
+  )
+
   await sendEmailBulk({
     fromName,
     to,
     subject: circular.subject,
-    body: `${formatCircularText(
-      circular
-    )}\n\n\nView this GCN Circular online at ${origin}/circulars/${
+    body: `${text}${truncated ? '...\n\n\nThis message was truncated. View the full' : '\n\n\nView this'} GCN Circular online at ${origin}/circulars/${
       circular.circularId
     }.`,
     topic: 'circulars',


### PR DESCRIPTION
Fixes #2899. Fixes #3110.