### PR TITLE
Fix peer endorser search timeouts

### DIFF
--- a/app/lib/cognito.server.ts
+++ b/app/lib/cognito.server.ts
@@ -136,7 +136,7 @@ export async function listUsersInGroup(GroupName: string) {
     'using a paginator; replace with alternative API calls that avoid large result sets'
   )
   const pages = paginateListUsersInGroup(
-    { client: cognito },
+    { client: cognito, pageSize: 60 },
     { GroupName, UserPoolId }
   )
   const users: UserType[] = []

--- a/build/server/config.arc
+++ b/build/server/config.arc
@@ -1,4 +1,4 @@
 @aws
 concurrency 100
 provisionedConcurrency 5
-timeout 10
+timeout 30


### PR DESCRIPTION
- Increase the page size returned by ListUsersInGroup to the maximum value of 60. This decreases the time to enumerate all ~1400 of our current Circulars users from about 25 seconds to about 20 seconds.
- Increase the timeout of the web application's Lambda to 30 seconds.

Addresses #3641 (but only as a temporary workaround).