### PR TITLE
Update Kafka client instructions for @confluentinc/kafka-javascript

### DIFF
--- a/app/components/ClientSampleCode.tsx
+++ b/app/components/ClientSampleCode.tsx
@@ -156,12 +156,14 @@ export function ClientSampleCode({
             // List topics
             const admin = kafka.admin()
             const topics = await admin.listTopics()
+            await admin.disconnect()
             console.log(topics)
             `
                 : ''
             }
             // Subscribe to topics and receive alerts
             const consumer = kafka.consumer()
+            await consumer.connect()
             try {
               await consumer.subscribe({
                 topics: [${topics
@@ -241,12 +243,14 @@ export function ClientSampleCode({
               // List topics
               const admin = kafka.admin()
               const topics = await admin.listTopics()
+              await admin.disconnect()
               console.log(topics)
               `
                 : ''
             }
               // Subscribe to topics and receive alerts
               const consumer = kafka.consumer()
+              await consumer.connect()
               try {
                 await consumer.subscribe({
                   topics: [${topics

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -276,11 +276,8 @@ export function Layout({ children }: { children?: ReactNode }) {
         <DevBanner />
         <Header />
         <NewsBanner>
-          New! MAXI Notices and Schema v7.2.0. See{' '}
-          <Link
-            className="usa-link"
-            to="/news#new-maxi-notices-and-schema-v720"
-          >
+          New JavaScript client! See{' '}
+          <Link className="usa-link" to="/news#new-javascript-client-v100">
             news and announcements
           </Link>
         </NewsBanner>

--- a/app/routes/news._index/route.mdx
+++ b/app/routes/news._index/route.mdx
@@ -28,6 +28,40 @@ import { Anchor } from '~/components/Anchor'
 ## 2026
 
 <CollectionItem
+  className="maxw-none grid-container"
+  variantComponent={
+    <CollectionCalendarDate datetime='July 25, 2026' />
+  }
+>
+  <CollectionHeading headingLevel="h3">
+    <Anchor>New JavaScript client v1.0.0</Anchor>
+  </CollectionHeading>
+  <CollectionDescription>
+    We have released version 1.0.0 of the [official JavaScript client for GCN Kafka](https://www.npmjs.com/package/gcn-kafka). We migrated the client backend from [kafkajs](https://www.npmjs.com/package/kafkajs) to [@confluentinc/kafka-javascript](https://www.npmjs.com/package/@confluentinc/kafka-javascript). They have the same interface, but the latter is better maintained and shares the same underlying Kafka client library as the [Python bindings](https://pypi.org/project/confluent-kafka/).
+
+    Aside from more reliable operation, the only change for users should be that you now have to explicitly call `connect()`, like this:
+
+    ```javascript
+    import { Kafka } from 'gcn-kafka'
+    const kafka = new Kafka({
+      client_id: 'fill me in',
+      client_secret: 'fill me in',
+    })
+
+    const consumer = kafka.consumer()
+    await consumer.connect() // <-- NOW REQUIRED IN VERSION 1.0.0
+    await consumer.subscribe({
+      topics: [
+        'gcn.classic.text.FERMI_GBM_FIN_POS',
+        'gcn.classic.text.LVC_INITIAL',
+      ],
+    })
+    ```
+
+  </CollectionDescription>
+</CollectionItem>
+
+<CollectionItem
     className="maxw-none grid-container"
     variantComponent={
       <CollectionCalendarDate datetime='July 15, 2026' />


### PR DESCRIPTION
The new client requires an explicit call to `connect()`.