### PR TITLE
Build auxiliary Lambdas before running Playwright tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -75,7 +75,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npx run-s build:sass dev:remix',
+    command: 'npx run-s build:sass build:esbuild dev:remix',
     port: 3333,
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',


### PR DESCRIPTION
These Lambdas must be built so that @architect/plugin-lambda-invoker can run them.