### PR TITLE
Give groups of events meaningful page titles

### DIFF
--- a/app/routes/circulars.events.$slug.tsx
+++ b/app/routes/circulars.events.$slug.tsx
@@ -20,8 +20,8 @@ import { PlainTextBody } from '~/components/circularDisplay/Body'
 import { FrontMatter } from '~/components/circularDisplay/FrontMatter'
 import type { BreadcrumbHandle } from '~/root/Title'
 
-export const handle: BreadcrumbHandle = {
-  breadcrumb: 'Circular Event Group',
+export const handle: BreadcrumbHandle<Awaited<ReturnType<typeof loader>>> = {
+  breadcrumb: ({ data: { eventIds } }) => eventIds.join(', '),
 }
 
 export async function loader({ params: { slug } }: LoaderFunctionArgs) {

--- a/app/routes/circulars.events/route.tsx
+++ b/app/routes/circulars.events/route.tsx
@@ -11,7 +11,7 @@ import { GridContainer } from '@trussworks/react-uswds'
 import type { BreadcrumbHandle } from '~/root/Title'
 
 export const handle: BreadcrumbHandle = {
-  breadcrumb: 'Circular Group',
+  breadcrumb: 'Events',
 }
 
 export default function () {


### PR DESCRIPTION
- Change parent breadcrumb from "Circular Groups" to "Events"
- Use event names as page title