### PR TITLE
Increase memory for scheduled Circulars Lambda

### DIFF
--- a/build/scheduled/circulars/config.arc
+++ b/build/scheduled/circulars/config.arc
@@ -1,3 +1,3 @@
 @aws
 timeout 900
-memory 512
+memory 1024


### PR DESCRIPTION
The Lambda is failing on production with the error message `Error Type: Runtime.OutOfMemory`.