### PR TITLE
Opt in to some React Router v7 feature flags

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -109,5 +109,9 @@ export default {
         ]
       : []),
   ],
-  future: { v3_relativeSplatPath: true },
+  future: {
+    v3_lazyRouteDiscovery: true,
+    v3_relativeSplatPath: true,
+    v3_throwAbortReason: true,
+  },
 }


### PR DESCRIPTION
Activate lazyRouteDiscovery and throwAbortReason to prepare for future React Router v7 migration.