### PR TITLE
Group Dependabot updates to first-party GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns:
+          - 'actions/*'
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
This will decrease the number of Dependabot updates by grouping together highly trusted actions that are maintained by Microsoft themselves.