### PR TITLE
Alter back buttons in circulars to use react hook instead of hard-coded links

### DIFF
--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -98,9 +98,6 @@ export default function () {
         <Link
           onClick={(event) => {
             event.preventDefault()
-            console.log(
-              'Navigating back to previous page with javaScript navigation'
-            )
             navigate(-1)
           }}
           className="usa-button"

--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -101,7 +101,7 @@ export default function () {
             navigate(-1)
           }}
           className="usa-button"
-          to={`/circulars/${searchString}`}
+          to={`/circulars${searchString}`}
         >
           <Icon.ArrowBack role="presentation" className="margin-y-neg-2px" />
           Back

--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -7,7 +7,12 @@
  */
 import type { HeadersFunction, LoaderFunctionArgs } from '@remix-run/node'
 import { json } from '@remix-run/node'
-import { Link, useLoaderData, useRouteLoaderData } from '@remix-run/react'
+import {
+  Link,
+  useLoaderData,
+  useNavigate,
+  useRouteLoaderData,
+} from '@remix-run/react'
 import { Button, ButtonGroup, CardBody, Icon } from '@trussworks/react-uswds'
 import { useRef, useState } from 'react'
 import invariant from 'tiny-invariant'
@@ -85,11 +90,12 @@ export default function () {
   const linkString = `/circulars/${circularId}${
     !latest && version ? `/${version}` : ''
   }`
+  const navigate = useNavigate()
 
   return (
     <>
       <ToolbarButtonGroup className="flex-wrap">
-        <Link to={`/circulars${searchString}`} className="usa-button">
+        <Link onClick={() => navigate(-1)} className="usa-button" to="">
           <Icon.ArrowBack role="presentation" className="margin-y-neg-2px" />
           Back
         </Link>

--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -95,7 +95,17 @@ export default function () {
   return (
     <>
       <ToolbarButtonGroup className="flex-wrap">
-        <Link onClick={() => navigate(-1)} className="usa-button" to="">
+        <Link
+          onClick={(event) => {
+            event.preventDefault()
+            console.log(
+              'Navigating back to previous page with javaScript navigation'
+            )
+            navigate(-1)
+          }}
+          className="usa-button"
+          to={`/circulars/${searchString}`}
+        >
           <Icon.ArrowBack role="presentation" className="margin-y-neg-2px" />
           Back
         </Link>

--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -86,7 +86,6 @@ export default function () {
   const linkString = `/circulars/${circularId}${
     !latest && version ? `/${version}` : ''
   }`
-  // const navigate = useNavigate()
   const { handleBack } = useBack(`/circulars${searchString}`)
 
   return (

--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -7,15 +7,11 @@
  */
 import type { HeadersFunction, LoaderFunctionArgs } from '@remix-run/node'
 import { json } from '@remix-run/node'
-import {
-  Link,
-  useLoaderData,
-  useNavigate,
-  useRouteLoaderData,
-} from '@remix-run/react'
+import { Link, useLoaderData, useRouteLoaderData } from '@remix-run/react'
 import { Button, ButtonGroup, CardBody, Icon } from '@trussworks/react-uswds'
 import { useRef, useState } from 'react'
 import invariant from 'tiny-invariant'
+import { useBack } from 'use-back'
 import { useOnClickOutside } from 'usehooks-ts'
 
 import type { loader as parentLoader } from '../circulars.$circularId/route'
@@ -90,16 +86,14 @@ export default function () {
   const linkString = `/circulars/${circularId}${
     !latest && version ? `/${version}` : ''
   }`
-  const navigate = useNavigate()
+  // const navigate = useNavigate()
+  const { handleBack } = useBack(`/circulars${searchString}`)
 
   return (
     <>
       <ToolbarButtonGroup className="flex-wrap">
         <Link
-          onClick={(event) => {
-            event.preventDefault()
-            navigate(-1)
-          }}
+          onClick={handleBack}
           className="usa-button"
           to={`/circulars${searchString}`}
         >

--- a/app/routes/circulars.events.$slug.tsx
+++ b/app/routes/circulars.events.$slug.tsx
@@ -46,9 +46,6 @@ export default function Group() {
         <Link
           onClick={(event) => {
             event.preventDefault()
-            console.log(
-              'Navigating back to previous page with javaScript navigation'
-            )
             navigate(-1)
           }}
           className="usa-button"

--- a/app/routes/circulars.events.$slug.tsx
+++ b/app/routes/circulars.events.$slug.tsx
@@ -6,11 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { LoaderFunctionArgs } from '@remix-run/node'
-import {
-  Link,
-  useLoaderData,
-  useNavigate,
-} from '@remix-run/react'
+import { Link, useLoaderData, useNavigate } from '@remix-run/react'
 import { Icon } from '@trussworks/react-uswds'
 import invariant from 'tiny-invariant'
 

--- a/app/routes/circulars.events.$slug.tsx
+++ b/app/routes/circulars.events.$slug.tsx
@@ -10,7 +10,6 @@ import {
   Link,
   useLoaderData,
   useNavigate,
-  useSearchParams,
 } from '@remix-run/react'
 import { Icon } from '@trussworks/react-uswds'
 import invariant from 'tiny-invariant'
@@ -44,7 +43,6 @@ export async function loader({ params: { slug } }: LoaderFunctionArgs) {
 
 export default function Group() {
   const { members, eventIds } = useLoaderData<typeof loader>()
-  const [searchParams] = useSearchParams()
   const navigate = useNavigate()
   return (
     <>

--- a/app/routes/circulars.events.$slug.tsx
+++ b/app/routes/circulars.events.$slug.tsx
@@ -6,7 +6,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { LoaderFunctionArgs } from '@remix-run/node'
-import { Link, useLoaderData, useSearchParams } from '@remix-run/react'
+import {
+  Link,
+  useLoaderData,
+  useNavigate,
+  useSearchParams,
+} from '@remix-run/react'
 import { Icon } from '@trussworks/react-uswds'
 import invariant from 'tiny-invariant'
 
@@ -40,15 +45,11 @@ export async function loader({ params: { slug } }: LoaderFunctionArgs) {
 export default function Group() {
   const { members, eventIds } = useLoaderData<typeof loader>()
   const [searchParams] = useSearchParams()
-  const searchString = searchParams.toString()
-
+  const navigate = useNavigate()
   return (
     <>
       <ToolbarButtonGroup className="flex-wrap">
-        <Link
-          to={`/circulars?${searchString}`}
-          className="usa-button flex-align-stretch"
-        >
+        <Link onClick={() => navigate(-1)} className="usa-button" to="">
           <Icon.ArrowBack role="presentation" className="margin-y-neg-2px" />
           Back
         </Link>

--- a/app/routes/circulars.events.$slug.tsx
+++ b/app/routes/circulars.events.$slug.tsx
@@ -48,7 +48,7 @@ export default function Group() {
             event.preventDefault()
             navigate(-1)
           }}
-          className="usa-button"
+          className="usa-button flex-align-stretch"
           to="/circulars?view=group"
         >
           <Icon.ArrowBack role="presentation" className="margin-y-neg-2px" />

--- a/app/routes/circulars.events.$slug.tsx
+++ b/app/routes/circulars.events.$slug.tsx
@@ -43,7 +43,17 @@ export default function Group() {
   return (
     <>
       <ToolbarButtonGroup className="flex-wrap">
-        <Link onClick={() => navigate(-1)} className="usa-button" to="">
+        <Link
+          onClick={(event) => {
+            event.preventDefault()
+            console.log(
+              'Navigating back to previous page with javaScript navigation'
+            )
+            navigate(-1)
+          }}
+          className="usa-button"
+          to="/circulars?view=group"
+        >
           <Icon.ArrowBack role="presentation" className="margin-y-neg-2px" />
           Back
         </Link>

--- a/app/routes/circulars.events.$slug.tsx
+++ b/app/routes/circulars.events.$slug.tsx
@@ -6,9 +6,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { LoaderFunctionArgs } from '@remix-run/node'
-import { Link, useLoaderData, useNavigate } from '@remix-run/react'
+import { Link, useLoaderData } from '@remix-run/react'
 import { Icon } from '@trussworks/react-uswds'
 import invariant from 'tiny-invariant'
+import { useBack } from 'use-back'
 
 import type { Synonym } from './synonyms/synonyms.lib'
 import {
@@ -39,15 +40,12 @@ export async function loader({ params: { slug } }: LoaderFunctionArgs) {
 
 export default function Group() {
   const { members, eventIds } = useLoaderData<typeof loader>()
-  const navigate = useNavigate()
+  const { handleBack } = useBack(`/circulars?view=group`)
   return (
     <>
       <ToolbarButtonGroup className="flex-wrap">
         <Link
-          onClick={(event) => {
-            event.preventDefault()
-            navigate(-1)
-          }}
+          onClick={handleBack}
           className="usa-button flex-align-stretch"
           to="/circulars?view=group"
         >

--- a/app/routes/circulars.new.tsx
+++ b/app/routes/circulars.new.tsx
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Link, Outlet } from '@remix-run/react'
+import { Link, Outlet, useNavigate } from '@remix-run/react'
 import {
   Button,
   Modal,
@@ -54,9 +54,8 @@ function SignInButton() {
 }
 
 function ModalUnauthorized() {
-  const searchString = useSearchString()
   const isAuthenticated = useAuthenticated()
-
+  const navigate = useNavigate()
   return (
     <Modal
       id="modal-unauthorized"
@@ -75,7 +74,7 @@ function ModalUnauthorized() {
         get a peer endorsement from an existing GCN Circulars user.
       </p>
       <ModalFooter>
-        <Link to={`/circulars${searchString}`}>
+        <Link onClick={() => navigate(-1)} className="usa-button" to="">
           <Button type="button" outline>
             Cancel
           </Button>

--- a/app/routes/circulars.new.tsx
+++ b/app/routes/circulars.new.tsx
@@ -13,7 +13,6 @@ import {
   ModalHeading,
 } from '@trussworks/react-uswds'
 
-import { useSearchString } from '~/lib/utils'
 import {
   useEmail,
   usePermissionModerator,

--- a/app/routes/circulars.new.tsx
+++ b/app/routes/circulars.new.tsx
@@ -73,7 +73,14 @@ function ModalUnauthorized() {
         get a peer endorsement from an existing GCN Circulars user.
       </p>
       <ModalFooter>
-        <Link onClick={() => navigate(-1)} className="usa-button" to="">
+        <Link
+          onClick={(event) => {
+            event.preventDefault()
+            navigate(-1)
+          }}
+          className="usa-button"
+          to="/circulars"
+        >
           <Button type="button" outline>
             Cancel
           </Button>

--- a/app/routes/circulars.new.tsx
+++ b/app/routes/circulars.new.tsx
@@ -5,13 +5,14 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Link, Outlet, useNavigate } from '@remix-run/react'
+import { Link, Outlet } from '@remix-run/react'
 import {
   Button,
   Modal,
   ModalFooter,
   ModalHeading,
 } from '@trussworks/react-uswds'
+import { useBack } from 'use-back'
 
 import {
   useEmail,
@@ -54,7 +55,7 @@ function SignInButton() {
 
 function ModalUnauthorized() {
   const isAuthenticated = useAuthenticated()
-  const navigate = useNavigate()
+  const { handleBack } = useBack(`/circulars`)
   return (
     <Modal
       id="modal-unauthorized"
@@ -73,14 +74,7 @@ function ModalUnauthorized() {
         get a peer endorsement from an existing GCN Circulars user.
       </p>
       <ModalFooter>
-        <Link
-          onClick={(event) => {
-            event.preventDefault()
-            navigate(-1)
-          }}
-          className="usa-button"
-          to="/circulars"
-        >
+        <Link onClick={handleBack} className="usa-button" to="/circulars">
           <Button type="button" outline>
             Cancel
           </Button>

--- a/app/routes/synonyms.$synonymId.tsx
+++ b/app/routes/synonyms.$synonymId.tsx
@@ -12,6 +12,7 @@ import {
   Link,
   useFetcher,
   useLoaderData,
+  useNavigate,
   useSubmit,
 } from '@remix-run/react'
 import type { ModalRef } from '@trussworks/react-uswds'
@@ -115,7 +116,7 @@ export default function () {
   const ref = useRef<HTMLDivElement>(null)
   const fetcher = useFetcher()
   const submit = useSubmit()
-
+  const navigate = useNavigate()
   const [showContent, setShowContent] = useState(false)
   useOnClickOutside(ref, () => {
     setShowContent(false)
@@ -133,7 +134,7 @@ export default function () {
   return (
     <>
       <ToolbarButtonGroup className="flex-wrap">
-        <Link to="/synonyms" className="usa-button">
+        <Link onClick={() => navigate(-1)} className="usa-button" to="">
           <Icon.ArrowBack role="presentation" className="margin-y-neg-2px" />
           Back
         </Link>

--- a/app/routes/synonyms.$synonymId.tsx
+++ b/app/routes/synonyms.$synonymId.tsx
@@ -134,7 +134,14 @@ export default function () {
   return (
     <>
       <ToolbarButtonGroup className="flex-wrap">
-        <Link onClick={() => navigate(-1)} className="usa-button" to="">
+        <Link
+          onClick={(event) => {
+            event.preventDefault()
+            navigate(-1)
+          }}
+          className="usa-button"
+          to="/synonyms"
+        >
           <Icon.ArrowBack role="presentation" className="margin-y-neg-2px" />
           Back
         </Link>

--- a/app/routes/synonyms.$synonymId.tsx
+++ b/app/routes/synonyms.$synonymId.tsx
@@ -12,7 +12,6 @@ import {
   Link,
   useFetcher,
   useLoaderData,
-  useNavigate,
   useSubmit,
 } from '@remix-run/react'
 import type { ModalRef } from '@trussworks/react-uswds'
@@ -31,6 +30,7 @@ import {
 } from '@trussworks/react-uswds'
 import { useEffect, useRef, useState } from 'react'
 import invariant from 'tiny-invariant'
+import { useBack } from 'use-back'
 import { useOnClickOutside } from 'usehooks-ts'
 
 import { getUser } from './_auth/user.server'
@@ -116,8 +116,8 @@ export default function () {
   const ref = useRef<HTMLDivElement>(null)
   const fetcher = useFetcher()
   const submit = useSubmit()
-  const navigate = useNavigate()
   const [showContent, setShowContent] = useState(false)
+  const { handleBack } = useBack(`/synonyms`)
   useOnClickOutside(ref, () => {
     setShowContent(false)
   })
@@ -134,14 +134,7 @@ export default function () {
   return (
     <>
       <ToolbarButtonGroup className="flex-wrap">
-        <Link
-          onClick={(event) => {
-            event.preventDefault()
-            navigate(-1)
-          }}
-          className="usa-button"
-          to="/synonyms"
-        >
+        <Link onClick={handleBack} className="usa-button" to="/synonyms">
           <Icon.ArrowBack role="presentation" className="margin-y-neg-2px" />
           Back
         </Link>

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "ts-dedent": "^2.2.0",
         "unified": "^10.0.0",
         "unist-builder": "^4.0.0",
+        "use-back": "^1.0.1",
         "usehooks-ts": "^3.0.2"
       },
       "devDependencies": {
@@ -33653,6 +33654,19 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
       "dev": true
+    },
+    "node_modules/use-back": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/use-back/-/use-back-1.0.1.tgz",
+      "integrity": "sha512-u1u4PWGX5cbH7uzuZD6VAz3Wm8qqI2sL4anAiKDZ8DSjuPut2+pOylhSe0GpcGegrxNsLXMGPM07qRGcr/Ze7w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-router-dom": "^6.0.0-beta.0"
+      }
     },
     "node_modules/usehooks-ts": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "ts-dedent": "^2.2.0",
     "unified": "^10.0.0",
     "unist-builder": "^4.0.0",
+    "use-back": "^1.0.1",
     "usehooks-ts": "^3.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
There has been a known inconsistency in the on-screen navigation buttons and whether or not they preserve the user's search parameters in the archive. This was partially addressed in solving https://github.com/nasa-gcn/gcn.nasa.gov/pull/2391, but we have continued to have some cases where the link to the previous page does not include the relevant search parameters. However, as @dakota002 noted, there is a [react hook](https://reactnavigation.org/docs/navigating/) to initiate a return to the previous page, which simplifies this button. This PR replaces the hard-coded link with the react hook.


# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->
1. Navigate to the circulars archive
2. Initiate a search
3. Select any result 
4. Press the on-screen back button
5. The page should still show the search being executed.
6. Repeat the above steps in Event view
7. Repeat steps 1 and 2, but select the button to submit a new circular. Pressing the back button at the bottom of the page should have the same behavior as step 5.