### PR TITLE
Add producer samples for python and javascript

### DIFF
--- a/__tests__/components/ClientSampleCode.tsx
+++ b/__tests__/components/ClientSampleCode.tsx
@@ -38,7 +38,7 @@ describe('ClientSampleCode', () => {
     expect(container.querySelector('.language-py')).not.toBeNull()
     expect(getByText('pip')).toHaveAttribute('href', 'https://pip.pypa.io/')
     expect(getByText('conda')).toHaveAttribute('href', 'https://docs.conda.io/')
-    expect(getByText(`example.py`)).toBeInTheDocument()
+    expect(getByText(`example-consumer.py`)).toBeInTheDocument()
     expect(container.textContent).toContain(clientId)
     expect(container.textContent).toContain(clientSecret)
     expect(container.textContent).toContain(topics[0])

--- a/__tests__/components/ClientSampleCode.tsx
+++ b/__tests__/components/ClientSampleCode.tsx
@@ -30,6 +30,7 @@ describe('ClientSampleCode', () => {
         clientSecret={clientSecret}
         listTopics={false}
         language="py"
+        groupType="consumer"
       />
     )
 
@@ -56,6 +57,7 @@ describe('ClientSampleCode', () => {
         clientSecret={clientSecret}
         listTopics={false}
         language="py"
+        groupType="consumer"
       />
     )
     expect(container.textContent).toContain(domain)
@@ -75,6 +77,7 @@ describe('ClientSampleCode', () => {
         clientSecret={clientSecret}
         listTopics={false}
         language="py"
+        groupType="consumer"
       />
     )
 
@@ -98,6 +101,7 @@ describe('ClientSampleCode', () => {
         listTopics
         language="py"
         topics={[]}
+        groupType="consumer"
       />
     )
 

--- a/app/components/ClientSampleCode.tsx
+++ b/app/components/ClientSampleCode.tsx
@@ -21,6 +21,7 @@ export function ClientSampleCode({
     'gcn.classic.text.LVC_INITIAL',
   ],
   language,
+  groupType,
 }: {
   clientName?: string
   clientId?: string
@@ -28,6 +29,7 @@ export function ClientSampleCode({
   listTopics?: boolean
   topics?: string[]
   language: 'py' | 'mjs' | 'cjs' | 'c' | 'cs' | 'java' | 'pyspark'
+  groupType: string
 }) {
   const domain = useDomain()
 
@@ -65,52 +67,26 @@ export function ClientSampleCode({
             code="conda install -c conda-forge gcn-kafka"
           />
           <p className="usa-paragraph">
-            Save the Python code below to a file called <code>example.py</code>:
+            Save the Python code below to a file called{' '}
+            <code>example-{groupType}.py</code>:
           </p>
           <Highlight
             language={language}
-            filename={`example.${language}`}
-            code={dedent(`
-            from gcn_kafka import Consumer
-
-            # Connect as a consumer${
-              clientName ? ` (client "${clientName}")` : ''
-            }
-            # Warning: don't share the client secret with others.
-            consumer = Consumer(client_id='${clientId}',
-                                client_secret='${clientSecret}'${
-                                  domain
-                                    ? `,
-                                domain='${domain}'`
-                                    : ''
-                                })
-            ${
-              listTopics
-                ? `
-            # List all topics
-            print(consumer.list_topics().topics)
-            `
-                : ''
-            }
-            # Subscribe to topics and receive alerts
-            consumer.subscribe([${topics.map((topic) => `'${topic}'`).join(`,
-                                `)}])
-            while True:
-                for message in consumer.consume(timeout=1):
-                    if message.error():
-                        print(message.error())
-                        continue
-                    # Print the topic and message ID
-                    print(f'topic={message.topic()}, offset={message.offset()}')
-                    value = message.value()
-                    print(value)
-
-            `)}
+            filename={`example-${groupType}.${language}`}
+            code={pythonCodeSample(
+              groupType,
+              clientId,
+              clientSecret,
+              domain,
+              listTopics,
+              topics,
+              clientName
+            )}
           />
           <p className="usa-paragraph">
             Run the code by typing this command in the terminal:
           </p>
-          <Highlight language="sh" code="python example.py" />
+          <Highlight language="sh" code={`python example-${groupType}.py`} />
         </>
       )
     case 'mjs':
@@ -131,70 +107,24 @@ export function ClientSampleCode({
           <Highlight language="sh" code="npm install gcn-kafka" />
           <p className="usa-paragraph">
             Save the JavaScript code below to a file called{' '}
-            <code>example.mjs</code>:
+            <code>example-{groupType}.mjs</code>:
           </p>
           <Highlight
             language={language}
-            filename={`example.${language}`}
-            code={dedent(`
-            import { Kafka } from 'gcn-kafka'
-
-            // Create a client.
-            // Warning: don't share the client secret with others.
-            const kafka = new Kafka({
-              client_id: '${clientId}',
-              client_secret: '${clientSecret}',${
-                domain
-                  ? `
-              domain: '${domain}',`
-                  : ''
-              }
-            })
-            ${
-              listTopics
-                ? `
-            // List topics
-            const admin = kafka.admin()
-            const topics = await admin.listTopics()
-            console.log(topics)
-            `
-                : ''
-            }
-            // Subscribe to topics and receive alerts
-            const consumer = kafka.consumer()
-            try {
-              await consumer.subscribe({
-                topics: [${topics
-                  .map(
-                    (topic) => `
-                    '${topic}',`
-                  )
-                  .join('')}
-                ],
-              })
-            } catch (error) {
-              if (error.type === 'TOPIC_AUTHORIZATION_FAILED')
-              {
-                console.warn('Not all subscribed topics are available')
-              } else {
-                throw error
-              }
-            }
-
-            await consumer.run({
-              eachMessage: async (payload) => {
-                const value = payload.message.value
-                console.log(\`topic=\${payload.topic}, offset=\${payload.message.offset}\`)
-                console.log(value?.toString())
-              },
-            })
-
-            `)}
+            filename={`example-${groupType}.${language}`}
+            code={mjsCodeSample(
+              groupType,
+              clientId,
+              clientSecret,
+              domain,
+              listTopics,
+              topics
+            )}
           />
           <p className="usa-paragraph">
             Run the code by typing this command in the terminal:
           </p>
-          <Highlight language="sh" code="node example.mjs" />
+          <Highlight language="sh" code={`node example-${groupType}.mjs`} />
         </>
       )
     case 'cjs':
@@ -219,68 +149,20 @@ export function ClientSampleCode({
           </p>
           <Highlight
             language={language}
-            filename={`example.${language}`}
-            code={dedent(`
-            const { Kafka } = require('gcn-kafka');
-
-            (async () => {
-              // Create a client.
-              // Warning: don't share the client secret with others.
-              const kafka = new Kafka({
-                client_id: '${clientId}',
-                client_secret: '${clientSecret}',${
-                  domain
-                    ? `
-                domain: '${domain}',`
-                    : ''
-                }
-              })
-            ${
-              listTopics
-                ? `
-              // List topics
-              const admin = kafka.admin()
-              const topics = await admin.listTopics()
-              console.log(topics)
-              `
-                : ''
-            }
-              // Subscribe to topics and receive alerts
-              const consumer = kafka.consumer()
-              try {
-                await consumer.subscribe({
-                  topics: [${topics
-                    .map(
-                      (topic) => `
-                      '${topic}',`
-                    )
-                    .join('')}
-                  ],
-                })
-              } catch (error) {
-                if (error.type === 'TOPIC_AUTHORIZATION_FAILED')
-                {
-                  console.warn('Not all subscribed topics are available')
-                } else {
-                  throw error
-                }
-              }
-
-              await consumer.run({
-                eachMessage: async (payload) => {
-                  const value = payload.message.value
-                  console.log(\`topic=\${payload.topic}, offset=\${payload.message.offset}\`)
-                  console.log(value?.toString())
-                },
-              })
-            })()
-
-            `)}
+            filename={`example-${groupType}.${language}`}
+            code={cjsSampleCode(
+              groupType,
+              clientId,
+              clientSecret,
+              domain,
+              listTopics,
+              topics
+            )}
           />
           <p className="usa-paragraph">
             Run the code by typing this command in the terminal:
           </p>
-          <Highlight language="sh" code="node example.cjs" />
+          <Highlight language="sh" code={`node example-${groupType}.cjs`} />
         </>
       )
     case 'c':
@@ -693,4 +575,227 @@ export function ClientSampleCode({
         </>
       )
   }
+}
+
+function pythonCodeSample(
+  groupType: string,
+  clientId: string,
+  clientSecret: string,
+  domain: 'dev.gcn.nasa.gov' | 'test.gcn.nasa.gov' | null,
+  listTopics: boolean,
+  topics: string[],
+  clientName?: string
+): string {
+  if (groupType === 'consumer') {
+    return dedent(`
+  from gcn_kafka import Consumer
+
+  # Connect as a consumer${clientName ? ` (client "${clientName}")` : ''}
+  # Warning: don't share the client secret with others.
+  consumer = Consumer(client_id='${clientId}',
+                      client_secret='${clientSecret}'${
+                        domain
+                          ? `,
+                      domain='${domain}'`
+                          : ''
+                      })
+  ${
+    listTopics
+      ? `
+  # List all topics
+  print(consumer.list_topics().topics)
+  `
+      : ''
+  }
+  # Subscribe to topics and receive alerts
+  consumer.subscribe([${topics.map((topic) => `'${topic}'`).join(`,
+                      `)}])
+  while True:
+      for message in consumer.consume(timeout=1):
+          if message.error():
+              print(message.error())
+              continue
+          # Print the topic and message ID
+          print(f'topic={message.topic()}, offset={message.offset()}')
+          value = message.value()
+          print(value)
+
+    `)
+  } else {
+    return dedent(`
+  from gcn_kafka import Producer
+  import json
+
+  producer = Producer(
+      client_id="${clientId}",
+      client_secret="${clientSecret}"${
+        domain
+          ? `,
+      domain='${domain}'`
+          : ''
+      }
+  )
+  data = json.dumps(
+      {
+          # Fill in your alert data here
+          "key": "value"
+      }
+  ).encode()
+
+  # Only produce your messages to a single Kafka Topic
+  producer.produce("${topics[0]}", data)
+  producer.flush()
+      `)
+  }
+}
+
+function mjsCodeSample(
+  groupType: string,
+  clientId: string,
+  clientSecret: string,
+  domain: 'dev.gcn.nasa.gov' | 'test.gcn.nasa.gov' | null,
+  listTopics: boolean,
+  topics: string[]
+) {
+  return dedent(`
+  import { Kafka } from 'gcn-kafka'
+
+  // Create a client.
+  // Warning: don't share the client secret with others.
+  const kafka = new Kafka({
+    client_id: '${clientId}',
+    client_secret: '${clientSecret}',${
+      domain
+        ? `
+    domain: '${domain}',`
+        : ''
+    }
+  })
+  ${
+    listTopics
+      ? `
+  // List topics
+  const admin = kafka.admin()
+  const topics = await admin.listTopics()
+  console.log(topics)
+  `
+      : ''
+  }
+  ${
+    groupType === 'consumer'
+      ? `
+    // Subscribe to topics and receive alerts
+    const consumer = kafka.consumer()
+    try {
+      await consumer.subscribe({
+        topics: [${topics
+          .map(
+            (topic) => `
+            '${topic}',`
+          )
+          .join('')}
+        ],
+      })
+    } catch (error) {
+      if (error.type === 'TOPIC_AUTHORIZATION_FAILED')
+      {
+        console.warn('Not all subscribed topics are available')
+      } else {
+        throw error
+      }
+    }
+
+    await consumer.run({
+      eachMessage: async (payload) => {
+        const value = payload.message.value
+        console.log(\`topic=\${payload.topic}, offset=\${payload.message.offset}\`)
+        console.log(value?.toString())
+      },
+    })
+    `
+      : `const producer = kafka.producer()
+  await producer.connect()
+  const value = {
+    // Fill in your data here
+    "key": "value"
+  }
+  await producer.send({topic: ${topics[0]}, messages:[{ value }]})
+  `
+  }
+`)
+}
+
+function cjsSampleCode(
+  groupType: string,
+  clientId: string,
+  clientSecret: string,
+  domain: 'dev.gcn.nasa.gov' | 'test.gcn.nasa.gov' | null,
+  listTopics: boolean,
+  topics: string[]
+) {
+  return dedent(`
+  const { Kafka } = require('gcn-kafka');
+
+  (async () => {
+    // Create a client.
+    // Warning: don't share the client secret with others.
+    const kafka = new Kafka({
+      client_id: '${clientId}',
+      client_secret: '${clientSecret}',${
+        domain
+          ? `
+      domain: '${domain}',`
+          : ''
+      }
+    })
+  ${
+    listTopics
+      ? `
+    // List topics
+    const admin = kafka.admin()
+    const topics = await admin.listTopics()
+    console.log(topics)
+    `
+      : ''
+  }
+  ${
+    groupType === 'consumer'
+      ? `// Subscribe to topics and receive alerts
+    const consumer = kafka.consumer()
+    try {
+      await consumer.subscribe({
+        topics: [${topics
+          .map(
+            (topic) => `
+            '${topic}',`
+          )
+          .join('')}
+        ],
+      })
+    } catch (error) {
+      if (error.type === 'TOPIC_AUTHORIZATION_FAILED')
+      {
+        console.warn('Not all subscribed topics are available')
+      } else {
+        throw error
+      }
+    }
+
+    await consumer.run({
+      eachMessage: async (payload) => {
+        const value = payload.message.value
+        console.log(\`topic=\${payload.topic}, offset=\${payload.message.offset}\`)
+        console.log(value?.toString())
+      },
+    })`
+      : `
+    const producer = kafka.producer()
+    await producer.connect()
+    const value = {
+      // Fill in your data here
+      "key": "value"
+    }
+    await producer.send({topic: ${topics[0]}, messages:[{ value }]})`
+  }
+  })()`)
 }

--- a/app/components/CredentialCard.tsx
+++ b/app/components/CredentialCard.tsx
@@ -116,6 +116,11 @@ export default function CredentialCard({
             </ModalToggleButton>
             <Form method="GET" action="/quickstart/alerts">
               <input type="hidden" name="clientId" value={client_id} />
+              <input
+                type="hidden"
+                name="groupType"
+                value={scope.endsWith('-consumer') ? 'consumer' : 'producer'}
+              />
               {alerts.map((alert) => (
                 <input key={alert} type="hidden" name="alerts" value={alert} />
               ))}

--- a/app/components/NewCredentialForm.tsx
+++ b/app/components/NewCredentialForm.tsx
@@ -48,6 +48,10 @@ export async function handleCredentialActions(
       if (redirectSource == 'quickstart') {
         const params = new URL(request.url).searchParams
         params.set('clientId', client_id)
+        params.set(
+          'groupType',
+          scope?.endsWith('-consumer') ? 'consumer' : 'producer'
+        )
         redirectTarget = `/quickstart/alerts?${params.toString()}`
       } else if (redirectSource == 'user') {
         redirectTarget = '/user/credentials'

--- a/app/routes/quickstart.alerts.tsx
+++ b/app/routes/quickstart.alerts.tsx
@@ -30,6 +30,7 @@ export default function () {
   const [noticeFormat, setFormat] = useState<NoticeFormat>(
     defaultFormat ?? 'text'
   )
+  const groupType = params.get('groupType') || 'consumer'
 
   return (
     <Form method="GET" action="../code">
@@ -56,6 +57,7 @@ export default function () {
         validationFunction={setAlertsValid}
       />
       <input type="hidden" name="clientId" value={clientId} />
+      <input type="hidden" name="groupType" value={groupType} />
       <FormGroup>
         <ButtonGroup>
           <Link

--- a/app/routes/quickstart.code.tsx
+++ b/app/routes/quickstart.code.tsx
@@ -22,7 +22,7 @@ export const handle: BreadcrumbHandle & SEOHandle = {
 }
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { clientId, noticeFormat, ...rest } = Object.fromEntries(
+  const { clientId, noticeFormat, groupType, ...rest } = Object.fromEntries(
     new URL(request.url).searchParams
   )
   const noticeTypes = Object.keys(rest)
@@ -31,6 +31,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return {
     noticeFormat,
     noticeTypes,
+    groupType,
     ...clientCredentialProps,
   }
 }
@@ -42,6 +43,7 @@ export default function () {
     client_secret: clientSecret,
     noticeFormat,
     noticeTypes,
+    groupType,
   } = useLoaderData<typeof loader>()
 
   const topics = noticeTypes.map((noticeType) =>
@@ -57,42 +59,49 @@ export default function () {
           <ClientSampleCode
             {...{ clientName, clientId, clientSecret, topics, listTopics }}
             language="py"
+            groupType={groupType}
           />
         </Tab>
         <Tab label="Node.js (ESM)">
           <ClientSampleCode
             {...{ clientName, clientId, clientSecret, topics, listTopics }}
             language="mjs"
+            groupType={groupType}
           />
         </Tab>
         <Tab label="Node.js (CommonJS)">
           <ClientSampleCode
             {...{ clientName, clientId, clientSecret, topics, listTopics }}
             language="cjs"
+            groupType={groupType}
           />
         </Tab>
         <Tab label="C/C++">
           <ClientSampleCode
             {...{ clientName, clientId, clientSecret, topics, listTopics }}
             language="c"
+            groupType={groupType}
           />
         </Tab>
         <Tab label="C#">
           <ClientSampleCode
             {...{ clientName, clientId, clientSecret, topics, listTopics }}
             language="cs"
+            groupType={groupType}
           />
         </Tab>
         <Tab label="Java">
           <ClientSampleCode
             {...{ clientName, clientId, clientSecret, topics, listTopics }}
             language="java"
+            groupType={groupType}
           />
         </Tab>
         <Tab label="PySpark">
           <ClientSampleCode
             {...{ clientName, clientId, clientSecret, topics, listTopics }}
             language="pyspark"
+            groupType={groupType}
           />
         </Tab>
       </Tabs>


### PR DESCRIPTION
Resolves [3421](https://github.com/nasa-gcn/gcn.nasa.gov/issues/3421)
- Adds the group type (consumer/producer) as an arg to the code samples components and routes
- breaks out the formatted text into functions to keep the component cleaner
- includes the type in the file names (ex: `example-producer.py` or `example-consumer.py`) to keep downloads organized for users