### PR TITLE
Replace GetObjectAttributes with HeadObject

### DIFF
--- a/app/routes/circulars._archive.tsx
+++ b/app/routes/circulars._archive.tsx
@@ -5,10 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import {
-  GetObjectAttributesCommand,
-  ObjectAttributes,
-} from '@aws-sdk/client-s3'
+import { HeadObjectCommand } from '@aws-sdk/client-s3'
 import { json } from '@remix-run/node'
 import { Outlet, useLoaderData } from '@remix-run/react'
 import { ButtonGroup, Icon } from '@trussworks/react-uswds'
@@ -24,15 +21,14 @@ import { s3 } from '~/scheduled/circulars/storage'
 async function getFileSize(format: string) {
   const Key = getBucketKey(format)
   try {
-    const { ObjectSize } = await s3.send(
-      new GetObjectAttributesCommand({
+    const { ContentLength } = await s3.send(
+      new HeadObjectCommand({
         Bucket,
         Key,
-        ObjectAttributes: [ObjectAttributes.OBJECT_SIZE],
       })
     )
-    invariant(ObjectSize !== undefined)
-    return ObjectSize
+    invariant(ContentLength !== undefined)
+    return ContentLength
   } catch (e) {
     if (
       process.env.NODE_ENV !== 'production' &&


### PR DESCRIPTION
We are seeing socket hang up errors from GetObjectAttributes which may be an indication that the responses are not being completely consumed, leaving sockets open and dangling.

I am not exactly sure why, but HeadObject is a simpler API call and is worth a try.


<img width="1512" height="1001" alt="Screenshot 2026-06-23 at 09 09 00" src="https://github.com/user-attachments/assets/e79354ac-0f39-4836-aedf-0825bcdf9fa0" />
