### PR TITLE
Add a config.arc to extend the timeout

### DIFF
--- a/build/scheduled/app-client-expire/config.arc
+++ b/build/scheduled/app-client-expire/config.arc
@@ -1,0 +1,2 @@
+@aws
+timeout 900


### PR DESCRIPTION
This should bump the timeout time for the new lambda