### PR TITLE
Fixes 403 handling when there is no origin

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -210,9 +210,10 @@ export function useOrigin() {
 }
 
 export function useUrl() {
-  const origin = useOrigin()
-  invariant(origin)
+  const origin = useOrigin() || 'https://gcn.nasa.gov'
   const { pathname, search, hash } = useLocation()
+
+  invariant(origin)
   const url = new URL(origin)
   url.pathname = pathname
   url.search = search


### PR DESCRIPTION
# Description
When curling routes, when unauthorized and there is no origin as the endpoint was curled, it was throwing a 500 error within the 403 error handling as it was trying to use the origin in the unauthorized page.


# Related Issue(s)
closes #3575


# Testing
I defaulted the origin to our main production domain so that it returns a 403.

<img width="1369" height="110" alt="Screenshot 2026-04-28 at 11 14 32 AM" src="https://github.com/user-attachments/assets/2a0a8233-d571-4538-bfbe-66c87c3bda5d" />
