### PR TITLE
Set playwright port instead of URL

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -76,7 +76,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'npx run-s build:sass dev:remix',
-    url: 'http://localhost:3333',
+    port: 3333,
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
     timeout: 300 * 1000, // 300 Seconds timeout on webServer


### PR DESCRIPTION
This didn't have anything to do with the Playwright test failures, but I think it is a little more elegant.