### PR TITLE
Add tables and models for new Team structure

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -104,6 +104,23 @@ legacy_users
   email *String
   PointInTimeRecovery true
 
+users
+  sub *String
+  PointInTimeRecovery true
+
+teams
+  teamId *String
+  PointInTimeRecovery true
+
+team_members
+  sub *String
+  teamId **String
+  PointInTimeRecovery true
+
+topics
+  topicId *String
+  PointInTimeRecovery true
+
 @tables-indexes
 email_notification_subscription
   topic *String
@@ -160,6 +177,18 @@ synonyms
 client_credentials
   client_id *String
   name credentialsByClientId
+
+users
+  username *String
+  name usersByUserName
+
+users
+  email *String
+  name usersByEmail
+
+team_members
+  teamId *String
+  name usersByTeam
 
 @aws
 runtime nodejs24.x

--- a/app/lib/teams.server.ts
+++ b/app/lib/teams.server.ts
@@ -1,0 +1,38 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type Team = {
+  teamId: string
+  teamName: string
+  description: String
+}
+
+/**
+ * Maps a User to a Team and their respective permission level
+ * to a topic within the scope of a team.
+ *
+ * @permission represents a level of access to a given topic:
+ * - "read": Consumer permissions only.
+ * - "write": Producer and Consumer permissions.
+ * - "admin": Producer and Consumer permissions, plus team level
+ *    moderator status, reserved for PoCs, must be at least one
+ *    per team.
+ */
+export type TeamMember = {
+  sub: string
+  teamId: string
+  topicId: string
+  permission: 'admin' | 'write' | 'read'
+}
+
+export type Topic = {
+  topicId: string
+  topicName: string
+  public: boolean
+  teamId: string
+}

--- a/app/lib/user.server.ts
+++ b/app/lib/user.server.ts
@@ -1,0 +1,14 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type UserMetadata = {
+  sub: string
+  email: string
+  username?: string
+  affiliation?: string
+}

--- a/seed.json
+++ b/seed.json
@@ -5787,5 +5787,70 @@
       "lastUsed": 1745014628845,
       "countUsed": 1
     }
+  ],
+  "users": [
+    {
+      "sub": "default",
+      "username": "Example User",
+      "affiliation": "Testing Corp",
+      "email": "user@example.com"
+    }
+  ],
+  "teams": [
+    {
+      "teamId": "team_abc",
+      "teamName": "Team ABC",
+      "description": "A cool new team"
+    },
+    {
+      "teamId": "team_def",
+      "teamName": "Team Def",
+      "description": "A second team"
+    },
+    {
+      "teamId": "team_ghi",
+      "teamName": "Team ghi",
+      "description": "Example team"
+    }
+  ],
+  "team_members": [
+    {
+      "sub": "default",
+      "teamId": "team_abc",
+      "permission": "admin",
+      "topicId": "topic_1"
+    },
+    {
+      "sub": "default",
+      "teamId": "team_def",
+      "permission": "write",
+      "topicId": "topic_2"
+    },
+    {
+      "sub": "default",
+      "teamId": "team_ghi",
+      "permission": "read",
+      "topicId": "topic_3"
+    }
+  ],
+  "topics": [
+    {
+      "topicId": "topic_1",
+      "topicName": "gcn.notices.team_abc",
+      "teamId": "team_abc",
+      "public": true
+    },
+    {
+      "topicId": "topic_2",
+      "topicName": "gcn.notices.team_def",
+      "public": false,
+      "teamId": "team_def"
+    },
+    {
+      "topicId": "topic_3",
+      "topicName": "gcn.notices.team_ghi",
+      "teamId": "team_ghi",
+      "public": true
+    }
   ]
 }


### PR DESCRIPTION
# Description
Based on design specified in https://github.com/nasa-gcn/gcn.nasa.gov/issues/3453
- Adds tables for:
  - Users: to replace the use of AWS Cognito
  - Teams: the new structure to improve user's self service capabilities
  - Topics: to allow team members control over their mission specific topics
  - TeamMembers: to bind User-Team-Topic
- Adds Models for each table
- Adds examples for each in `seed.json`