### PR TITLE
create kafka event topics

### DIFF
--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -11,6 +11,7 @@ export interface CircularMetadata {
   circularId: number
   subject: string
   eventId?: string
+  eventType?: string[]
 }
 
 export type SubmittedHow = 'web' | 'email' | 'email-legacy' | 'api'

--- a/app/table-streams/circulars-kafka/index.ts
+++ b/app/table-streams/circulars-kafka/index.ts
@@ -26,6 +26,14 @@ export const handler = createTriggerHandler(
           ...cleanedCircular,
         })
       )
+      await Promise.all(
+        circular.eventType?.map((eventType) =>
+          send(
+            `gcn.circulars.${eventType.toLowerCase().replaceAll(' ', '_')}`,
+            JSON.stringify(circular)
+          )
+        ) ?? []
+      )
     }
   }
 )


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
Creates Kafka subtopics for event types. When a circular is added to the dynamoDB table and sent out to the general gcn circulars topic, it will also be sent out to subtopics for each matched event type. The event type topics are converted, as relevant, to match the naming conventions in place (lowercase and using underscores for spaces).

# Related Issue(s)
<!-- Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
Example:
`Resolves #100` -->
Resolves #3522 

# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->
1. Set up client credentials for kafka consumption as per the quickstart
2. Set subscriptions to relevant topics (ie `consumer.subscribe(['gcn.circulars.grb', 'gcn.circulars.radio_transient', 'gcn.circulars.retraction'])`
3. Run python script
4. Submit dummy circular with relevant keywords in local development
5. The python script should return the circular for all relevant event types
