### PR TITLE
Change default in quickstart to json

### DIFF
--- a/app/components/NoticeFormat.tsx
+++ b/app/components/NoticeFormat.tsx
@@ -36,6 +36,26 @@ export function NoticeFormatInput({
     label: ReactNode
     description: ReactNode
   }[] = [
+    ...(showJson
+      ? [
+          {
+            value: 'json' as NoticeFormat,
+            label: 'JSON',
+            description: (
+              <>
+                New notice types in JSON format defined using{' '}
+                <a
+                  href="https://json-schema.org"
+                  rel="external noopener"
+                  target="_blank"
+                >
+                  JSON schema
+                </a>
+              </>
+            ),
+          },
+        ]
+      : []),
     {
       value: 'text',
       label: 'Text',
@@ -74,26 +94,6 @@ export function NoticeFormatInput({
         </>
       ),
     },
-    ...(showJson
-      ? [
-          {
-            value: 'json' as NoticeFormat,
-            label: 'JSON',
-            description: (
-              <>
-                New notice types in JSON format defined using{' '}
-                <a
-                  href="https://json-schema.org"
-                  rel="external noopener"
-                  target="_blank"
-                >
-                  JSON schema
-                </a>
-              </>
-            ),
-          },
-        ]
-      : []),
   ]
 
   return (

--- a/app/routes/quickstart.alerts.tsx
+++ b/app/routes/quickstart.alerts.tsx
@@ -28,7 +28,7 @@ export default function () {
   const defaultFormat =
     (params.get('noticeFormat') as NoticeFormat) || undefined
   const [noticeFormat, setFormat] = useState<NoticeFormat>(
-    defaultFormat ?? 'text'
+    defaultFormat ?? 'json'
   )
 
   return (


### PR DESCRIPTION


<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
In the quickstart documentation, `json` is now listed as the first option and is also the default.

<img width="973" height="698" alt="Screenshot 2026-07-20 at 10 28 51" src="https://github.com/user-attachments/assets/21f851e9-a4ce-4eb5-b681-a0834bd09d93" />

# Related Issue(s)
<!-- Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
Example:
`Resolves #100` -->
Resolves #3706 

# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->
1. Log in to dummy account in local env
2. Select quickstart on home page
3. Begin credential creation workflow
4. On step 3, `json` should now be default
