### PR TITLE
Replace backslashed to fix path on Windows

### DIFF
--- a/app/lib/schema-data.server.ts
+++ b/app/lib/schema-data.server.ts
@@ -8,8 +8,7 @@
 import { RequestError } from '@octokit/request-error'
 import { Octokit } from '@octokit/rest'
 import memoizee from 'memoizee'
-import { basename, dirname, extname } from 'path'
-import { join, relative } from 'path/posix'
+import { basename, dirname, extname, join, relative } from 'path/posix'
 
 import { getEnvOrDieInProduction } from './env.server'
 import { exampleSuffix, schemaSuffix } from './schema-data'


### PR DESCRIPTION
This resolves an issue on Windows where the path joining causes the Schema Browser to error out locally.