### PR TITLE
Switch to release of lambda-runtimes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23297,12 +23297,13 @@
       "license": "MIT"
     },
     "node_modules/lambda-runtimes": {
-      "version": "2.0.5",
-      "resolved": "git+ssh://git@github.com/lpsinger/lambda-runtimes.git#85d67da48a3f3e110bedc440c60ecc8c65e40314",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lambda-runtimes/-/lambda-runtimes-3.0.0.tgz",
+      "integrity": "sha512-fre88KwPAjsDq8jeenv8GlgkdqbKf4wPGTlnKMXEDA5K12A3IptirNFv1koG47IBcgSykCbWYF9T3wmmKJFJtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=14"
+        "node": ">=22"
       }
     },
     "node_modules/langium": {

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
   "overrides": {
     "@architect/deploy": "github:DocLM/deploy#d3116f41d5fda00337ebfda543a69d3b3d4546be",
     "@architect/inventory": "github:lpsinger/inventory#allow-set-env-plugin-to-return-empty-object",
-    "lambda-runtimes": "github:lpsinger/lambda-runtimes#update-runtimes"
+    "lambda-runtimes": "3.0.0"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
Our patch (https://github.com/architect/lambda-runtimes/pull/9) was merged and is now in a release.