### PR TITLE
Split the list user function to fix timeout errors

### DIFF
--- a/app/lib/cognito.server.ts
+++ b/app/lib/cognito.server.ts
@@ -103,9 +103,8 @@ export async function listUsers(
     name: extractAttribute(user.Attributes, 'name'),
     affiliation: extractAttribute(user.Attributes, 'custom:affiliation'),
   }))
-  return results.filter(
-    (item, index, self) => index === self.findIndex((t) => t.sub === item.sub)
-  )
+  const userMap = new Map(results.map((user) => [user.name, user])).values()
+  return Array.from(userMap)
 }
 
 async function searchForUsersByKey(


### PR DESCRIPTION
This fixes a timeout issue on the user admin page where the `listUsers` function times out on prod. 

Adding the filter directly to the `paginateListUsers` function improves the time, but it does not support any level of complexity other than "equal to" (=) or "starts with" (^=) so it has to run twice if we want to check both the name and email fields for a user