### PR TITLE
Users migration

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -104,6 +104,19 @@ legacy_users
   email *String
   PointInTimeRecovery true
 
+users
+  sub *String
+  PointInTimeRecovery true
+
+teams
+  teamId *String
+  PointInTimeRecovery true
+
+team_members
+  sub *String
+  teamId **String
+  PointInTimeRecovery true
+
 @tables-indexes
 email_notification_subscription
   topic *String
@@ -160,6 +173,18 @@ synonyms
 client_credentials
   client_id *String
   name credentialsByClientId
+
+users
+  username *String
+  name usersByUserName
+
+users
+  email *String
+  name usersByEmail
+
+team_members
+  teamId *String
+  name usersByTeam
 
 @aws
 runtime nodejs24.x

--- a/app/lib/cognito.server.ts
+++ b/app/lib/cognito.server.ts
@@ -241,15 +241,20 @@ export async function getUserGroupStrings(Username: string) {
 }
 
 export async function checkUserIsVerified(sub: string) {
-  const { Username } = await getCognitoUserFromSub(sub)
+  try {
+    const { Username } = await getCognitoUserFromSub(sub)
 
-  const { UserAttributes } = await cognito.send(
-    new AdminGetUserCommand({
-      UserPoolId,
-      Username,
-    })
-  )
-  return extractAttribute(UserAttributes, 'email_verified')
+    const { UserAttributes } = await cognito.send(
+      new AdminGetUserCommand({
+        UserPoolId,
+        Username,
+      })
+    )
+    return extractAttribute(UserAttributes, 'email_verified')
+  } catch (error) {
+    maybeThrowCognito(error, 'returning is verified as true')
+    return 'true'
+  }
 }
 
 export async function removeUserFromGroup(sub: string, GroupName: string) {

--- a/app/lib/teams.server.ts
+++ b/app/lib/teams.server.ts
@@ -1,0 +1,90 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { tables } from '@architect/functions'
+import crypto from 'crypto'
+
+import type { User } from '~/routes/_auth/user.server'
+
+export type Team = {
+  teamId: string
+  teamName: string
+  description: string
+  topic: string
+}
+
+export type TeamMember = {
+  sub: string
+  teamId: string
+  permission: string
+}
+
+export async function createTeam(
+  name: string,
+  description: string,
+  topic: string
+) {
+  const db = await tables()
+
+  const team: Team = {
+    teamId: crypto.randomUUID(),
+    teamName: name,
+    description,
+    topic,
+  }
+  await db.teams.put(team)
+  return team
+}
+
+export async function deleteTeam(teamId: string) {
+  const db = await tables()
+  await db.teams.delete({ teamId })
+  const teamPermissions = (
+    await db.team_members.query({
+      IndexName: 'usersByTeam',
+      KeyConditionExpression: 'teamId = :teamId',
+      ExpressionAttributeValues: {
+        ':teamId': teamId,
+      },
+    })
+  ).Items as TeamMember[]
+
+  await Promise.all(
+    teamPermissions.map((x) => db.team_members.delete({ sub: x.sub, teamId }))
+  )
+}
+
+export async function addUserToTeam(
+  user: User,
+  teamId: string,
+  permission: 'admin' | 'producer' | 'consumer'
+) {
+  const db = await tables()
+
+  await db.team_members.put({
+    sub: user.sub,
+    teamId,
+    permission,
+  })
+}
+
+export async function getUsersByTeamId(teamId: string) {
+  const db = await tables()
+  const { Items } = await db.team_members.query({
+    IndexName: 'usersByTeam',
+    KeyConditionExpression: 'teamId = :teamId',
+    ExpressionAttributeValues: {
+      ':teamId': teamId,
+    },
+  })
+  return Items as TeamMember[]
+}
+
+export async function removeUserFromTeam(sub: string, teamId: string) {
+  const db = await tables()
+  await db.team_members.delete({ sub, teamId })
+}

--- a/app/lib/user.server.ts
+++ b/app/lib/user.server.ts
@@ -1,0 +1,106 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { tables } from '@architect/functions'
+import type { DynamoDBDocument } from '@aws-sdk/lib-dynamodb'
+import { paginateScan } from '@aws-sdk/lib-dynamodb'
+
+import type { Team, TeamMember } from './teams.server'
+
+export type UserMetadata = {
+  sub: string
+  email: string
+  username?: string
+  affiliation?: string
+}
+
+export type TeamPermission = Team & {
+  permission: string
+}
+
+export async function addUser(user: UserMetadata) {
+  const db = await tables()
+  await db.users.put(user)
+}
+
+export async function getUserMetadata(sub: string) {
+  const db = await tables()
+  const user = await db.users.get({ sub })
+  return user
+}
+
+export async function findUsersByNameOrEmail(
+  value: string
+): Promise<UserMetadata[]> {
+  const db = await tables()
+  const client = db._doc as unknown as DynamoDBDocument
+  const TableName = db.name('users')
+
+  const pages = paginateScan(
+    { client },
+    {
+      TableName,
+      FilterExpression: 'contains(username, :value) OR contains(email, :value)',
+      ExpressionAttributeValues: {
+        ':value': value,
+      },
+    }
+  )
+  const users: UserMetadata[] = []
+  for await (const page of pages) {
+    const newUsers = page.Items as UserMetadata[]
+    if (newUsers) users.push(...newUsers)
+  }
+  return users
+}
+
+export async function updateUser(user: UserMetadata) {
+  const db = await tables()
+  await db.users.update({
+    Key: { sub: user.sub },
+    UpdateExpression:
+      'set username = :username, affiliation = :affiliation, email = :email',
+    ExpressionAttributeValues: {
+      ':username': user.username,
+      ':affiliation': user.affiliation,
+      ':email': user.email,
+    },
+  })
+}
+
+export async function getUsersKafkaPermissions(
+  sub: string
+): Promise<TeamPermission[]> {
+  const db = await tables()
+  const items = (
+    await db.team_members.query({
+      KeyConditionExpression: '#sub = :sub',
+      ExpressionAttributeNames: {
+        '#sub': 'sub',
+      },
+      ExpressionAttributeValues: {
+        ':sub': sub,
+      },
+    })
+  ).Items as TeamMember[]
+
+  const teams = (await Promise.all(
+    items.map((item) => db.teams.get({ teamId: item.teamId }))
+  )) as Team[]
+  // Should this return permissions just `verb:resource`? ie, admin:team_abc ? or parse it later?
+  return items.map((item) => {
+    const team = teams.find((x) => x.teamId == item.teamId)
+    if (!team) throw new Response(null, { status: 500 })
+    return {
+      teamId: item.teamId,
+      permission: item.permission,
+      teamName: team.teamName,
+      description: team.description,
+      topic: team.topic,
+    }
+  })
+}

--- a/app/routes/user._index.tsx
+++ b/app/routes/user._index.tsx
@@ -23,6 +23,7 @@ import { formatAuthor } from './circulars/circulars.lib'
 import Hint from '~/components/Hint'
 import Spinner from '~/components/Spinner'
 import { cognito, maybeThrowCognito } from '~/lib/cognito.server'
+import { updateUser } from '~/lib/user.server'
 import { getFormDataString } from '~/lib/utils'
 import type { BreadcrumbHandle } from '~/root/Title'
 import type { SEOHandle } from '~/root/seo'
@@ -63,6 +64,13 @@ export async function action({ request }: ActionFunctionArgs) {
       },
     ],
     AccessToken: session.get('accessToken'),
+  })
+
+  await updateUser({
+    sub: user.sub,
+    email: user.email,
+    username: name,
+    affiliation,
   })
 
   try {

--- a/seed.json
+++ b/seed.json
@@ -5787,5 +5787,53 @@
       "lastUsed": 1745014628845,
       "countUsed": 1
     }
+  ],
+  "users": [
+    {
+      "sub": "default",
+      "username": "Example User",
+      "affiliation": "Testing Corp",
+      "email": "user@example.com"
+    }
+  ],
+  "teams": [
+    {
+      "teamId": "team_abc",
+      "teamName": "Team ABC",
+      "description": "A cool new team",
+      "topic": "gcn.notices.team_abc",
+      "public": true
+    },
+    {
+      "teamId": "team_def",
+      "teamName": "Team Def",
+      "description": "A second team",
+      "topic": "gcn.notices.team_def",
+      "public": false
+    },
+    {
+      "teamId": "team_ghi",
+      "teamName": "Team ghi",
+      "description": "Example team",
+      "topic": "gcn.notices.team_ghi",
+      "public": false
+    }
+  ],
+  "team_members": [
+    {
+      "sub": "default",
+      "teamId": "team_abc",
+      "permission": "admin"
+    },
+    {
+      "sub": "default",
+      "teamId": "team_def",
+      "permission": "write"
+    },
+    {
+      "sub": "default",
+      "teamId": "team_ghi",
+      "permission": "read"
+    }
   ]
 }


### PR DESCRIPTION
- Add 3 new tables and seed data examples for managing Users:
  - `users`: where minor metadata is maintained
  - `teams`: future replacement for group membership
  - `team_members`: link between previous two
- Add `user.server.ts` and `teams.server.ts` to do DynamoDB based interactions with the new `users` and `teams` tables
- Update client credentials server to add new functions that check team membership before creating new app clients
- Update the New Credential Form behind a feature flag to use the new functions 
- Update the users api behind feature flag to query DynamoDB by name and email instead of checking cognito
- Update the user page to update their rows in DynamoDB