### PR TITLE
Add table of contents to documentation

### DIFF
--- a/app/components/TableOfContents.tsx
+++ b/app/components/TableOfContents.tsx
@@ -1,0 +1,58 @@
+import classNames from 'classnames'
+import { useEffect, useState } from 'react'
+
+type TocItem = {
+  id: string
+  text: string
+}
+
+function compileTOC(container: ParentNode): TocItem[] {
+  return Array.from(container.querySelectorAll('h2, h3, h4, h5, h6'))
+    .map((heading) => ({
+      id: heading.id,
+      text: heading.textContent?.trim() ?? '',
+    }))
+    .filter((heading) => heading.id && heading.text)
+}
+
+export function TableOfContents({
+  className,
+  selector = '[data-mdx-content]',
+}: {
+  className?: string
+  selector?: string
+}) {
+  const [items, setItems] = useState<TocItem[]>([])
+
+  useEffect(() => {
+    const container = document.querySelector(selector)
+
+    if (container) {
+      setItems(compileTOC(container))
+    }
+  }, [selector])
+
+  if (items.length === 0) {
+    return null
+  }
+
+  return (
+    <nav
+      aria-label="Table of contents"
+      className={classNames('margin-y-4 padding-2', className)}
+    >
+      <p className="usa-label margin-top-0 margin-bottom-2">
+        Table of Contents
+      </p>
+      <ul className="usa-list usa-list--unstyled margin-0">
+        {items.map((item) => (
+          <li key={item.id} className="margin-bottom-1">
+            <a className="usa-link" href={`#${item.id}`}>
+              {item.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/app/components/TableOfContents.tsx
+++ b/app/components/TableOfContents.tsx
@@ -51,10 +51,8 @@ export function TableOfContents({
           <li
             key={item.id}
             className={classNames('margin-bottom-1', {
-              'margin-left-2': item.level === 3,
-              'margin-left-4': item.level === 4,
-              'margin-left-6': item.level === 5,
-              'margin-left-8': item.level === 6,
+              [`margin-left-${(item.level - 1) * 2}`]:
+                item.level >= 3 && item.level <= 6,
             })}
           >
             <a className="usa-link" href={`#${item.id}`}>

--- a/app/components/TableOfContents.tsx
+++ b/app/components/TableOfContents.tsx
@@ -39,28 +39,29 @@ export function TableOfContents({
   }
 
   return (
-    <nav
-      aria-label="Table of contents"
-      className={classNames('margin-y-4 padding-2', className)}
-    >
-      <p className="usa-label margin-top-0 margin-bottom-2">
-        Table of Contents
-      </p>
-      <ul className="usa-list usa-list--unstyled margin-0">
-        {items.map((item) => (
-          <li
-            key={item.id}
-            className={classNames('margin-bottom-1', {
-              [`margin-left-${(item.level - 1) * 2}`]:
-                item.level >= 3 && item.level <= 6,
-            })}
-          >
-            <a className="usa-link" href={`#${item.id}`}>
-              {item.text}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </nav>
+    <details>
+      <summary>Table of Contents</summary>
+
+      <nav
+        aria-label="Table of contents"
+        className={classNames('padding-2', className)}
+      >
+        <ul className="usa-list usa-list--unstyled margin-0">
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className={classNames('margin-bottom-1', {
+                [`margin-left-${(item.level - 1) * 2}`]:
+                  item.level >= 3 && item.level <= 6,
+              })}
+            >
+              <a className="usa-link" href={`#${item.id}`}>
+                {item.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </details>
   )
 }

--- a/app/components/TableOfContents.tsx
+++ b/app/components/TableOfContents.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 
 type TocItem = {
   id: string
+  level: number
   text: string
 }
 
@@ -10,6 +11,7 @@ function compileTOC(container: ParentNode): TocItem[] {
   return Array.from(container.querySelectorAll('h2, h3, h4, h5, h6'))
     .map((heading) => ({
       id: heading.id,
+      level: Number.parseInt(heading.tagName.slice(1), 10),
       text: heading.textContent?.trim() ?? '',
     }))
     .filter((heading) => heading.id && heading.text)
@@ -46,7 +48,15 @@ export function TableOfContents({
       </p>
       <ul className="usa-list usa-list--unstyled margin-0">
         {items.map((item) => (
-          <li key={item.id} className="margin-bottom-1">
+          <li
+            key={item.id}
+            className={classNames('margin-bottom-1', {
+              'margin-left-2': item.level === 3,
+              'margin-left-4': item.level === 4,
+              'margin-left-6': item.level === 5,
+              'margin-left-8': item.level === 6,
+            })}
+          >
             <a className="usa-link" href={`#${item.id}`}>
               {item.text}
             </a>

--- a/app/components/TableOfContents.tsx
+++ b/app/components/TableOfContents.tsx
@@ -55,7 +55,20 @@ export function TableOfContents({
                   item.level >= 3 && item.level <= 6,
               })}
             >
-              <a className="usa-link" href={`#${item.id}`}>
+              <a
+                className="usa-link"
+                href={`#${item.id}`}
+                onClick={(e) => {
+                  e.preventDefault()
+                  const target = document.getElementById(item.id)
+                  if (target) {
+                    target.scrollIntoView({
+                      behavior: 'smooth',
+                      block: 'start',
+                    })
+                  }
+                }}
+              >
                 {item.text}
               </a>
             </li>

--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -10,13 +10,13 @@ import { WithFeature } from '~/root'
 
 # Circulars Archive
 
+<TableOfContents />
+
 Upon successful submission and distribution, a GCN Circular is assigned a number and stored permanently in the [GCN Circulars archive](/circulars). The archive lists links to the full text of every GCN Circular in reverse chronological order. The archive has a full-text search feature that you can use to find all Circulars that contain a phrase or keyword.
 
 <Link to="/circulars" className="usa-button">
   Go to GCN Circulars Archive
 </Link>
-
-<TableOfContents />
 
 ## Searching the Archive
 

--- a/app/routes/docs.circulars.archive.mdx
+++ b/app/routes/docs.circulars.archive.mdx
@@ -5,6 +5,7 @@ handle:
 
 import { Link } from '@remix-run/react'
 
+import { TableOfContents } from '~/components/TableOfContents'
 import { WithFeature } from '~/root'
 
 # Circulars Archive
@@ -14,6 +15,8 @@ Upon successful submission and distribution, a GCN Circular is assigned a number
 <Link to="/circulars" className="usa-button">
   Go to GCN Circulars Archive
 </Link>
+
+<TableOfContents />
 
 ## Searching the Archive
 

--- a/app/routes/docs.tsx
+++ b/app/routes/docs.tsx
@@ -262,7 +262,9 @@ export default function () {
           />
         </div>
         <div className="desktop:grid-col-9">
-          <Outlet />
+          <div data-mdx-content>
+            <Outlet />
+          </div>
         </div>
       </div>
     </GridContainer>


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
Per our discussion in our most recent sprint planning, some of the documentation pages are becoming long enough to benefit from a table of contents. Rather than using markdown for each page and updating as new sections are added, it would be useful to have a component to generate the table of contents dynamically.

This adds a new TableOfContents component that finds all subheadings on a page and compiles them into a list of links to each. When clicked, each item will scroll the page to that subheading. By default, the table of contents is collapsed in a manner similar to #2713 

<img width="1017" height="1178" alt="image" src="https://github.com/user-attachments/assets/8dcb1d43-c018-4c68-a96b-d240b8d1aadc" />

As of opening this PR, this is just implemented for the Circulars archive documentation page, but the component should be usable for any documentation page that uses subheaders to organize the content.


# Related Issue(s)
<!-- Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
Example:
`Resolves #100` -->
Resolves #3604 

# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->
1. Navigate to Circulars documentation on the archive
2. Expand the table of contents
3. Click on any of the links
4. They should direct you to the relevant subheading
