### PR TITLE
Examples Consistent With the Core Schema

### DIFF
--- a/app/routes/docs.notices.producers.mdx
+++ b/app/routes/docs.notices.producers.mdx
@@ -67,7 +67,9 @@ also happy to work with the mission teams to help construct your alerts.
       # Connect as a producer.
       # Warning: don't share the client secret with others.
       producer = Producer(client_id='fill me in', client_secret='fill me in')
-      # any topic starting with 'mission.'
+      # Choose the right topic for this notice.  If your mission has
+      # multiple topics, they all start with 'gcn.notices.mission.'
+      # If there is only one topic, it will be simply as follows:
       topic = 'gcn.notices.mission'
       # JSON data converted to byte string format
       data = json.dumps({

--- a/app/routes/docs.sample.json.md
+++ b/app/routes/docs.sample.json.md
@@ -44,7 +44,7 @@ for message in consumer.consume(timeout=1):
 
 ## Decoding Embedded Data
 
-Some GCN notices include HEALPix sky maps encoded in [base64](https://datatracker.ietf.org/doc/html/rfc4648.html), a way of encoding binary data into text.
+Some GCN notices include HEALPix sky maps encoded in [Base 64](https://datatracker.ietf.org/doc/html/rfc4648.html), a way of encoding binary data into text.
 The following code demonstrates how to extract, decode, and save the HEALPix data as a `.fits` file from a received notice. Python's built-in [`base64`](https://docs.python.org/3/library/base64.html#base64.b64encode) module provides the `b64decode` method to simplify the decoding process.
 
 ```python

--- a/app/routes/docs.sample.json.md
+++ b/app/routes/docs.sample.json.md
@@ -68,14 +68,13 @@ with fits.open("skymap.fits") as hdul:
 
 ## JSON Schema Example for Embedding a FITS File
 
-If you want your notices to be able to include a FITS file with 
-a HEALPix localization map, just `"$ref"` the Core Localization 
-schema from your schema and then embed the FITS file in the
-`"healpix_file"` property (see also the next example.)  If you
-want to be able to include a second HEALPix or other binary
-data, you need to declare your own property.  For example, if
-your notice carries a PDF contour plot, the new property can
-look like the following.
+Use the `"healpix_file"` property of te the Core Localization 
+schema to embed the FITS file of a HEALPix localization map
+(see also the next example.)
+If you want to be able to include a second HEALPix or other
+binary data, you need to declare your own property.
+For example, if your notice carries a PDF contour plot,
+the new property can look like the following.
 
 ```json
 "contours_file": {


### PR DESCRIPTION
# Description

1. The `dict` keys in the examples `["event"][skymap"]` changed to `"healpix_file"`.  
2. Edited the narrative for the JSON Schema example for embedding a file, incl. a description of the following example. Changed the property name in the schema snippet, which is supposed to be mission-specific, so it doesn't conflict with the Core schema.  Adjusted the `"description"` accordingly.
3. Replaced the topic in the Parsing and Encoding examples to follow the GCN topics pattern.  The new topic is also used as an example elsewhere in the docs. 
4. Fixed a possible typo: "base64" -> "Base 64" -- the name of the encoding vs. the python module or the MIME type, etc.