### PR TITLE
[Minor] Update Super-Kamiokande description

### DIFF
--- a/app/routes/missions.sksn/route.mdx
+++ b/app/routes/missions.sksn/route.mdx
@@ -24,7 +24,7 @@ import logo from './logo.png'
 [University of Tokyo](https://www-sk.icrr.u-tokyo.ac.jp/en/sk/for-reseacher/)
 
 The [Super-Kamiokande experiment](https://www-sk.icrr.u-tokyo.ac.jp/en/sk/), also known as Super-K or SK, was built and has been operated with funding from the Japanese Ministry of Education, Science, Sports and Culture, and the U.S. Department of Energy.
-The Hyper-Kamiokande experiment will be the successor of SK, it is expected to start operation around 2028.
+The Hyper-Kamiokande experiment will be the successor of SK. It is expected to start operation around 2028.
 
 **GCN Notice Types in GCN Classic and GCN Classic Over Kafka:**
 [Detailed Descriptions and Examples](https://gcn.gsfc.nasa.gov/sk_sn.html)

--- a/app/routes/missions.sksn/route.mdx
+++ b/app/routes/missions.sksn/route.mdx
@@ -23,7 +23,7 @@ import logo from './logo.png'
 **Data Archives:**
 [University of Tokyo](https://www-sk.icrr.u-tokyo.ac.jp/en/sk/for-reseacher/)
 
-The [Super-Kamiokande experiment](https://www-sk.icrr.u-tokyo.ac.jp/en/sk/), also known as Super-K or SK, was built and has been operated with funding from the Japanese Ministry of Education, Science, Sports and Culture, and the U.S. Department of Energy.
+The [Super-Kamiokande experiment](https://www-sk.icrr.u-tokyo.ac.jp/en/sk/), also known as Super-K or SK, was built and is operated with funding from the Japanese Ministry of Education, Science, Sports and Culture, and the U.S. Department of Energy.
 The Hyper-Kamiokande experiment will be the successor of SK. It is expected to start operation around 2028.
 
 **GCN Notice Types in GCN Classic and GCN Classic Over Kafka:**

--- a/app/routes/missions.sksn/route.mdx
+++ b/app/routes/missions.sksn/route.mdx
@@ -20,12 +20,11 @@ import logo from './logo.png'
 
 **Start:** 1996
 
-**Upgrade:** 2028 to Hyper-Kamiokande
-
 **Data Archives:**
 [University of Tokyo](https://www-sk.icrr.u-tokyo.ac.jp/en/sk/for-reseacher/)
 
-[Super-Kamiokande](https://www-sk.icrr.u-tokyo.ac.jp/en/sk/), also known as Super-K or SK, is a neutrino observatory built by the Japanese Ministry of Education, Science, Sports and Culture with a contribution from the US Department of Energy. Designed to understand the nature of neutrinos, Super-K is a leading detector in the search for MeV neutrino detections of core-collapse supernovae.
+The [Super-Kamiokande experiment](https://www-sk.icrr.u-tokyo.ac.jp/en/sk/), also known as Super-K or SK, was built and has been operated with funding from the Japanese Ministry of Education, Science, Sports and Culture, and the U.S. Department of Energy.
+The Hyper-Kamiokande experiment will be the successor of SK, it is expected to start operation around 2028.
 
 **GCN Notice Types in GCN Classic and GCN Classic Over Kafka:**
 [Detailed Descriptions and Examples](https://gcn.gsfc.nasa.gov/sk_sn.html)


### PR DESCRIPTION
# Description
Following discussion with SK Spokeperson, we noticed the description of Super-Kamiokande experiment in the mission page should better match the official sentence use in our acknowledgments. In addition, we believe it's not fully correct to present Hyper-Kamiokande as "Super-Kamiokande's upgrade" but more as its successor (since both experiments are at different location and will run separately for at least a couple of year).

# Related Issue(s)
Partially addresses #2604 

# Testing
local

<img width="648" height="391" alt="image" src="https://github.com/user-attachments/assets/78aa13db-1ba8-48a9-af14-3ff9c46ee35a" />


