### PR TITLE
Fix broken link to quickstart in documentation

### DIFF
--- a/app/routes/docs.circulars.subscribing.mdx
+++ b/app/routes/docs.circulars.subscribing.mdx
@@ -44,8 +44,8 @@ Most users prefer to receive GCN Circulars by email. Automated systems may benef
 
 ## Stream Circulars over Kafka
 
-If you have an existing Kafka listener generated from the [Start Streaming GCN Notices interface](quickstart), simply add the Kafka topic `gcn.circulars`.
+If you have an existing Kafka listener generated from the [Start Streaming GCN Notices interface](/quickstart), simply add the Kafka topic `gcn.circulars`.
 
-Alternatively, visit the [Start Streaming GCN Notices interface](quickstart), select JSON, and the Circulars topic.
+Alternatively, visit the [Start Streaming GCN Notices interface](/quickstart), select JSON, and the Circulars topic.
 
 Note that upon [corrections](corrections), all revised Circular versions will be distributed over the Kafka stream.


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
I noticed that the links to Quickstart were broken on the Circulars subscribing page. This PR fixes that. I had a previously created another PR #3693, but had made an error with the branch on the fork. I closed that one and created this new one. The changes to the repo are identical.

# Related Issue(s)

# Testing
