### PR TITLE
Remove unused dependency on yarn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,8 +137,7 @@
         "sass": "^1.64.2",
         "ts-jest": "^29.4.9",
         "typescript": "^5.9.2",
-        "wait-port": "^1.1.0",
-        "yarn": "^1.22.21"
+        "wait-port": "^1.1.0"
       },
       "engines": {
         "node": ">=22"
@@ -32434,20 +32433,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yarn": {
-      "version": "1.22.21",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.21.tgz",
-      "integrity": "sha512-ynXaJsADJ9JiZ84zU25XkPGOvVMmZ5b7tmTSpKURYwgELdjucAOydqIOrOfTxVYcNXe91xvLZwcRh68SR3liCg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "yarn": "bin/yarn.js",
-        "yarnpkg": "bin/yarn.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/yazl": {

--- a/package.json
+++ b/package.json
@@ -157,8 +157,7 @@
     "sass": "^1.64.2",
     "ts-jest": "^29.4.9",
     "typescript": "^5.9.2",
-    "wait-port": "^1.1.0",
-    "yarn": "^1.22.21"
+    "wait-port": "^1.1.0"
   },
   "overrides": {
     "@architect/deploy": "github:lpsinger/deploy#e4d55b670a95049109ae42eca5ad1a1f56534d56",


### PR DESCRIPTION
This was added to support ACROSS development in 1cb68dff8c6e263a0cd674189d4bf06b516083d4. It is no longer used.