### PR TITLE
Fix some issues with orderBy

### DIFF
--- a/app/routes/synonyms/synonyms.server.ts
+++ b/app/routes/synonyms/synonyms.server.ts
@@ -10,7 +10,8 @@ import { type DynamoDBDocument } from '@aws-sdk/lib-dynamodb'
 import { search as getSearchClient } from '@nasa-gcn/architect-functions-search'
 import crypto from 'crypto'
 import { slug } from 'github-slugger'
-import { orderBy } from 'lodash'
+import min from 'lodash/min.js'
+import orderBy from 'lodash/orderBy.js'
 
 import type { Circular } from '../circulars/circulars.lib'
 import type { Synonym, SynonymGroup } from './synonyms.lib'
@@ -252,7 +253,7 @@ export async function putSynonyms({
 
 export async function getOldestDate(eventId: string) {
   const circulars = await getSynonymMembers(eventId)
-  return orderBy(circulars, ['circularId'], ['asc'])[0].createdOn
+  return min(circulars.map(({ createdOn }) => createdOn))
 }
 
 /*

--- a/app/table-streams/synonyms/index.ts
+++ b/app/table-streams/synonyms/index.ts
@@ -8,7 +8,7 @@
 import { search as getSearchClient } from '@nasa-gcn/architect-functions-search'
 import { errors } from '@opensearch-project/opensearch'
 import type { DynamoDBRecord } from 'aws-lambda'
-import { orderBy } from 'lodash'
+import min from 'lodash/min.js'
 
 import { unmarshallTrigger } from '../utils'
 import { createTriggerHandler } from '~/lib/lambdaTrigger.server'
@@ -49,8 +49,9 @@ export const handler = createTriggerHandler(
           const synonyms = await getSynonymsByUuid(synonymId)
 
           if (synonyms.length > 0) {
-            const oldestDate = orderBy(synonyms, ['initialDate'], ['asc'])[0]
-              .initialDate
+            const oldestDate = min(
+              synonyms.map(({ initialDate }) => initialDate)
+            )!
 
             await putIndex({
               synonymId,

--- a/sandbox-search.js
+++ b/sandbox-search.js
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { readFile } from 'fs/promises'
-import orderBy from 'lodash/orderBy.js'
+import min from 'lodash/min.js'
 
 export default async function () {
   const text = await readFile('seed.json', { encoding: 'utf-8' })
@@ -18,7 +18,7 @@ export default async function () {
       synonymId,
       eventIds: values.map(({ eventId }) => eventId),
       slugs: values.map(({ slug }) => slug),
-      initialDate: orderBy(values, ['initialDate'], ['asc'])[0].initialDate,
+      initialDate: min(values.map(({ initialDate }) => initialDate)),
     },
   ])
   return [


### PR DESCRIPTION
- orderBy is O(N log N), but we can replace most instances of this with min, which is O(N).
- Use tree-shakeable lodash imports for smaller code bundles.
- Fix incorrect assumption that the Circular withe least ID is the oldest Circular.