### PR TITLE
Add backend to search for event types

### DIFF
--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -203,7 +203,7 @@ export async function search({
   ]
 
   if (feature('EVENTTYPE')) {
-    if (eventTypes && eventTypes.length > 0) {
+    if (eventTypes?.length > 0) {
       if (eventTypesLogic === 'AND') {
         filterConditions.push({
           bool: {

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -147,7 +147,7 @@ export async function search({
   startDate,
   endDate,
   eventTypes,
-  eventTypesLogic = 'AND',
+  eventTypesLogic = 'OR',
   eventTypesExclude,
   sort,
 }: {

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -42,7 +42,7 @@ import type {
   CircularMetadata,
 } from './circulars.lib'
 import { sendEmail, sendEmailBulk } from '~/lib/email.server'
-import { origin } from '~/lib/env.server'
+import { feature, origin } from '~/lib/env.server'
 import { truncateJsonMaxBytes } from '~/lib/utils'
 import { closeZendeskTicket } from '~/lib/zendesk.server'
 
@@ -146,6 +146,9 @@ export async function search({
   limit,
   startDate,
   endDate,
+  eventTypes,
+  eventTypesLogic = 'AND',
+  eventTypesExclude,
   sort,
 }: {
   query?: string
@@ -153,6 +156,9 @@ export async function search({
   limit?: number
   startDate?: string
   endDate?: string
+  eventTypes?: string[]
+  eventTypesLogic?: 'AND' | 'OR'
+  eventTypesExclude?: string[]
   sort?: string
 }): Promise<{
   items: CircularMetadata[]
@@ -185,20 +191,56 @@ export async function search({
       }
     : undefined
 
+  const filterConditions: any[] = [
+    {
+      range: {
+        createdOn: {
+          gte: startTime,
+          lte: endTime,
+        },
+      },
+    },
+  ]
+
+  if (feature('EVENTTYPE')) {
+    if (eventTypes && eventTypes.length > 0) {
+      if (eventTypesLogic === 'AND') {
+        filterConditions.push({
+          bool: {
+            must: eventTypes.map((type) => ({
+              term: { 'eventType.keyword': type },
+            })),
+          },
+        })
+      } else {
+        filterConditions.push({
+          terms: {
+            'eventType.keyword': eventTypes,
+          },
+        })
+      }
+    }
+
+    if (eventTypesExclude && eventTypesExclude.length > 0) {
+      filterConditions.push({
+        bool: {
+          must_not: {
+            terms: {
+              'eventType.keyword': eventTypesExclude,
+            },
+          },
+        },
+      })
+    }
+  }
+
   const searchBody = {
     index: 'circulars',
     body: {
       query: {
         bool: {
           must: queryObj,
-          filter: {
-            range: {
-              createdOn: {
-                gte: startTime,
-                lte: endTime,
-              },
-            },
-          },
+          filter: filterConditions,
         },
       },
       fields: ['subject'],

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -203,7 +203,7 @@ export async function search({
   ]
 
   if (feature('EVENTTYPE')) {
-    if (eventTypes?.length > 0) {
+    if (eventTypes && (eventTypes.length ?? 0) > 0) {
       if (eventTypesLogic === 'AND') {
         filterConditions.push({
           bool: {


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
Adds the backend for the circulars archive to filter circulars by tagged event types. 

Additionally, this PR includes boolean logic that will allow for users to select whether to filter circulars with all (AND) or any (OR) of the selected event types. This logic is set as an argument in the search function. There is also the option to exclude specified event types (NOT), which are contained within a separate argument for excluded event types.

This PR refactors the filter aspect of the search function to be more modular, with event type filtering being separate from the date filtering and being hidden behind a feature flag 'EVENTTYPE' for now. 

When adding future search/filter features, this modularity should make it easier to modify

In order to test this, you will have to temporarily replace your seed.json, as we don't have #3520 implemented yet.

Note: this is the same as #3667, which was closed as it was based on an out of date fork.

# Related Issue(s)
<!-- Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
Example:
`Resolves #100` -->
Resolves #3521 

# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->
1. Enable EVENTTYPE in .env
2. Replace seed.json with the version with eventType tags included (located [here](https://github.com/tylerbarna/gcn.nasa.gov/blob/db9819e55ecdd75fbe0b285115c751a68ca252cc/seed.json))
3. Start container
4. Navigate to Circulars archive
6. In circulars.server.ts, change the default values for eventTypes, eventTypesLogic, and evenTypesExclude (example: eventTypes=["GRB", "Afterglow"], eventTypesLogic="AND", eventTypesExclude=["GW"]) and verify that the listed circulars change. 