### PR TITLE
Add direct link to individual circular page from event view

### DIFF
--- a/app/routes/circulars.events.$slug.tsx
+++ b/app/routes/circulars.events.$slug.tsx
@@ -72,6 +72,16 @@ export default function Group() {
             <div key={circularId}>
               <h2 className="margin-2">
                 <Anchor>{`GCN Circular ${circularId}`}</Anchor>
+                <Link
+                  to={`/circulars/${circularId}`}
+                  className="margin-left-1"
+                  title="View this circular"
+                >
+                  <Icon.Launch
+                    role="presentation"
+                    className="margin-y-neg-2px"
+                  />
+                </Link>
               </h2>
               <div className="margin-2">
                 <FrontMatter


### PR DESCRIPTION
## Summary
Adds a direct link to individual circular pages from the event view.

## Problem
When viewing an event page (e.g. circulars/events/ligovirgokagra-s230922g), 
circulars are displayed inline but there is no way to navigate 
to a circular's dedicated page (/circulars/{circularId}).

The existing anchor icon only scrolls within the page — it does 
not link to the individual circular page. Users cannot share a 
direct URL to a specific circular or access its dedicated page 
with full metadata.

## Solution
Added a launch icon Link next to each circular heading that 
navigates to /circulars/{circularId}, giving users a clear way 
to open any circular on its own dedicated page.

## Testing
Verified locally at http://localhost:3333/circulars/events/ligovirgokagra-s230922g
The launch icon appears next to each circular heading and 
correctly navigates to the individual circular page.

## Related
This complements the discussion in #3516 about the unclear 
anchor link behavior, by adding a separate and clearly distinct 
navigation link.