### PR TITLE
Allow Lambda cognito-idp:AdminRemoveUserFromGroup IAM action

### DIFF
--- a/src/plugins/lambda-cognito-permissions.js
+++ b/src/plugins/lambda-cognito-permissions.js
@@ -27,6 +27,7 @@ export const deploy = {
               'cognito-idp:AdminAddUserToGroup',
               'cognito-idp:AdminGetUser',
               'cognito-idp:AdminListGroupsForUser',
+              'cognito-idp:AdminRemoveUserFromGroup',
               'cognito-idp:CreateUserPoolClient',
               'cognito-idp:DeleteUserPoolClient',
               'cognito-idp:DescribeUserPoolClient',


### PR DESCRIPTION
Without this, removing a user from a group through the admin page always fails.