### PR TITLE
Playwright: address failing tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: Boolean(process.env.CI),
   /* Retry on CI only */
-  retries: 3,
+  retries: 5,
   /* Opt out of parallel tests on CI. */
   // workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -70,6 +70,6 @@ export default defineConfig({
     url: 'http://localhost:3333',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
-    timeout: 240 * 1000, // 240 Seconds timeout on webServer
+    timeout: 300 * 1000, // 300 Seconds timeout on webServer
   },
 })


### PR DESCRIPTION
# Description
Experimenting with different means of resolving the playwright timeout errors. This boosts the number of retries before giving up on a test as well as the timeout on the webServer.

# Related Issue(s)
#3163
