### PR TITLE
Replace paginateQuery with paginateScan

### DIFF
--- a/app/scheduled/app-client-expire/index.ts
+++ b/app/scheduled/app-client-expire/index.ts
@@ -45,7 +45,7 @@ export async function handler() {
         'attribute_not_exists(expired) and (lastUsed < :warningCutoff or (attribute_not_exists(lastUsed) and created < :warningCutoff))',
       TableName,
       ExpressionAttributeValues: {
-        ':warningCutoff': { N: warningCutoff.toString() },
+        ':warningCutoff': warningCutoff,
       },
     }
   )


### PR DESCRIPTION
Cloudwatch is throwing the following error:
```
"errorType": "ValidationException",
"errorMessage": "Either the KeyConditions or KeyConditionExpression parameter must be specified in the request.",
```
This is likely due to trying to run a paginateQuery without a key expression. This should fix the issue