### PR TITLE
Split circulars table stream

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -32,8 +32,13 @@ app-client-expire
   src build/scheduled/app-client-expire
 
 @tables-streams
-circulars
-  src build/table-streams/circulars
+circulars-kafka
+  table circulars
+  src build/table-streams/circulars-kafka
+
+circulars-email
+  table circulars
+  src build/table-streams/circulars-email
 
 synonyms
   src build/table-streams/synonyms

--- a/app/table-streams/circulars-email/index.ts
+++ b/app/table-streams/circulars-email/index.ts
@@ -10,12 +10,9 @@ import { errors } from '@opensearch-project/opensearch'
 import type { DynamoDBRecord } from 'aws-lambda'
 
 import { unmarshallTrigger } from '../utils'
-import { send as sendKafka } from '~/lib/kafka.server'
 import { createTriggerHandler } from '~/lib/lambdaTrigger.server'
 import type { Circular } from '~/routes/circulars/circulars.lib'
 import { send } from '~/routes/circulars/circulars.server'
-
-import { $id as circularsJsonSchemaId } from '@nasa-gcn/schema/gcn/circulars.schema.json'
 
 const index = 'circulars'
 
@@ -42,28 +39,14 @@ async function putIndex(circular: Circular) {
 export const handler = createTriggerHandler(
   async ({ eventName, dynamodb }: DynamoDBRecord) => {
     const id = unmarshallTrigger(dynamodb!.Keys).circularId as number
-    const promises = []
-
     if (eventName === 'REMOVE') {
-      promises.push(removeIndex(id))
+      await removeIndex(id)
     } /* (eventName === 'INSERT' || eventName === 'MODIFY') */ else {
       const circular = unmarshallTrigger(dynamodb!.NewImage) as Circular
-      const { sub, ...cleanedCircular } = circular
-      promises.push(
-        putIndex(circular),
-        sendKafka(
-          'gcn.circulars',
-          JSON.stringify({
-            $schema: circularsJsonSchemaId,
-            ...cleanedCircular,
-          })
-        )
-      )
+      await putIndex(circular)
       if (eventName === 'INSERT') {
-        promises.push(send(circular))
+        await send(circular)
       }
     }
-
-    await Promise.all(promises)
   }
 )

--- a/app/table-streams/circulars-kafka/index.ts
+++ b/app/table-streams/circulars-kafka/index.ts
@@ -1,0 +1,31 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { DynamoDBRecord } from 'aws-lambda'
+
+import { unmarshallTrigger } from '../utils'
+import { send } from '~/lib/kafka.server'
+import { createTriggerHandler } from '~/lib/lambdaTrigger.server'
+import type { Circular } from '~/routes/circulars/circulars.lib'
+
+import { $id as circularsJsonSchemaId } from '@nasa-gcn/schema/gcn/circulars.schema.json'
+
+export const handler = createTriggerHandler(
+  async ({ eventName, dynamodb }: DynamoDBRecord) => {
+    if (eventName === 'INSERT' || eventName === 'MODIFY') {
+      const circular = unmarshallTrigger(dynamodb!.NewImage) as Circular
+      const { sub, ...cleanedCircular } = circular
+      await send(
+        'gcn.circulars',
+        JSON.stringify({
+          $schema: circularsJsonSchemaId,
+          ...cleanedCircular,
+        })
+      )
+    }
+  }
+)


### PR DESCRIPTION
Splits the stream processes to prevent multiple emails from sending when Kafka has connections issues.

Resolves #3658 