### PR TITLE
Don't segment date selector dropdown button

### DIFF
--- a/app/routes/circulars._archive._index/DateSelectorMenu.tsx
+++ b/app/routes/circulars._archive._index/DateSelectorMenu.tsx
@@ -8,7 +8,6 @@
 import { useSubmit } from '@remix-run/react'
 import {
   Button,
-  ButtonGroup,
   CardBody,
   CardFooter,
   DateRangePicker,
@@ -36,36 +35,37 @@ function DateSelectorButton({
   startDate,
   endDate,
   expanded,
+  className,
   ...props
 }: {
   startDate?: string
   endDate?: string
   expanded?: boolean
-} & Omit<Parameters<typeof ButtonGroup>[0], 'segmented' | 'children'>) {
+} & Omit<Parameters<typeof Button>[0], 'children' | 'type'>) {
   const slimClasses = 'padding-y-1'
 
   return (
-    <ButtonGroup type="segmented" {...props}>
-      <Button type="button" className={`${slimClasses} padding-x-2`}>
-        {(startDate && dateSelectorLabels[startDate]) ||
-          (startDate && endDate && (
-            <>
-              {startDate}—{endDate}
-            </>
-          )) ||
-          (startDate && <>After {startDate}</>) ||
-          (endDate && <>Before {endDate}</>) ||
-          'Filter by date'}
-      </Button>
-      <Button type="button" className={`${slimClasses} padding-x-1`}>
-        <Icon.CalendarToday role="presentation" />
-        {expanded ? (
-          <Icon.ExpandLess role="presentation" />
-        ) : (
-          <Icon.ExpandMore role="presentation" />
-        )}
-      </Button>
-    </ButtonGroup>
+    <Button
+      type="button"
+      className={classNames(className, slimClasses, 'padding-x-2')}
+      {...props}
+    >
+      <Icon.CalendarToday role="presentation" />
+      {(startDate && dateSelectorLabels[startDate]) ||
+        (startDate && endDate && (
+          <>
+            {startDate}—{endDate}
+          </>
+        )) ||
+        (startDate && <>After {startDate}</>) ||
+        (endDate && <>Before {endDate}</>) ||
+        'Filter by date'}
+      {expanded ? (
+        <Icon.ExpandLess role="presentation" />
+      ) : (
+        <Icon.ExpandMore role="presentation" />
+      )}
+    </Button>
   )
 }
 


### PR DESCRIPTION
The segmentation conveys the mistaken impression that clicking one side of the button does something different from clicking the other side of the button.

# Before

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 - 2025-09-09 at 11 25 56" src="https://github.com/user-attachments/assets/c4281ce5-11bb-4207-862a-abe5e8c928cd" />

# After

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 - 2025-09-09 at 11 23 41" src="https://github.com/user-attachments/assets/50f55e00-34f6-4fbe-a0a9-54e5ba02cb25" />
