### PR TITLE
Count the number of times each app client is used

### DIFF
--- a/app/eventbridge/app-clients/index.ts
+++ b/app/eventbridge/app-clients/index.ts
@@ -79,12 +79,16 @@ export async function handler(
   })
   await db.client_credentials.update({
     Key: { sub, client_id },
-    UpdateExpression: 'set #lastUsed = :lastUsed',
+    UpdateExpression:
+      'set #lastUsed = :lastUsed, #countUsed = if_not_exists(#countUsed, :countUsedDefault) + :countUsedIncrement',
     ExpressionAttributeNames: {
       '#lastUsed': 'lastUsed',
+      '#countUsed': 'countUsed',
     },
     ExpressionAttributeValues: {
       ':lastUsed': Date.parse(event.detail.eventTime),
+      ':countUsedIncrement': 1,
+      ':countUsedDefault': 0,
     },
   })
 }

--- a/app/routes/user.credentials/client_credentials.server.ts
+++ b/app/routes/user.credentials/client_credentials.server.ts
@@ -25,6 +25,7 @@ export interface RedactedClientCredential {
   created: number
   lastUsed?: number
   expired?: number
+  countUsed?: number
 }
 
 export interface ClientCredential extends RedactedClientCredential {
@@ -72,7 +73,7 @@ export class ClientCredentialVendingMachine {
         ':sub': this.#sub,
       },
       ProjectionExpression:
-        'client_id, #name, #scope, created, lastUsed, expired',
+        'client_id, #name, #scope, created, lastUsed, countUsed, expired',
     })
     const credentials = results.Items as RedactedClientCredential[]
     credentials.sort((a, b) => a.created - b.created)


### PR DESCRIPTION
We suspect that some users have an inefficient single-shot client usage pattern.