### PR TITLE
Break up promise.all to check getEndorsment calls

### DIFF
--- a/app/routes/api.users.ts
+++ b/app/routes/api.users.ts
@@ -51,7 +51,6 @@ export async function action({ request }: ActionFunctionArgs) {
           name?.toLowerCase().includes(filter.toLowerCase())
         )
         .slice(0, 5)
-      console.warn('Confirming users is returned: ', users)
     } else if (userIsAdmin) {
       users = await listUsers(filter)
     }

--- a/app/routes/user.endorsements/route.tsx
+++ b/app/routes/user.endorsements/route.tsx
@@ -43,10 +43,11 @@ export const handle: BreadcrumbHandle & SEOHandle = {
 export async function loader({ request }: LoaderFunctionArgs) {
   const user = await getUser(request)
   if (!user) throw new Response(undefined, { status: 403 })
-  const [requestedEndorsements, awaitingEndorsements] = await Promise.all([
-    getEndorsements(user, 'requestor'),
-    getEndorsements(user, 'endorser'),
-  ])
+
+  const requestedEndorsements = await getEndorsements(user, 'requestor')
+
+  const awaitingEndorsements = await getEndorsements(user, 'endorser')
+
   return {
     requestedEndorsements,
     awaitingEndorsements,


### PR DESCRIPTION
The previous check with a cognito debugger made it clear that the issue is NOT coming from the loop itself. I am now further investigating the error:

```
ERROR	Y6: "iat" claim timestamp check failed (too far in the past)
at Dye (/var/task/index.cjs:262:19392)
at gM (/var/task/index.cjs:262:19818)
at _M (/var/task/index.cjs:262:23337)
at y$t (/var/task/index.cjs:2745:1938)
at Object.LZe [as callRouteLoader] (/var/task/index.cjs:18:9269)
at /var/task/index.cjs:3:5119
at VUe (/var/task/index.cjs:3:5551)
at async Promise.all (index 1)
at HY (/var/task/index.cjs:3:4179)
at YY (/var/task/index.cjs:3:4613) {
code: 'ERR_JWT_EXPIRED',
claim: 'iat',
reason: 'check_failed'
}
```
The `callRouteLoader` in the above error suggests it is coming from the loader function, possibly as it is trying to update after the POST, and this is the only `promise.all` in the loader, so breaking it up should show if the error is being caused by one of these failing and just getting swallowed
