### PR TITLE
Move new circular button to top of page

### DIFF
--- a/app/routes/circulars._archive._index/CircularsHeader.tsx
+++ b/app/routes/circulars._archive._index/CircularsHeader.tsx
@@ -14,14 +14,18 @@ export default function () {
   if (searchString) searchString = `?${searchString}`
   return (
     <>
-      <div className="display-flex flex-justify-space-between flex-align-center">
-        <h1>GCN Circulars</h1>
-        <div className="margin-left-auto">
-          <Link to={`/circulars/new${searchString}`}>
-            <Button type="button" className="padding-y-1">
-              <Icon.Edit role="presentation" /> Submit New Circular
-            </Button>
-          </Link>
+      <div className="grid-container usa-prose padding-left-0 padding-right-0">
+        <div className="grid-row">
+          <div className="grid-col-auto">
+            <h1 className="margin-bottom-0">GCN Circulars</h1>
+          </div>
+          <div className="grid-col-auto margin-left-auto">
+            <Link to={`/circulars/new${searchString}`}>
+              <Button type="button" className="">
+                <Icon.Edit role="presentation" /> Submit New Circular
+              </Button>
+            </Link>
+          </div>
         </div>
       </div>
       <p className="usa-paragraph">

--- a/app/routes/circulars._archive._index/CircularsHeader.tsx
+++ b/app/routes/circulars._archive._index/CircularsHeader.tsx
@@ -15,13 +15,13 @@ export default function () {
   return (
     <>
       <div className="grid-container usa-prose padding-left-0 padding-right-0">
-        <div className="grid-row grid-row-gap-0">
+        <div className="grid-row grid-row-gap-0 flex-column-reverse tablet:flex-row">
           <div className="grid-col-auto display-flex flex-align-center">
             <h1 className="margin-bottom-0">GCN Circulars</h1>
           </div>
-          <div className="grid-col-auto margin-left-auto display-flex flex-align-center">
-            <Link to={`/circulars/new${searchString}`}>
-              <Button type="button" className="">
+          <div className="grid-col-auto margin-left-auto display-flex flex-align-center width-full tablet:width-auto">
+            <Link to={`/circulars/new${searchString}`} className="width-full">
+              <Button type="button" className="width-full">
                 <Icon.Edit role="presentation" /> Submit New Circular
               </Button>
             </Link>

--- a/app/routes/circulars._archive._index/CircularsHeader.tsx
+++ b/app/routes/circulars._archive._index/CircularsHeader.tsx
@@ -5,12 +5,25 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Link } from '@remix-run/react'
+import { Link, useSearchParams } from '@remix-run/react'
+import { Button, Icon } from '@trussworks/react-uswds'
 
 export default function () {
+  const [searchParams] = useSearchParams()
+  let searchString = searchParams.toString()
+  if (searchString) searchString = `?${searchString}`
   return (
     <>
-      <h1>GCN Circulars</h1>
+      <div className="display-flex flex-justify-space-between flex-align-center">
+        <h1>GCN Circulars</h1>
+        <div className="margin-left-auto">
+          <Link to={`/circulars/new${searchString}`}>
+            <Button type="button" className="padding-y-1">
+              <Icon.Edit role="presentation" /> Submit New Circular
+            </Button>
+          </Link>
+        </div>
+      </div>
       <p className="usa-paragraph">
         <b>
           GCN Circulars are rapid astronomical bulletins submitted by and

--- a/app/routes/circulars._archive._index/CircularsHeader.tsx
+++ b/app/routes/circulars._archive._index/CircularsHeader.tsx
@@ -15,11 +15,11 @@ export default function () {
   return (
     <>
       <div className="grid-container usa-prose padding-left-0 padding-right-0">
-        <div className="grid-row">
-          <div className="grid-col-auto">
+        <div className="grid-row grid-row-gap-0">
+          <div className="grid-col-auto display-flex flex-align-center">
             <h1 className="margin-bottom-0">GCN Circulars</h1>
           </div>
-          <div className="grid-col-auto margin-left-auto">
+          <div className="grid-col-auto margin-left-auto display-flex flex-align-center">
             <Link to={`/circulars/new${searchString}`}>
               <Button type="button" className="">
                 <Icon.Edit role="presentation" /> Submit New Circular

--- a/app/routes/circulars._archive._index/route.tsx
+++ b/app/routes/circulars._archive._index/route.tsx
@@ -314,11 +314,6 @@ export default function () {
           </Link>
         </ButtonGroup>
 
-        <Link to={`/circulars/new${searchString}`}>
-          <Button type="button" className="padding-y-1">
-            <Icon.Edit role="presentation" /> New
-          </Button>
-        </Link>
         {!isGroupView && (
           <DateSelector
             form={formId}


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
As per sprint planning discussion, several team members agreed that the "new circular" button wasn't particularly useful to have as part of the search bar and created some level of confusion. This PR moves the new circular button to the top of the page but does not change the behavior otherwise.

# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->
1. Navigate to Circulars archive
2. The new circulars page should function the same, just in a different place