### PR TITLE
Display circulars in group view in descending order

### DIFF
--- a/app/routes/api.synonym.circulars.ts
+++ b/app/routes/api.synonym.circulars.ts
@@ -24,5 +24,7 @@ export async function loader({
   const parsedUrl = new URL(url)
   const eventIds = parsedUrl.searchParams.getAll('eventIds')
 
-  return eventIds?.length ? await getAllSynonymMembers(eventIds) : []
+  return eventIds?.length
+    ? (await getAllSynonymMembers(eventIds)).reverse()
+    : []
 }


### PR DESCRIPTION
Just like the non-grouped view, the Circulars should be listed in reverse chronological order.