### PR TITLE
Return 404 for API endpoints requested from the browser

### DIFF
--- a/app/lib/headers.server.ts
+++ b/app/lib/headers.server.ts
@@ -54,3 +54,16 @@ export function pickHeaders(headers: Headers, keys: string[]) {
   }
   return result
 }
+
+/**
+ * Throw 404 Not Found if request headers indicate that the request is from
+ * a browser. Intended for use in routes that are only intended to be used as
+ * API endpoints.
+ */
+export function notFoundIfBrowserRequest(headers: Headers) {
+  const acceptHeader = headers.get('accept') || ''
+  const isHtmlRequest = acceptHeader.includes('text/html')
+  if (isHtmlRequest) {
+    throw new Response(null, { status: 404 })
+  }
+}

--- a/app/routes/api.circulars.ts
+++ b/app/routes/api.circulars.ts
@@ -29,6 +29,7 @@ import {
   getUserGroupStrings,
 } from '~/lib/cognito.server'
 import { getEnvOrDie } from '~/lib/env.server'
+import { notFoundIfBrowserRequest } from '~/lib/headers.server'
 
 // FIXME: BaseClient.validateJWT is non-private but undocumented.
 // openid-client doesn't provide a type for it.
@@ -171,6 +172,7 @@ async function getUserAttributes(Username: string) {
  * A new circular version will be created.
  */
 export async function action({ request }: ActionFunctionArgs) {
+  notFoundIfBrowserRequest(request.headers)
   if (!['PUT', 'POST'].includes(request.method))
     throw new Response(null, { status: 405 })
 

--- a/app/routes/api.synonym.circulars.ts
+++ b/app/routes/api.synonym.circulars.ts
@@ -8,19 +8,12 @@
 import type { LoaderFunctionArgs } from '@remix-run/node'
 
 import { getAllSynonymMembers } from './synonyms/synonyms.server'
+import { notFoundIfBrowserRequest } from '~/lib/headers.server'
 
 export async function loader({
   request: { headers, url },
 }: LoaderFunctionArgs) {
-  // This route exists only to fetch data. If the route is accessed via
-  // the browser, throw a 404.
-  const acceptHeader = headers.get('accept') || ''
-  const isHtmlRequest = acceptHeader.includes('text/html')
-
-  if (isHtmlRequest) {
-    throw new Response('Not Found', { status: 404 })
-  }
-
+  notFoundIfBrowserRequest(headers)
   const parsedUrl = new URL(url)
   const eventIds = parsedUrl.searchParams.getAll('eventIds')
 

--- a/app/routes/api.tooltip.arxiv.$.ts
+++ b/app/routes/api.tooltip.arxiv.$.ts
@@ -9,10 +9,17 @@ import { type LoaderFunctionArgs, json } from '@remix-run/node'
 import { DOMParser } from '@xmldom/xmldom'
 import invariant from 'tiny-invariant'
 
-import { publicStaticShortTermCacheControlHeaders } from '~/lib/headers.server'
+import {
+  notFoundIfBrowserRequest,
+  publicStaticShortTermCacheControlHeaders,
+} from '~/lib/headers.server'
 import { throwForStatus } from '~/lib/utils'
 
-export async function loader({ params: { '*': value } }: LoaderFunctionArgs) {
+export async function loader({
+  request: { headers },
+  params: { '*': value },
+}: LoaderFunctionArgs) {
+  notFoundIfBrowserRequest(headers)
   invariant(value)
 
   const url = new URL('https://export.arxiv.org/api/query')

--- a/app/routes/api.tooltip.circular.$.ts
+++ b/app/routes/api.tooltip.circular.$.ts
@@ -9,9 +9,16 @@ import { type LoaderFunctionArgs, json } from '@remix-run/node'
 import invariant from 'tiny-invariant'
 
 import { get } from './circulars/circulars.server'
-import { publicStaticShortTermCacheControlHeaders } from '~/lib/headers.server'
+import {
+  notFoundIfBrowserRequest,
+  publicStaticShortTermCacheControlHeaders,
+} from '~/lib/headers.server'
 
-export async function loader({ params: { '*': value } }: LoaderFunctionArgs) {
+export async function loader({
+  request: { headers },
+  params: { '*': value },
+}: LoaderFunctionArgs) {
+  notFoundIfBrowserRequest(headers)
   invariant(value)
   const { subject, submitter } = await get(parseFloat(value))
   return json(

--- a/app/routes/api.tooltip.doi.$.ts
+++ b/app/routes/api.tooltip.doi.$.ts
@@ -10,13 +10,20 @@ import { term } from 'lucene'
 import invariant from 'tiny-invariant'
 
 import { getEnvOrDieInProduction } from '~/lib/env.server'
-import { publicStaticShortTermCacheControlHeaders } from '~/lib/headers.server'
+import {
+  notFoundIfBrowserRequest,
+  publicStaticShortTermCacheControlHeaders,
+} from '~/lib/headers.server'
 import { throwForStatus } from '~/lib/utils'
 import { stripTags } from '~/lib/utils.server'
 
 const adsTokenTooltip = getEnvOrDieInProduction('ADS_TOKEN_TOOLTIP')
 
-export async function loader({ params: { '*': value } }: LoaderFunctionArgs) {
+export async function loader({
+  request: { headers },
+  params: { '*': value },
+}: LoaderFunctionArgs) {
+  notFoundIfBrowserRequest(headers)
   invariant(value)
 
   const url = new URL('https://api.adsabs.harvard.edu/v1/search/query')

--- a/app/routes/api.tooltip.tns.$.ts
+++ b/app/routes/api.tooltip.tns.$.ts
@@ -9,12 +9,19 @@ import { type LoaderFunctionArgs, json } from '@remix-run/node'
 import invariant from 'tiny-invariant'
 
 import { getEnvOrDie } from '~/lib/env.server'
-import { publicStaticShortTermCacheControlHeaders } from '~/lib/headers.server'
+import {
+  notFoundIfBrowserRequest,
+  publicStaticShortTermCacheControlHeaders,
+} from '~/lib/headers.server'
 import { throwForStatus } from '~/lib/utils'
 
 const splitter = /[:.]/
 
-export async function loader({ params: { '*': value } }: LoaderFunctionArgs) {
+export async function loader({
+  request: { headers },
+  params: { '*': value },
+}: LoaderFunctionArgs) {
+  notFoundIfBrowserRequest(headers)
   invariant(value)
 
   const tnsBotName = getEnvOrDie('TNS_BOT_NAME')

--- a/app/routes/api.users.ts
+++ b/app/routes/api.users.ts
@@ -9,12 +9,14 @@ import {
   listUsers,
   listUsersInGroup,
 } from '~/lib/cognito.server'
+import { notFoundIfBrowserRequest } from '~/lib/headers.server'
 import { getFormDataString } from '~/lib/utils'
 
 // Groups verified users are allowed to search
 const filterableGroups = [submitterGroup]
 
 export async function action({ request }: ActionFunctionArgs) {
+  notFoundIfBrowserRequest(request.headers)
   const user = await getUser(request)
   if (!user) throw new Response(null, { status: 403 })
   const userIsAdmin = user.groups.includes(adminGroup)


### PR DESCRIPTION
Refactor code that was only present in one API endpoint so that it is shared in common with all API endpoints.