### PR TITLE
Adjust playwright comments to start web server

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -75,7 +75,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: 'npx run-s build:sass dev:remix',
     url: 'http://localhost:3333',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',


### PR DESCRIPTION
Don't run sass in watch mode, because this seems to cause the Playwright tests to hang in GitHub Actions.

Fixes #3440.