### PR TITLE
Preserve search params in event link

### DIFF
--- a/app/components/circularDisplay/FrontMatter.tsx
+++ b/app/components/circularDisplay/FrontMatter.tsx
@@ -11,6 +11,7 @@ import { slug } from 'github-slugger'
 import type { ReactNode } from 'react'
 
 import TimeAgo from '~/components/TimeAgo'
+import { useSearchString } from '~/lib/utils'
 import { type Circular, formatDateISO } from '~/routes/circulars/circulars.lib'
 
 const submittedHowMap = {
@@ -55,12 +56,15 @@ export function FrontMatter({
   | 'editedBy'
   | 'editedOn'
 >) {
+  const searchString = useSearchString()
   return (
     <>
       <FrontMatterItem label="Subject">{subject}</FrontMatterItem>
       {eventId && (
         <FrontMatterItem label="Event">
-          <Link to={`/circulars/events/${slug(eventId)}`}>{eventId}</Link>
+          <Link to={`/circulars/events/${slug(eventId)}${searchString}`}>
+            {eventId}
+          </Link>
         </FrontMatterItem>
       )}
       <FrontMatterItem label="Date">


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
This adds the search parameters to the event link in the circular page header so they aren't wiped when using in-page navigation.

# Related Issue(s)
<!-- Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
Example:
`Resolves #100` -->
Resolves #3273 

# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->
1. Search for any term, like "LIGO"
2. Navigate to a circular with an associated event
3. Click on event link in header
4. Press the in-page back button to return to the circular, then again when on that page to return to the archive
5. The search will not be wiped