### PR TITLE
Add event type tagging to circular submission

### DIFF
--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -33,6 +33,7 @@ import {
   formatCircularText,
   formatIsValid,
   parseEventFromSubject,
+  parseEventTypeFromSubject,
   subjectIsValid,
 } from './circulars.lib'
 import type {
@@ -328,7 +329,9 @@ export async function remove(circularId: number, request: Request) {
  * Adds a new entry into the GCN Circulars table WITHOUT authentication
  */
 export async function putRaw(
-  item: Require<Omit<Circular, 'createdOn' | 'circularId'>, 'submittedHow'>
+  item: Require<Omit<Circular, 'createdOn' | 'circularId'>, 'submittedHow'> & {
+    eventType?: string[]
+  }
 ): Promise<Circular> {
   const autoincrement = await getDynamoDBAutoIncrement()
   const createdOn = Date.now()
@@ -350,7 +353,7 @@ export async function put(
   item: Require<
     Omit<
       Circular,
-      'sub' | 'submitter' | 'createdOn' | 'circularId' | 'eventId'
+      'sub' | 'submitter' | 'createdOn' | 'circularId' | 'eventId' | 'eventType'
     >,
     'submittedHow'
   >,
@@ -371,6 +374,8 @@ export async function put(
 
   const eventId = parseEventFromSubject(item.subject)
   if (eventId) circular.eventId = eventId
+  const eventTypes = parseEventTypeFromSubject(item.subject)
+  if (eventTypes) circular.eventType = eventTypes
   const result = await putRaw(circular)
   if (eventId) await tryInitSynonym(eventId, result.createdOn)
   return result


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
This makes it so newly posted circulars are tagged with their event type(s), following the updated schema. This is done in the same step that the eventId is extracted.

# Related Issue(s)
<!-- Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
Example:
`Resolves #100` -->
Resolves #3520 

# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->
1. Navigate to archive in local development environment
2. Referencing the list of pattern matchers for event types, submit a dummy circular with one or several keywords in the subject
3. Navigate to the json version of the dummy circular
4. The event type property should be present
