### PR TITLE
Update UserLookup to get single user per email

### DIFF
--- a/app/components/UserLookup.tsx
+++ b/app/components/UserLookup.tsx
@@ -18,7 +18,6 @@ import { formatAuthor } from '~/routes/circulars/circulars.lib'
 import loaderImage from 'nasawds/src/img/loader.gif'
 
 export interface UserLookup {
-  sub?: string
   email: string
   name?: string
   affiliation?: string
@@ -43,7 +42,6 @@ export function UserLookupComboBox({
   className,
   group,
   onChange,
-  // ref,
   ...props
 }: UserComboBoxProps & UserComboBoxHandle) {
   const fetcher = useFetcher<typeof action>()
@@ -151,12 +149,12 @@ export function UserLookupComboBox({
           (items.length ? (
             items.map((item, index) => (
               <li
-                key={item.sub}
+                key={formatAuthor(item)}
                 className={classnames('usa-combo-box__list-option', {
                   'usa-combo-box__list-option--focused':
                     index === highlightedIndex,
                   'usa-combo-box__list-option--selected':
-                    selectedItem?.sub === item.sub,
+                    selectedItem?.email === item.email,
                 })}
                 {...getItemProps({ item, index })}
               >

--- a/app/lib/cognito.server.ts
+++ b/app/lib/cognito.server.ts
@@ -107,17 +107,15 @@ export async function listUsers(
   return Array.from(userMap)
 }
 
-export async function searchForUsersByKey(
+async function searchForUsersByKey(
   filterString: string,
-  filterKey: 'email' | 'name',
-  limit?: number
+  filterKey: 'email' | 'name'
 ) {
   const pages = paginateListUsers(
     { client: cognito },
     {
       UserPoolId,
       Filter: `${filterKey} ^= "${filterString}"`,
-      Limit: limit,
     }
   )
   const results = []
@@ -139,6 +137,7 @@ export async function getSingleUserFromEmail(email: string) {
     throw new Response('Requested user does not exist', {
       status: 400,
     })
+
   let user: UserType | undefined
 
   if (matches.length > 1) {
@@ -149,7 +148,6 @@ export async function getSingleUserFromEmail(email: string) {
   } else {
     user = matches[0]
   }
-
   return user
 }
 

--- a/app/lib/cognito.server.ts
+++ b/app/lib/cognito.server.ts
@@ -107,15 +107,17 @@ export async function listUsers(
   return Array.from(userMap)
 }
 
-async function searchForUsersByKey(
+export async function searchForUsersByKey(
   filterString: string,
-  filterKey: 'email' | 'name'
+  filterKey: 'email' | 'name',
+  limit?: number
 ) {
   const pages = paginateListUsers(
     { client: cognito },
     {
       UserPoolId,
       Filter: `${filterKey} ^= "${filterString}"`,
+      Limit: limit,
     }
   )
   const results = []
@@ -129,6 +131,26 @@ async function searchForUsersByKey(
       )
   }
   return results
+}
+
+export async function getSingleUserFromEmail(email: string) {
+  const matches = await searchForUsersByKey(email, 'email')
+  if (matches.length === 0)
+    throw new Response('Requested user does not exist', {
+      status: 400,
+    })
+  let user: UserType | undefined
+
+  if (matches.length > 1) {
+    user = matches.find(
+      (user) => !extractAttribute(user.Attributes, 'dev:custom:existingIdp')
+    )
+    if (!user) throw new Response(null, { status: 404 })
+  } else {
+    user = matches[0]
+  }
+
+  return user
 }
 
 export async function listUsersInGroup(GroupName: string) {
@@ -242,7 +264,6 @@ export async function getUserGroupStrings(Username: string) {
 
 export async function checkUserIsVerified(sub: string) {
   const { Username } = await getCognitoUserFromSub(sub)
-
   const { UserAttributes } = await cognito.send(
     new AdminGetUserCommand({
       UserPoolId,

--- a/app/routes/admin.users._index.tsx
+++ b/app/routes/admin.users._index.tsx
@@ -14,6 +14,7 @@ import { useState } from 'react'
 import { getUser } from './_auth/user.server'
 import { adminGroup } from './admin'
 import { UserLookupComboBox } from '~/components/UserLookup'
+import { extractAttribute, getSingleUserFromEmail } from '~/lib/cognito.server'
 import { getFormDataString } from '~/lib/utils'
 import type { BreadcrumbHandle } from '~/root/Title'
 import type { SEOHandle } from '~/root/seo'
@@ -31,26 +32,34 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export async function action({ request }: ActionFunctionArgs) {
+  const user = await getUser(request)
+  if (!user?.groups.includes(adminGroup))
+    throw new Response(null, { status: 403 })
   const data = await request.formData()
-  const userSub = getFormDataString(data, 'userSub')
-  return redirect(`/admin/users/${userSub}`)
+  const userEmail = getFormDataString(data, 'userEmail')
+  if (!userEmail) throw new Response('Missing user email', { status: 400 })
+  const userToUpdate = await getSingleUserFromEmail(userEmail)
+
+  return redirect(
+    `/admin/users/${extractAttribute(userToUpdate.Attributes, 'sub')}`
+  )
 }
 
 export default function () {
-  const [userSub, setUserSub] = useState('')
+  const [userEmail, setUserEmail] = useState('')
   return (
     <>
       <h1>Users</h1>
       <p>Manage users and their group associations</p>
       <Form method="POST">
         <Label htmlFor="emailFilter">Filter</Label>
-        <input type="hidden" name="userSub" value={userSub} />
+        <input type="hidden" name="userEmail" value={userEmail} />
         <UserLookupComboBox
           onSelectedItemChange={({ selectedItem }) =>
-            setUserSub(selectedItem?.sub ?? '')
+            setUserEmail(selectedItem?.email ?? '')
           }
         />
-        <Button type="submit" className="margin-y-1" disabled={!userSub}>
+        <Button type="submit" className="margin-y-1" disabled={!userEmail}>
           Edit
         </Button>
       </Form>

--- a/app/routes/api.users.ts
+++ b/app/routes/api.users.ts
@@ -34,7 +34,6 @@ export async function action({ request }: ActionFunctionArgs) {
       users = (await listUsersInGroup(groupFilter))
         .map((x) => {
           return {
-            sub: x.Attributes?.find((x) => x.Name == 'sub')?.Value,
             email: x.Attributes?.find((x) => x.Name == 'email')?.Value ?? '',
             name: x.Attributes?.find((x) => x.Name == 'name')?.Value,
             affiliation: x.Attributes?.find((x) => x.Name == 'affiliation')

--- a/app/routes/user.endorsements/endorsements.server.ts
+++ b/app/routes/user.endorsements/endorsements.server.ts
@@ -21,9 +21,9 @@ import {
   extractAttribute,
   extractAttributeRequired,
   getCognitoUserFromSub,
+  getSingleUserFromEmail,
   listUsersInGroup,
   maybeThrowCognito,
-  searchForUsersByKey,
 } from '~/lib/cognito.server'
 import { sendEmail } from '~/lib/email.server'
 import { origin } from '~/lib/env.server'
@@ -55,56 +55,8 @@ export interface EndorsementUser {
   affiliation?: string
 }
 
-async function getUsersInGroup(): Promise<EndorsementUser[]> {
-  let users
-  try {
-    users = await listUsersInGroup(submitterGroup)
-  } catch (error) {
-    maybeThrowCognito(error, 'returning fake users')
-    return [
-      {
-        sub: crypto.randomUUID(),
-        email: 'a.einstein@example.com',
-        name: 'Albert Einstein',
-      },
-      {
-        sub: crypto.randomUUID(),
-        email: 'c.sagan@example.com',
-        name: 'Carl Sagan',
-      },
-    ]
-  }
-
-  return users.map(({ Attributes }) => ({
-    sub: extractAttributeRequired(Attributes, 'sub'),
-    email: extractAttributeRequired(Attributes, 'email'),
-    name: extractAttribute(Attributes, 'name'),
-    affiliation: extractAttribute(Attributes, 'custom:affiliation'),
-  }))
-}
-
 function userIsSubmitter(user: User) {
   return user.groups.includes(submitterGroup)
-}
-
-/**
- * Adds a user to the circulars submitters group
- *
- * Throws an HTTP error if:
- *  - The provided sub does not correspond to an existing user
- *
- * @param sub - sub of another user
- */
-async function addUserToGroup(sub: string) {
-  const { Username } = await getCognitoUserFromSub(sub)
-
-  await cognito.send(
-    new AdminAddUserToGroupCommand({
-      Username,
-      UserPoolId: process.env.COGNITO_USER_POOL_ID,
-      GroupName: submitterGroup,
-    })
-  )
 }
 
 /**
@@ -130,15 +82,11 @@ export async function createEndorsementRequest(
       }
     )
 
-  const endorsementUser = await searchForUsersByKey(endorserEmail, 'email', 1)
-  if (endorsementUser.length === 0)
-    throw new Response('Requested endorser email does not exist', {
-      status: 400,
-    })
+  const endorsementUser = await getSingleUserFromEmail(endorserEmail)
 
   const { Groups } = await cognito.send(
     new AdminListGroupsForUserCommand({
-      Username: endorsementUser[0].Username,
+      Username: endorsementUser.Username,
       UserPoolId: process.env.COGNITO_USER_POOL_ID,
     })
   )
@@ -149,7 +97,7 @@ export async function createEndorsementRequest(
     })
 
   const endorserSub = extractAttributeRequired(
-    endorsementUser[0].Attributes,
+    endorsementUser.Attributes,
     'sub'
   )
 
@@ -393,4 +341,52 @@ export async function getSubmitterUsers(user: User) {
   ])
 
   return users.filter(({ sub }) => !excludedSubs.has(sub))
+}
+
+/**
+ * Adds a user to the circulars submitters group
+ *
+ * Throws an HTTP error if:
+ *  - The provided sub does not correspond to an existing user
+ *
+ * @param sub - sub of another user
+ */
+async function addUserToGroup(sub: string) {
+  const { Username } = await getCognitoUserFromSub(sub)
+
+  await cognito.send(
+    new AdminAddUserToGroupCommand({
+      Username,
+      UserPoolId: process.env.COGNITO_USER_POOL_ID,
+      GroupName: submitterGroup,
+    })
+  )
+}
+
+async function getUsersInGroup(): Promise<EndorsementUser[]> {
+  let users
+  try {
+    users = await listUsersInGroup(submitterGroup)
+  } catch (error) {
+    maybeThrowCognito(error, 'returning fake users')
+    return [
+      {
+        sub: crypto.randomUUID(),
+        email: 'a.einstein@example.com',
+        name: 'Albert Einstein',
+      },
+      {
+        sub: crypto.randomUUID(),
+        email: 'c.sagan@example.com',
+        name: 'Carl Sagan',
+      },
+    ]
+  }
+
+  return users.map(({ Attributes }) => ({
+    sub: extractAttributeRequired(Attributes, 'sub'),
+    email: extractAttributeRequired(Attributes, 'email'),
+    name: extractAttribute(Attributes, 'name'),
+    affiliation: extractAttribute(Attributes, 'custom:affiliation'),
+  }))
 }

--- a/app/routes/user.endorsements/endorsements.server.ts
+++ b/app/routes/user.endorsements/endorsements.server.ts
@@ -23,6 +23,7 @@ import {
   getCognitoUserFromSub,
   listUsersInGroup,
   maybeThrowCognito,
+  searchForUsersByKey,
 } from '~/lib/cognito.server'
 import { sendEmail } from '~/lib/email.server'
 import { origin } from '~/lib/env.server'
@@ -54,8 +55,56 @@ export interface EndorsementUser {
   affiliation?: string
 }
 
+async function getUsersInGroup(): Promise<EndorsementUser[]> {
+  let users
+  try {
+    users = await listUsersInGroup(submitterGroup)
+  } catch (error) {
+    maybeThrowCognito(error, 'returning fake users')
+    return [
+      {
+        sub: crypto.randomUUID(),
+        email: 'a.einstein@example.com',
+        name: 'Albert Einstein',
+      },
+      {
+        sub: crypto.randomUUID(),
+        email: 'c.sagan@example.com',
+        name: 'Carl Sagan',
+      },
+    ]
+  }
+
+  return users.map(({ Attributes }) => ({
+    sub: extractAttributeRequired(Attributes, 'sub'),
+    email: extractAttributeRequired(Attributes, 'email'),
+    name: extractAttribute(Attributes, 'name'),
+    affiliation: extractAttribute(Attributes, 'custom:affiliation'),
+  }))
+}
+
 function userIsSubmitter(user: User) {
   return user.groups.includes(submitterGroup)
+}
+
+/**
+ * Adds a user to the circulars submitters group
+ *
+ * Throws an HTTP error if:
+ *  - The provided sub does not correspond to an existing user
+ *
+ * @param sub - sub of another user
+ */
+async function addUserToGroup(sub: string) {
+  const { Username } = await getCognitoUserFromSub(sub)
+
+  await cognito.send(
+    new AdminAddUserToGroupCommand({
+      Username,
+      UserPoolId: process.env.COGNITO_USER_POOL_ID,
+      GroupName: submitterGroup,
+    })
+  )
 }
 
 /**
@@ -70,10 +119,10 @@ function userIsSubmitter(user: User) {
  */
 export async function createEndorsementRequest(
   user: User,
-  endorserSub: string,
+  endorserEmail: string,
   note: string
 ) {
-  if (endorserSub === user.sub)
+  if (endorserEmail === user.email)
     throw new Response(
       'Users cannot request themselves as the endorser of their own request',
       {
@@ -81,11 +130,15 @@ export async function createEndorsementRequest(
       }
     )
 
-  const endorsementUser = await getCognitoUserFromSub(endorserSub)
+  const endorsementUser = await searchForUsersByKey(endorserEmail, 'email', 1)
+  if (endorsementUser.length === 0)
+    throw new Response('Requested endorser email does not exist', {
+      status: 400,
+    })
 
   const { Groups } = await cognito.send(
     new AdminListGroupsForUserCommand({
-      Username: endorsementUser.Username,
+      Username: endorsementUser[0].Username,
       UserPoolId: process.env.COGNITO_USER_POOL_ID,
     })
   )
@@ -95,9 +148,9 @@ export async function createEndorsementRequest(
       status: 400,
     })
 
-  const endorserEmail = extractAttributeRequired(
-    endorsementUser.Attributes,
-    'email'
+  const endorserSub = extractAttributeRequired(
+    endorsementUser[0].Attributes,
+    'sub'
   )
 
   const db = await tables()
@@ -340,52 +393,4 @@ export async function getSubmitterUsers(user: User) {
   ])
 
   return users.filter(({ sub }) => !excludedSubs.has(sub))
-}
-
-/**
- * Adds a user to the circulars submitters group
- *
- * Throws an HTTP error if:
- *  - The provided sub does not correspond to an existing user
- *
- * @param sub - sub of another user
- */
-async function addUserToGroup(sub: string) {
-  const { Username } = await getCognitoUserFromSub(sub)
-
-  await cognito.send(
-    new AdminAddUserToGroupCommand({
-      Username,
-      UserPoolId: process.env.COGNITO_USER_POOL_ID,
-      GroupName: submitterGroup,
-    })
-  )
-}
-
-async function getUsersInGroup(): Promise<EndorsementUser[]> {
-  let users
-  try {
-    users = await listUsersInGroup(submitterGroup)
-  } catch (error) {
-    maybeThrowCognito(error, 'returning fake users')
-    return [
-      {
-        sub: crypto.randomUUID(),
-        email: 'a.einstein@example.com',
-        name: 'Albert Einstein',
-      },
-      {
-        sub: crypto.randomUUID(),
-        email: 'c.sagan@example.com',
-        name: 'Carl Sagan',
-      },
-    ]
-  }
-
-  return users.map(({ Attributes }) => ({
-    sub: extractAttributeRequired(Attributes, 'sub'),
-    email: extractAttributeRequired(Attributes, 'email'),
-    name: extractAttribute(Attributes, 'name'),
-    affiliation: extractAttribute(Attributes, 'custom:affiliation'),
-  }))
 }

--- a/app/routes/user.endorsements/route.tsx
+++ b/app/routes/user.endorsements/route.tsx
@@ -58,6 +58,7 @@ export async function action({ request }: ActionFunctionArgs) {
   if (!user) throw new Response(undefined, { status: 403 })
   const data = await request.formData()
   const intent = getFormDataString(data, 'intent')
+  const endorserEmail = getFormDataString(data, 'endorserEmail')
   const endorserSub = getFormDataString(data, 'endorserSub')
   const requestorSub = getFormDataString(data, 'requestorSub')
   const filter = getFormDataString(data, 'filter')
@@ -65,9 +66,9 @@ export async function action({ request }: ActionFunctionArgs) {
 
   switch (intent) {
     case 'create':
-      if (!endorserSub)
+      if (!endorserEmail)
         throw new Response('Valid endorser is required', { status: 403 })
-      await createEndorsementRequest(user, endorserSub, note)
+      await createEndorsementRequest(user, endorserEmail, note)
       break
     case 'approved':
     case 'rejected':
@@ -362,7 +363,7 @@ interface EndorsementComboBoxHandle {
 
 export function EndorsementRequestForm() {
   const ref = useRef<EndorsementComboBoxHandle>(null)
-  const [endorserSub, setEndorserSub] = useState('')
+  const [endorserEmail, setEndorserEmail] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const fetcher = useFetcher()
 
@@ -375,7 +376,7 @@ export function EndorsementRequestForm() {
 
   return (
     <fetcher.Form method="POST" onSubmit={() => setSubmitting(true)}>
-      <input type="hidden" name="endorserSub" value={endorserSub} />
+      <input type="hidden" name="endorserEmail" value={endorserEmail} />
       <Grid row>
         <Grid col="fill">
           <Label htmlFor="endorserSubSelect" className="usa-sr-only">
@@ -386,7 +387,7 @@ export function EndorsementRequestForm() {
             className="maxw-full"
             disabled={submitting}
             onSelectedItemChange={({ selectedItem }) =>
-              setEndorserSub(selectedItem?.sub ?? '')
+              setEndorserEmail(selectedItem?.email ?? '')
             }
           />
         </Grid>
@@ -405,7 +406,7 @@ export function EndorsementRequestForm() {
             type="submit"
             name="intent"
             value="create"
-            disabled={submitting || !endorserSub}
+            disabled={submitting || !endorserEmail}
             className="margin-top-1 tablet:margin-left-1 tablet:margin-right-0"
           >
             {submitting ? 'Requesting...' : 'Request'}


### PR DESCRIPTION
# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->

- Updates `UserLookup` to not require sub
- Updates `cognito.server.ts`:
  - add function to get single user when there may be multiple entries for a given email
- Updates the Endorsement system:
  - Use the updated `UserLookup` in the webpage and new cognito function in backend
  - Reuse the userIsSubmitter permission 
- Updates admin pages to use updated `UserLookup`



# Testing
Manually tested admin page behavior locally, still works as expected
Tested the creation and acceptance of endorsement requests, still behaves as expected