### PR TITLE
Fix bug with automatic subject-eventId linking

### DIFF
--- a/app/routes/circulars.new.$circularId/CircularEditForm.tsx
+++ b/app/routes/circulars.new.$circularId/CircularEditForm.tsx
@@ -234,8 +234,8 @@ export function CircularEditForm({
                 <InputPrefix className="wide-input-prefix">
                   Event ID
                 </InputPrefix>
-                <span className="padding-1">{defaultEventId}</span>
-                <input type="hidden" name="eventId" value={defaultEventId} />
+                <span className="padding-1">{derivedEventId}</span>
+                <input type="hidden" name="eventId" value={derivedEventId} />
               </InputGroup>
             ) : (
               <InputGroup className="maxw-full">
@@ -261,7 +261,8 @@ export function CircularEditForm({
               label={
                 <>
                   Automatically fill event ID from subject
-                  {defaultEventId !== derivedEventId &&
+                  {!linkEventId &&
+                    eventId !== derivedEventId &&
                     '. The event ID does not match.'}
                 </>
               }


### PR DESCRIPTION
# Description
This corrects an issue where it looks like the eventId was being updated in the circular edit form and it wasn't.

# Related Issue(s)
This was introduced when we made these changes [PR 3](https://github.com/Courey/gcn.nasa.gov/pull/3/files) I believe at [this line](https://github.com/Courey/gcn.nasa.gov/pull/3/files#diff-be6bb4a0f73274ad470d7b05e6594f345b3578ddff27702fddba5465fe34b20dR289) which was merged in in this [PR 3198](https://github.com/nasa-gcn/gcn.nasa.gov/pull/3198)
Resolves #3427 

# Testing
Tested locally.
- changed subject with eventId linked (in edit and request correction)
- unlinked them and changed the subject (in edit and request correction)
- re-linked them and submitted (in edit and request correction)
- unlinked them and changed the eventId (in edit and request correction)
- re-linked them and submitted (in edit and request correction)
