### PR TITLE
Remove ability to edit circular submit date

### DIFF
--- a/__playwright__/circulars/corrections.spec.ts
+++ b/__playwright__/circulars/corrections.spec.ts
@@ -33,7 +33,6 @@ const loadingTestsCircular = {
   subject: 'LIGO/Virgo/KAGRA S240630t: Updated Sky localization',
   eventId: 'LIGO/Virgo/KAGRA S240630t',
   submittedHow: 'web',
-  createdOn: 1719767201026,
   circularId: 36796,
   submitter:
     'Christopher P L Berry at LVK Collaboration <christopher.berry@ligo.org>',
@@ -53,8 +52,6 @@ test.describe('Circulars correction page', () => {
     await expect(page.locator('#submitter')).toHaveValue(
       loadingTestsCircular.submitter
     )
-    const testDateTime = new Date(loadingTestsCircular.createdOn).toISOString()
-    await expect(page.locator('#createdOn')).toHaveValue(testDateTime)
     await expect(page.locator('#subject')).toHaveValue(
       loadingTestsCircular.subject
     )

--- a/__playwright__/circulars/edit.spec.ts
+++ b/__playwright__/circulars/edit.spec.ts
@@ -33,7 +33,7 @@ const loadingTestsCircular = {
   subject: 'LIGO/Virgo/KAGRA S240630t: Updated Sky localization',
   eventId: 'LIGO/Virgo/KAGRA S240630t',
   submittedHow: 'web',
-  createdOn: 1719767201026,
+  // createdOn: 1719767201026,
   circularId: 36796,
   submitter:
     'Christopher P L Berry at LVK Collaboration <christopher.berry@ligo.org>',
@@ -46,7 +46,7 @@ const editTestsCircular = {
     'ZTF23aaoohpy/AT2023lcr: JWST observations consistent with the presence of a supernova',
   submittedHow: 'web',
   bibcode: '2023GCN.34370....1M',
-  createdOn: '2024-09-18 06:00',
+  // createdOn: '2024-09-18 06:00',
   circularId: 34370,
   submitter:
     'Antonio Martin-Carrillo at UCD,Space Science Group <antonio.martin-carrillo@ucd.ie>',
@@ -66,8 +66,6 @@ test.describe('Circulars edit page', () => {
     await expect(page.locator('#submitter')).toHaveValue(
       loadingTestsCircular.submitter
     )
-    const testDateTime = new Date(loadingTestsCircular.createdOn).toISOString()
-    await expect(page.locator('#createdOn')).toHaveValue(testDateTime)
     await expect(page.locator('#subject')).toHaveValue(
       loadingTestsCircular.subject
     )
@@ -81,7 +79,6 @@ test.describe('Circulars edit page', () => {
     const testSubject = `${editTestsCircular.subject} - ${browserName}`
     await page.goto(`/circulars/edit/${editTestsCircular.circularId}`)
     await page.locator('#submitter').fill(editTestsCircular.submitter)
-    await page.locator('#createdOn').fill(editTestsCircular.createdOn)
     await page.locator('#subject').fill(testSubject)
     await page.getByTestId('textarea').fill(editTestsCircular.body)
     await page.getByRole('button', { name: 'Update' }).click({ timeout: 10000 })

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -110,9 +110,6 @@ export async function action({ request }: ActionFunctionArgs) {
     throw new Response('Body and subject are required', { status: 400 })
   const user = await getUser(request)
   const circularId = getFormDataString(data, 'circularId')
-  const createdOnDate =
-    getFormDataString(data, 'createdOn') || Date.now().toString()
-  const createdOn = Date.parse(createdOnDate)
   let newCircular
   const props = { body, subject, eventId, ...(format ? { format } : {}) }
   switch (intent) {
@@ -126,9 +123,6 @@ export async function action({ request }: ActionFunctionArgs) {
         submitter = getFormDataString(data, 'submitter')
         if (!submitter) throw new Response(null, { status: 400 })
       }
-
-      if (!createdOnDate || !createdOn)
-        throw new Response(null, { status: 400 })
 
       let zendeskTicketId: number | undefined
 
@@ -157,7 +151,6 @@ export async function action({ request }: ActionFunctionArgs) {
           circularId: parseFloat(circularId),
           ...props,
           submitter,
-          createdOn,
           zendeskTicketId,
           eventId,
         },
@@ -168,13 +161,11 @@ export async function action({ request }: ActionFunctionArgs) {
     case 'edit':
       if (circularId === undefined)
         throw new Response('circularId is required', { status: 400 })
-      if (!createdOnDate || !createdOn)
-        throw new Response(null, { status: 400 })
+
       await putVersion(
         {
           circularId: parseFloat(circularId),
           ...props,
-          createdOn,
         },
         user
       )

--- a/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
+++ b/app/routes/circulars.edit.$circularId/CircularEditForm.tsx
@@ -23,7 +23,6 @@ import { dedent } from 'ts-dedent'
 import {
   type CircularFormat,
   bodyIsValid,
-  dateTimeIsValid,
   parseEventFromSubject,
   subjectIsValid,
   submitterIsValid,
@@ -136,7 +135,6 @@ export function CircularEditForm({
   const [body, setBody] = useState(defaultBody)
   const [subject, setSubject] = useState(defaultSubject)
   const [format, setFormat] = useState(defaultFormat)
-  const [dateTime, setDateTime] = useState(defaultCreatedOnDateTime ?? '')
   const [submitter, setSubmitter] = useState(defaultSubmitter)
   const subjectValid = subjectIsValid(subject)
   const derivedEventId = parseEventFromSubject(subject)
@@ -149,9 +147,8 @@ export function CircularEditForm({
   const [eventId, setEventId] = useState(defaultEventId)
   const submitterValid = circularId ? submitterIsValid(submitter) : true
   const bodyValid = bodyIsValid(body)
-  const dateTimeValid = circularId ? dateTimeIsValid(dateTime) : true
   const sending = Boolean(useNavigation().formData)
-  const valid = subjectValid && bodyValid && dateTimeValid && submitterValid
+  const valid = subjectValid && bodyValid && submitterValid
   let headerText, saveButtonText
 
   switch (intent) {
@@ -174,7 +171,6 @@ export function CircularEditForm({
     subject.trim() !== defaultSubject.trim() ||
     format !== defaultFormat ||
     submitter?.trim() !== defaultSubmitter ||
-    dateTime !== defaultCreatedOnDateTime ||
     eventId?.trim() !== originalEventId
 
   const userIsModerator = useModStatus()
@@ -229,25 +225,6 @@ export function CircularEditForm({
             </Button>
           </Link>
         </InputGroup>
-        {circularId !== undefined && (
-          <InputGroup
-            className={classnames('maxw-full', {
-              'usa-input--error': !dateTime || !Date.parse(dateTime),
-              'usa-input--success': dateTime && Date.parse(dateTime),
-            })}
-          >
-            <InputPrefix className="wide-input-prefix">Date</InputPrefix>
-            <input
-              defaultValue={defaultCreatedOnDateTime}
-              onInput={({ currentTarget: { value } }) => {
-                setDateTime(value)
-              }}
-              name="createdOn"
-              id="createdOn"
-              className="maxw-full"
-            />
-          </InputGroup>
-        )}
         <InputGroup
           className={classnames('maxw-full', {
             'usa-input--error': subjectValid === false,


### PR DESCRIPTION
Removes the date fields from the edit form and from the action function to prevent edits to existing circulars.

Also removes the date from the related sections in the tests

Resolves #3259