### PR TITLE
Reword client credential documentation

### DIFF
--- a/app/routes/docs.client._index.mdx
+++ b/app/routes/docs.client._index.mdx
@@ -7,7 +7,7 @@ import { ClientSampleCode } from '~/components/ClientSampleCode'
 
 # Kafka Client Setup
 
-See our [Start Streaming GCN Notices quick start guide](/quickstart) for a step-by-step walkthrough to begin streaming alerts now! See [documentation](/docs/faq#why-are-my-kafka-client-credentials-expiring) on Client Credential expiration for more details.
+See our [Start Streaming GCN Notices quick start guide](/quickstart) for a step-by-step walkthrough to begin streaming alerts now!
 
 ## Python
 

--- a/app/routes/docs.faq/route.mdx
+++ b/app/routes/docs.faq/route.mdx
@@ -102,7 +102,7 @@ To get started, [sign in or sign up](https://gcn.nasa.gov/login) and then select
 
 ### Why are my Kafka client credentials expiring?
 
-For security purposes, we will disable client credentials that you have not used to connect to a Kafka broker for 30 the past days. We will email you reminders 9 days before client credentials will expire. Once disabled, a client credential cannot be used again. To prevent a credential from expiring and being disabled, simply use it to connect to a Kafka broker. You may create new client credentials at any time. To review, create, delete, and manage your client credentials, see your account [client credential settings](https://gcn.nasa.gov/user/credentials).
+For security purposes, we will disable client credentials that you have not used to connect to a Kafka broker for the past 30 days. We will email you reminders 9 days before client credentials will expire. Once disabled, a client credential cannot be used again. To prevent a credential from expiring and being disabled, simply use it to connect to a Kafka broker. You may create new client credentials at any time. To review, create, delete, and manage your client credentials, see your account [client credential settings](https://gcn.nasa.gov/user/credentials).
 
 ## Circulars
 

--- a/app/routes/docs.faq/route.mdx
+++ b/app/routes/docs.faq/route.mdx
@@ -102,7 +102,7 @@ To get started, [sign in or sign up](https://gcn.nasa.gov/login) and then select
 
 ### Why are my Kafka client credentials expiring?
 
-GCN has updated our security practices to disable disused Kafka client credentials that have not connected to one of our Kafka brokers within the last month. The [client credentials page](/user/credentials) lists the date that the credential was last used to connect to one of the GCN Kafka brokers. Users will receive an email warning in advance of the expiration date. Connecting that client credential to one of the GCN Kafka brokers after the warning email will update the last used date and postpone the expiration. Users may delete expired client credentials and generate new client credentials at any time in the [client credential page](/user/credentials).
+For security purposes, we will disable client credentials that you have not used to connect to a Kafka broker for 30 the past days. We will email you reminders 9 days before client credentials will expire. Once disabled, a client credential cannot be used again. To prevent a credential from expiring and being disabled, simply use it to connect to a Kafka broker. You may create new client credentials at any time. To review, create, delete, and manage your client credentials, see your account [client credential settings](https://gcn.nasa.gov/user/credentials).
 
 ## Circulars
 

--- a/app/routes/quickstart.credentials.tsx
+++ b/app/routes/quickstart.credentials.tsx
@@ -7,7 +7,7 @@
  */
 import type { SEOHandle } from '@nasa-gcn/remix-seo'
 import type { ActionFunctionArgs } from '@remix-run/node'
-import { Link, useLoaderData } from '@remix-run/react'
+import { useLoaderData } from '@remix-run/react'
 
 import CredentialCard from '~/components/CredentialCard'
 import {
@@ -45,15 +45,7 @@ export default function () {
         <>
           <p className="usa-paragraph">
             {explanation} Select one of your existing client credentials, or
-            create a new one. For more information about Client Credential
-            expiration see the{' '}
-            <Link
-              className="usa-link"
-              to="/docs/faq#why-are-my-kafka-client-credentials-expiring"
-            >
-              documentation
-            </Link>
-            .
+            create a new one.
           </p>
           <SegmentedCards>
             {client_credentials.map((credential) => (

--- a/app/routes/user.credentials._index.tsx
+++ b/app/routes/user.credentials._index.tsx
@@ -61,12 +61,15 @@ export default function () {
         <Link className="usa-link" to="/docs/client">
           client documentation
         </Link>
-        . For more information on Client Credential expiration, see the{' '}
+        .
+      </p>
+      <p>
+        Unused client credentials{' '}
         <Link
           className="usa-link"
           to="/docs/faq#why-are-my-kafka-client-credentials-expiring"
         >
-          documentation
+          expire after 30 days
         </Link>
         .
       </p>


### PR DESCRIPTION
- Make verbs more active.
- Shorten text.
- Make link text more descriptive and natural.
- Remove links that are out of place.
- Be precise about when credentials expire: after 30 days, not after one month.