### PR TITLE
Consolidate Circulars button bar

### DIFF
--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -95,6 +95,48 @@ export default function () {
           Back
         </Link>
         <ButtonGroup type="segmented">
+          {Number.isFinite(previousCircular) ? (
+            <Link
+              to={`/circulars/${previousCircular}${searchString}`}
+              className="usa-button"
+            >
+              <Icon.NavigateBefore
+                role="presentation"
+                className="margin-y-neg-2px"
+              />
+              Previous
+            </Link>
+          ) : (
+            <Button type="button" className="usa-button" disabled aria-disabled>
+              <Icon.NavigateBefore
+                role="presentation"
+                className="margin-y-neg-2px"
+              />
+              Previous
+            </Button>
+          )}
+          {Number.isFinite(nextCircular) ? (
+            <Link
+              to={`/circulars/${nextCircular}${searchString}`}
+              className="usa-button"
+            >
+              Next
+              <Icon.NavigateNext
+                role="presentation"
+                className="margin-y-neg-2px"
+              />
+            </Link>
+          ) : (
+            <Button type="button" className="usa-button" disabled aria-disabled>
+              Next
+              <Icon.NavigateNext
+                role="presentation"
+                className="margin-y-neg-2px"
+              />
+            </Button>
+          )}
+        </ButtonGroup>
+        <ButtonGroup type="segmented">
           <Link
             to={`${linkString}.txt`}
             className="usa-button usa-button--outline"
@@ -155,42 +197,6 @@ export default function () {
       <h1 className="margin-bottom-0">GCN Circular {circularId}</h1>
       <FrontMatter {...frontMatter} />
       <Body className="margin-y-2">{body}</Body>
-      <div className="margin-top-4 display-flex flex-justify-center gap-2">
-        {Number.isFinite(previousCircular) ? (
-          <Link
-            to={`/circulars/${previousCircular}${searchString}`}
-            className="usa-button"
-          >
-            <Icon.ArrowBack role="presentation" className="margin-y-neg-2px" />
-            Previous Circular
-          </Link>
-        ) : (
-          <Button type="button" className="usa-button" disabled aria-disabled>
-            <Icon.ArrowBack role="presentation" className="margin-y-neg-2px" />
-            Previous Circular
-          </Button>
-        )}
-        {Number.isFinite(nextCircular) ? (
-          <Link
-            to={`/circulars/${nextCircular}${searchString}`}
-            className="usa-button"
-          >
-            Next Circular
-            <Icon.ArrowForward
-              role="presentation"
-              className="margin-y-neg-2px"
-            />
-          </Link>
-        ) : (
-          <Button type="button" className="usa-button" disabled aria-disabled>
-            Next Circular
-            <Icon.ArrowForward
-              role="presentation"
-              className="margin-y-neg-2px"
-            />
-          </Button>
-        )}
-      </div>
     </>
   )
 }


### PR DESCRIPTION
- Display Next and Previous buttons at top so that the rest of the page does not visibly move when you press them.
- Shorten button text.
- Fix incorrect vertical positioning of disclosure arrow.
- Replace nonbreaking spaces with CSS positioning adjustment.

# Before

<img width="1208" height="1050" alt="Screenshot 2025-08-21 at 22 46 44" src="https://github.com/user-attachments/assets/e41623d8-83a4-48df-a17d-6eafd06b0507" />

# After

<img width="1208" height="1050" alt="Screenshot 2025-08-21 at 22 44 07" src="https://github.com/user-attachments/assets/87ecc142-d9d3-43b8-8d0d-773b5f905bf0" />
