### PR TITLE
Correct Super-K mission page topic table

### DIFF
--- a/app/routes/missions.sksn/route.mdx
+++ b/app/routes/missions.sksn/route.mdx
@@ -66,10 +66,9 @@ Super-Kamiokande specific variables:
 
 <div className="overflow-table">
 
-| Kafka topic                       | Comments                                    |
-| --------------------------------- | ------------------------------------------- |
-| `gcn.notice.superk.sn_alert.real` | For a real supernova alert                  |
-| `gcn.notice.superk.sn_alert.test` | For a test alert (generated once per month) |
+| Kafka topic                  | Comments                           |
+| ---------------------------- | ---------------------------------- |
+| `gcn.notice.superk.sn_alert` | For a real or test supernova alert |
 
  </div>
 </WithFeature>


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
The mission page says that there are 2 topics (one for test and one for real), when there is only 1 in the Quickstart.  This PR corrects the mission page.

# Related Issue(s)
Related to #2604

# Testing
local dev
