### PR TITLE
Adds moderator check to synonym moderation action

### DIFF
--- a/app/routes/synonyms.$synonymId.tsx
+++ b/app/routes/synonyms.$synonymId.tsx
@@ -82,7 +82,7 @@ export async function action({
 
   const user = await getUser(request)
 
-  if (!user || !user.groups.includes(moderatorGroup))
+  if (!user?.groups.includes(moderatorGroup))
     throw new Response(null, { status: 403 })
 
   const data = await request.formData()

--- a/app/routes/synonyms.$synonymId.tsx
+++ b/app/routes/synonyms.$synonymId.tsx
@@ -79,6 +79,12 @@ export async function action({
   params: { synonymId },
 }: ActionFunctionArgs) {
   invariant(synonymId)
+
+  const user = await getUser(request)
+
+  if (!user || !user.groups.includes(moderatorGroup))
+    throw new Response(null, { status: 403 })
+
   const data = await request.formData()
   const intent = getFormDataString(data, 'intent')
 


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
I wanted to add a moderator check to this action to ensure the actions are only available with the proper permissions.


# Related Issue(s)
None


# Testing
curled local endpoint to check that a 200 is not returned if user doesn't have appropriate permissions and throws a 403.

Locally a 500 is returned instead due to a bug in the 403 error handling. That will be patched following this PR.

the line that throws the 500:
https://github.com/nasa-gcn/gcn.nasa.gov/blob/main/app/root.tsx#L214
it does this because origin is undefined when hit from curl.
 
in the error for unauthorized:
https://github.com/nasa-gcn/gcn.nasa.gov/blob/main/app/root.tsx#L308
 
that calls useUrl, which fails on the invariant line since the origin is null
https://github.com/nasa-gcn/gcn.nasa.gov/blob/main/app/root.tsx#L212
<img width="998" height="207" alt="Screenshot 2026-04-21 at 10 56 46 AM" src="https://github.com/user-attachments/assets/9a326335-90a0-4198-847a-8ecf2833b1ff" />
<img width="1188" height="107" alt="mod_perms" src="https://github.com/user-attachments/assets/00ec00aa-71ad-47a1-9ad2-e5570bd8fa7f" />

