### PR TITLE
Teams Update: Kafka Acl Functions

### DIFF
--- a/app/lib/kafka.server.ts
+++ b/app/lib/kafka.server.ts
@@ -6,17 +6,54 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { KafkaJS } from '@confluentinc/kafka-javascript'
-import { Kafka } from 'gcn-kafka'
+import type { AclEntry } from 'gcn-kafka'
+import {
+  AclOperationTypes,
+  AclPermissionTypes,
+  AclResourceTypes,
+  Kafka,
+  KafkaJSError,
+  ResourcePatternTypes,
+} from 'gcn-kafka'
 import memoizee from 'memoizee'
 import { custom } from 'openid-client'
 
 import { domain, getEnvOrDieInProduction } from './env.server'
+import type { Team, Topic } from './teams.server'
+import type { User } from '~/routes/_auth/user.server'
+
+export type UserClientType = 'producer' | 'consumer'
+
+const operations = {
+  // Read only permissions
+  consumer: [AclOperationTypes.READ, AclOperationTypes.DESCRIBE],
+  // Read and write permissions
+  producer: [
+    AclOperationTypes.CREATE,
+    AclOperationTypes.READ,
+    AclOperationTypes.WRITE,
+    AclOperationTypes.DESCRIBE,
+  ],
+}
+
+const resourceTypes = [
+  ResourcePatternTypes.LITERAL,
+  ResourcePatternTypes.PREFIXED,
+]
 
 const client_id = getEnvOrDieInProduction('KAFKA_CLIENT_ID') ?? ''
 const client_secret = getEnvOrDieInProduction('KAFKA_CLIENT_SECRET')
 const kafka = new Kafka({
   client_id,
   client_secret,
+  domain,
+})
+
+const admin_client_id = getEnvOrDieInProduction('KAFKA_ADMIN_CLIENT_ID') ?? ''
+const admin_client_secret = getEnvOrDieInProduction('KAFKA_ADMIN_CLIENT_SECRET')
+const adminKafka = new Kafka({
+  client_id: admin_client_id,
+  client_secret: admin_client_secret,
   domain,
 })
 
@@ -86,4 +123,143 @@ if (process.env.ARC_SANDBOX) {
     const producer = await getProducer()
     await producer.send({ topic, messages: [{ value }] })
   }
+}
+
+function formatTeamName(teamName: string) {
+  return teamName.toLowerCase().replaceAll(' ', '_')
+}
+
+/**
+ * Updates the Kafka broker with new Kafka ACL Entries.
+ * Should be called after team creation.
+ *
+ * @throws 403 response if the user is not a GCN admin
+ *
+ */
+export async function createTeamAcls(user: User, topic: Topic, team: Team) {
+  if (!user.groups.includes('gcn.nasa.gov/gcn-admin')) {
+    throw new Response(null, { status: 403 })
+  }
+  const formattedTeamName = formatTeamName(team.teamName)
+  const consumerAcls = buildAcls(topic.topicName, formattedTeamName, 'consumer')
+  if (topic.public) {
+    consumerAcls.push(...buildAcls(topic.topicName, '*', 'consumer'))
+  }
+  const producerAcls = buildAcls(topic.topicName, formattedTeamName, 'producer')
+  const adminClient = adminKafka.admin()
+  await adminClient.connect()
+  await adminClient.createAcls({ acl: [...consumerAcls, ...producerAcls] })
+}
+
+/**
+ * Deletes all acls for a given topic.
+ * @param user
+ * @param topic
+ * @param team
+ */
+export async function deleteTeamAcls(user: User, topic: Topic, team: Team) {
+  if (!user.groups.includes('gcn.nasa.gov/gcn-admin')) {
+    throw new Response(null, { status: 403 })
+  }
+
+  const formattedTeamName = formatTeamName(team.teamName)
+  const aclsToDelete = [
+    // Producer topics
+    ...buildAcls(topic.topicName, formattedTeamName, 'producer'),
+    // Private Consumer topics
+    ...buildAcls(topic.topicName, formattedTeamName, 'consumer'),
+    // Public Consumer topics
+    ...buildAcls(topic.topicName, '*', 'consumer'),
+  ]
+  const adminClient = adminKafka.admin()
+  await adminClient.connect()
+  await adminClient.deleteAcls({
+    filters: aclsToDelete,
+  })
+}
+
+/**
+ * Creates public consumer acl rules on the broker if topic.pulic is true,
+ * deletes them otherwise
+ */
+export async function toggleTopicPrivacy(user: User, topic: Topic) {
+  // TODO: Add check for userIsTeamAdmin when that function is merged
+  const acls = buildAcls(topic.topicName, '*', 'consumer')
+  const adminClient = adminKafka.admin()
+  await adminClient.connect()
+  if (topic.public) {
+    await adminClient.createAcls({ acl: acls })
+  } else {
+    await adminClient.deleteAcls({ filters: acls })
+  }
+}
+
+export async function getAclsFromBrokers(user: User): Promise<AclEntry[]> {
+  if (!user.groups.includes('gcn.nasa.gov/gcn-admin'))
+    throw new Response(null, { status: 403 })
+  const adminClient = adminKafka.admin()
+  await adminClient.connect()
+  const acls = await adminClient.describeAcls({
+    resourceType: AclResourceTypes.ANY,
+    host: '*',
+    permissionType: AclPermissionTypes.ANY,
+    operation: AclOperationTypes.ANY,
+    resourcePatternType: ResourcePatternTypes.ANY,
+  })
+  await adminClient.disconnect()
+  const results: AclEntry[] = []
+  for (const item of acls.resources) {
+    results.push(
+      ...item.acls.map((acl) => {
+        return {
+          ...acl,
+          resourceName: item.resourceName,
+          resourceType: item.resourceType,
+          resourcePatternType: item.resourcePatternType,
+        }
+      })
+    )
+  }
+
+  return results
+}
+
+/**
+ * Constructs an array of AclEntry objects based on the provided principal type.
+ *
+ * The returned array will have AclEntry objects for both the LITERAL and PREFIXED
+ * resource types.
+ *
+ * The format of `principal` on each AclEntry will be: `principalType:formattedTeamName`,
+ * e.g. `consumer:team_a`, `producer:team_a`
+ *
+ * @param topicName name of the topic, should NOT end with a period or have trailing
+ * whitespace, as a period will automatically be appended for the PREFIX AclEntries
+ * @param formattedTeamName the team name in lowercase with spaces replaced with '_'.
+ * If "*" is provided as `formattedTeamName`, this will return the AclEntries to make
+ * the topic publicly available.
+ * @param principalType `producer` or `consumer`, which map as keys in the
+ * `operations` const
+ */
+function buildAcls(
+  topicName: string,
+  formattedTeamName: string,
+  principalType: UserClientType
+): AclEntry[] {
+  return resourceTypes.flatMap((type) =>
+    operations[principalType].map((operation) => {
+      return {
+        resourceType: AclResourceTypes.TOPIC,
+        resourceName: `${topicName}${type === ResourcePatternTypes.PREFIXED ? '.' : ''}`,
+        resourcePatternType: type,
+        principal:
+          formattedTeamName == '*'
+            ? 'User:*'
+            : `${principalType}:${formattedTeamName}`, // This may need to be User:`${principalType}:${formattedTeamName}`, still testing
+        host: '*',
+        operation,
+        permissionType: AclPermissionTypes.ALLOW,
+      }
+    })
+  )
 }

--- a/src/plugins/admin-kafka-client.js
+++ b/src/plugins/admin-kafka-client.js
@@ -1,0 +1,35 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const deploy = {
+  start({ cloudformation }) {
+    const clientKey = 'GcnKafkaAdminUserPoolClient'
+    const env =
+      cloudformation.Resources.AnyCatchallHTTPLambda.Properties.Environment
+        .Variables
+    const user_pool_id = env.COGNITO_USER_POOL_ID
+    if (!user_pool_id)
+      throw new Error('Environment variable COGNITO_USER_POOL_ID must be set')
+    cloudformation.Resources[clientKey] = {
+      Type: 'AWS::Cognito::UserPoolClient',
+      Properties: {
+        AllowedOAuthFlows: ['client_credentials'],
+        AllowedOAuthFlowsUserPoolClient: true,
+        AllowedOAuthScopes: ['gcn.nasa.gov/kafka-admin'],
+        GenerateSecret: true,
+        UserPoolId: process.env.COGNITO_USER_POOL_ID,
+      },
+    }
+    env.KAFKA_ADMIN_CLIENT_ID = {
+      'Fn::GetAtt': `${clientKey}.ClientId`,
+    }
+    env.KAFKA_ADMIN_CLIENT_SECRET = {
+      'Fn::GetAtt': `${clientKey}.ClientSecret`,
+    }
+  },
+}


### PR DESCRIPTION
# Description

- Provision app client for admin actions
- Add functions for:
  - Building `AclEntry` objects based on Client Type ('producer'/'consumer')
  - Creating ACLs on brokers
  - Deleting ACLs on brokers
  - Retrieving ACLs from brokers
  - Updating topic as Public/Private

Also I am open to changing the use of producer/consumer wording in code to write/read

# Related Issue(s)
Relates to https://github.com/nasa-gcn/gcn.nasa.gov/pull/3577, referenced in TODO comments

# Testing

Working on tests