### PR TITLE
Circulars by event type emails backend

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -72,6 +72,16 @@ circulars_subscriptions
   sub **String
   PointInTimeRecovery true
 
+circular_eventType_email
+  sub *String
+  uuid **String
+  PointInTimeRecovery
+
+circular_eventType_email_subscriptions
+  uuid *String
+  eventType **String
+  PointInTimeRecovery true
+
 email_notification
   sub *String
   uuid **String

--- a/app.arc
+++ b/app.arc
@@ -80,6 +80,16 @@ circulars_subscriptions
   sub **String
   PointInTimeRecovery true
 
+circular_eventType_email
+  sub *String
+  uuid **String
+  PointInTimeRecovery true
+
+circular_eventType_email_subscriptions
+  uuid *String
+  eventType **String
+  PointInTimeRecovery true
+
 email_notification
   sub *String
   uuid **String

--- a/app/lib/email.server.ts
+++ b/app/lib/email.server.ts
@@ -45,6 +45,15 @@ interface BulkMessageProps extends MessageProps {
   topic: string
 }
 
+// Basis for email subscription types
+export type EmailSubscription = {
+  uuid?: string // Unique identifier for this subscription
+  sub: string // User ID
+  name: string // Reader friendly name of this subscription
+  recipient: string // Address to send to
+  created: number // Created on date
+}
+
 function getBody(body: string) {
   if (hostname !== 'gcn.nasa.gov') {
     const { heading, description } = getEnvBannerHeaderAndDescription(hostname)

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -6,12 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { tables } from '@architect/functions'
-import type { DynamoDB } from '@aws-sdk/client-dynamodb'
-import {
-  type DynamoDBDocument,
-  paginateQuery,
-  paginateScan,
-} from '@aws-sdk/lib-dynamodb'
+import { type DynamoDB } from '@aws-sdk/client-dynamodb'
+import { type DynamoDBDocument, paginateScan } from '@aws-sdk/lib-dynamodb'
 import { search as getSearch } from '@nasa-gcn/architect-functions-search'
 import {
   DynamoDBAutoIncrement,
@@ -27,10 +23,10 @@ import {
   manageSynonymOnVersionUpdates,
   tryInitSynonym,
 } from '../synonyms/synonyms.server'
+import { send } from '../user.email/email_circulars.server'
 import {
   bodyIsValid,
   formatAuthor,
-  formatCircularText,
   formatIsValid,
   parseEventFromSubject,
   parseEventTypeFromSubject,
@@ -42,9 +38,8 @@ import type {
   CircularChangeRequestKeys,
   CircularMetadata,
 } from './circulars.lib'
-import { sendEmail, sendEmailBulk } from '~/lib/email.server'
+import { sendEmail } from '~/lib/email.server'
 import { feature, origin } from '~/lib/env.server'
-import { truncateJsonMaxBytes } from '~/lib/utils'
 import { closeZendeskTicket } from '~/lib/zendesk.server'
 
 // A type with certain keys required.
@@ -52,8 +47,6 @@ type Require<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
 
 export const submitterGroup = 'gcn.nasa.gov/circular-submitter'
 export const moderatorGroup = 'gcn.nasa.gov/circular-moderator'
-
-const fromName = 'GCN Circulars'
 
 const getDynamoDBAutoIncrement = memoizee(
   async function () {
@@ -731,69 +724,4 @@ export function validateCircular({
   if (!bodyIsValid(body)) throw new Response('body is invalid', { status: 400 })
   if (!(format === undefined || formatIsValid(format)))
     throw new Response('format is invalid', { status: 400 })
-}
-
-async function getEmails() {
-  const db = await tables()
-  const client = db._doc as unknown as DynamoDBDocument
-  const TableName = db.name('circulars_subscriptions')
-  const pages = paginateScan(
-    { client },
-    { AttributesToGet: ['email'], TableName }
-  )
-  const emails: string[] = []
-  for await (const page of pages) {
-    const newEmails = page.Items?.map(({ email }) => email)
-    if (newEmails) emails.push(...newEmails)
-  }
-  return emails
-}
-
-async function getLegacyEmails() {
-  const db = await tables()
-  const client = db._doc as unknown as DynamoDBDocument
-  const TableName = db.name('legacy_users')
-  const pages = paginateQuery(
-    { client },
-    {
-      IndexName: 'legacyReceivers',
-      KeyConditionExpression: 'receive = :receive',
-      ExpressionAttributeValues: {
-        ':receive': 1,
-      },
-      ProjectionExpression: 'email',
-      TableName,
-    }
-  )
-  const emails: string[] = []
-  for await (const page of pages) {
-    const newEmails = page.Items?.map(({ email }) => email)
-    if (newEmails) emails.push(...newEmails)
-  }
-  return emails
-}
-
-export async function send(circular: Circular) {
-  const [emails, legacyEmails] = await Promise.all([
-    getEmails(),
-    getLegacyEmails(),
-  ])
-  const to = [...emails, ...legacyEmails]
-
-  // There is a limit of 262144 bytes for the Amazon SES API's TemplateData argument.
-  // See https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_Template.html#SES-Type-Template-TemplateData
-  const { text, truncated } = truncateJsonMaxBytes(
-    formatCircularText(circular),
-    200_000
-  )
-
-  await sendEmailBulk({
-    fromName,
-    to,
-    subject: circular.subject,
-    body: `${text}${truncated ? '...\n\n\nThis message was truncated. View the full' : '\n\n\nView this'} GCN Circular online at ${origin}/circulars/${
-      circular.circularId
-    }.`,
-    topic: 'circulars',
-  })
 }

--- a/app/routes/circulars/circulars.server.ts
+++ b/app/routes/circulars/circulars.server.ts
@@ -43,6 +43,7 @@ import type {
   CircularChangeRequestKeys,
   CircularMetadata,
 } from './circulars.lib'
+import type { EmailSubscription } from '~/lib/email.server'
 import { sendEmail, sendEmailBulk } from '~/lib/email.server'
 import { feature, origin } from '~/lib/env.server'
 import { truncateJsonMaxBytes } from '~/lib/utils'
@@ -54,7 +55,16 @@ type Require<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
 export const submitterGroup = 'gcn.nasa.gov/circular-submitter'
 export const moderatorGroup = 'gcn.nasa.gov/circular-moderator'
 
-const fromName = 'GCN Circulars'
+export type CircularsEventTypeSubscriptions = EmailSubscription & {
+  eventTypes: EventTypePreference[]
+}
+
+type EventTypePreference = {
+  uuid: string // Id linking to the EmailSubscription's UUID
+  eventType: string
+  ignore: boolean
+}
+const fromName = 'GCN Circualrs'
 
 const getDynamoDBAutoIncrement = memoizee(
   async function () {
@@ -797,6 +807,10 @@ export async function send(circular: Circular) {
   ])
   const to = [...emails, ...legacyEmails]
 
+  await sendBulkCircularsTo(circular, to)
+}
+
+async function sendBulkCircularsTo(circular: Circular, to: string[]) {
   // There is a limit of 262144 bytes for the Amazon SES API's TemplateData argument.
   // See https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_Template.html#SES-Type-Template-TemplateData
   const { text, truncated } = truncateJsonMaxBytes(
@@ -813,4 +827,84 @@ export async function send(circular: Circular) {
     }.`,
     topic: 'circulars',
   })
+}
+
+export async function sendEventTypedEmails(circular: Circular) {
+  if (!circular.eventType) throw new Response(null, { status: 500 })
+  const to = await getEmailsForEventTypes(circular.eventType)
+  await sendBulkCircularsTo(circular, to)
+}
+
+export async function createEventBasedCircularEmailSubscription(
+  item: CircularsEventTypeSubscriptions
+) {
+  const created = Date.now()
+  const uuid = crypto.randomUUID()
+
+  const db = await tables()
+  const main = db.circular_eventType_email.put({
+    sub: item.sub,
+    uuid,
+    name: item.name,
+    created,
+    eventNames: item.eventTypes,
+    recipient: item.recipient,
+  })
+  const subscriptionPromises = item.eventTypes.map((prefernce) =>
+    db.circular_eventType_email_subscriptions.put({
+      uuid,
+      eventType: prefernce.eventType,
+      recipient: item.recipient,
+      ignore: prefernce.ignore,
+    })
+  )
+
+  await Promise.all([main, ...subscriptionPromises])
+}
+
+/**
+ * Given a list of eventType strings from a circular, retrieve addresses from users
+ * who have created notification sets that include this event type. If the type is
+ * included, but marked as ignored, that set will not be included.
+ * @param eventType
+ * @returns
+ */
+export async function getEmailsForEventTypes(
+  eventTypes: string[]
+): Promise<string[]> {
+  const db = await tables()
+  const client = db._doc as unknown as DynamoDBDocument
+  const TableName = db.name('circular_eventType_email_subscriptions')
+  const pages = paginateScan(
+    { client },
+    {
+      TableName,
+      ProjectionExpression: '#uuid, recipient, eventType, #ignore',
+      ExpressionAttributeNames: {
+        '#uuid': 'uuid',
+        '#ignore': 'ignore',
+      },
+    }
+  )
+
+  const preferences: (EventTypePreference & { recipient: string })[] = []
+  const ignoredUuids = new Set<string>()
+
+  for await (const page of pages) {
+    if (page.Items) {
+      const items = page.Items as (EventTypePreference & {
+        recipient: string
+      })[]
+      for (const item of items) {
+        preferences.push(item)
+        if (item.ignore && eventTypes.includes(item.eventType)) {
+          ignoredUuids.add(item.uuid)
+        }
+      }
+    }
+  }
+
+  return preferences
+    .filter((item) => !ignoredUuids.has(item.uuid))
+    .map((item) => item.recipient)
 }

--- a/app/routes/user.email/email_circulars.server.ts
+++ b/app/routes/user.email/email_circulars.server.ts
@@ -6,6 +6,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { tables } from '@architect/functions'
+import type { DynamoDBDocument } from '@aws-sdk/lib-dynamodb'
+import { paginateQuery, paginateScan } from '@aws-sdk/lib-dynamodb'
+
+import { type Circular, formatCircularText } from '../circulars/circulars.lib'
+import { type EmailSubscription, sendEmailBulk } from '~/lib/email.server'
+import { origin } from '~/lib/env.server'
+import { truncateJsonMaxBytes } from '~/lib/utils'
+
+export type CircularsEventTypeSubscriptions = EmailSubscription & {
+  eventTypes: EventTypePreference[]
+}
+
+type EventTypePreference = {
+  uuid: string // Id linking to the EmailSubscription's UUID
+  eventType: string
+  ignore: boolean
+}
+const fromName = 'GCN Circulars'
 
 export async function createCircularEmailNotification(
   sub: string,
@@ -66,4 +84,151 @@ export async function deleteCircularEmailNotification(
     sub,
     email,
   })
+}
+
+async function getEmails() {
+  const db = await tables()
+  const client = db._doc as unknown as DynamoDBDocument
+  const TableName = db.name('circulars_subscriptions')
+  const pages = paginateScan(
+    { client },
+    { AttributesToGet: ['email'], TableName }
+  )
+  const emails: string[] = []
+  for await (const page of pages) {
+    const newEmails = page.Items?.map(({ email }) => email)
+    if (newEmails) emails.push(...newEmails)
+  }
+  return emails
+}
+
+async function getLegacyEmails() {
+  const db = await tables()
+  const client = db._doc as unknown as DynamoDBDocument
+  const TableName = db.name('legacy_users')
+  const pages = paginateQuery(
+    { client },
+    {
+      IndexName: 'legacyReceivers',
+      KeyConditionExpression: 'receive = :receive',
+      ExpressionAttributeValues: {
+        ':receive': 1,
+      },
+      ProjectionExpression: 'email',
+      TableName,
+    }
+  )
+  const emails: string[] = []
+  for await (const page of pages) {
+    const newEmails = page.Items?.map(({ email }) => email)
+    if (newEmails) emails.push(...newEmails)
+  }
+  return emails
+}
+
+export async function send(circular: Circular) {
+  const [emails, legacyEmails] = await Promise.all([
+    getEmails(),
+    getLegacyEmails(),
+  ])
+  const to = [...emails, ...legacyEmails]
+
+  await sendBulkCircularsTo(circular, to)
+}
+
+async function sendBulkCircularsTo(circular: Circular, to: string[]) {
+  const { text, truncated } = truncateJsonMaxBytes(
+    formatCircularText(circular),
+    200_000
+  )
+
+  await sendEmailBulk({
+    fromName,
+    to,
+    subject: circular.subject,
+    body: `${text}${truncated ? '...\n\n\nThis message was truncated. View the full' : '\n\n\nView this'} GCN Circular online at ${origin}/circulars/${
+      circular.circularId
+    }.`,
+    topic: 'circulars',
+  })
+}
+
+export async function sendEventTypedEmails(circular: Circular) {
+  if (!circular.eventType) throw new Response(null, { status: 500 })
+  const to = await getEmailsForEventTypes(circular.eventType)
+  await sendBulkCircularsTo(circular, to)
+}
+
+export async function createEventBasedCircularEmailSubscription(
+  item: CircularsEventTypeSubscriptions
+) {
+  const created = Date.now()
+  const uuid = crypto.randomUUID()
+
+  const db = await tables()
+  const main = db.circular_eventType_email.put({
+    sub: item.sub,
+    uuid,
+    name: item.name,
+    created,
+    eventNames: item.eventTypes,
+    recipient: item.recipient,
+  })
+  const subscriptionPromises = item.eventTypes.map((prefernce) =>
+    db.circular_eventType_email_subscriptions.put({
+      uuid,
+      eventType: prefernce.eventType,
+      recipient: item.recipient,
+      ignore: prefernce.ignore,
+    })
+  )
+
+  await Promise.all([main, ...subscriptionPromises])
+}
+
+/**
+ * Given a list of eventType strings from a circular, retrieve addresses from users
+ * who have created notification sets that include this event type. If the type is
+ * included, but marked as ignored, that set will not be included.
+ * @param eventType
+ * @returns
+ */
+export async function getEmailsForEventTypes(
+  eventTypes: string[]
+): Promise<string[]> {
+  const db = await tables()
+  const client = db._doc as unknown as DynamoDBDocument
+  const TableName = db.name('circular_eventType_email_subscriptions')
+  const pages = paginateScan(
+    { client },
+    {
+      TableName,
+      ProjectionExpression: '#uuid, recipient, eventType, #ignore',
+      ExpressionAttributeNames: {
+        '#uuid': 'uuid',
+        '#ignore': 'ignore',
+      },
+    }
+  )
+
+  const preferences: (EventTypePreference & { recipient: string })[] = []
+  const ignoredUuids = new Set<string>()
+
+  for await (const page of pages) {
+    if (page.Items) {
+      const items = page.Items as (EventTypePreference & {
+        recipient: string
+      })[]
+      for (const item of items) {
+        preferences.push(item)
+        if (item.ignore && eventTypes.includes(item.eventType)) {
+          ignoredUuids.add(item.uuid)
+        }
+      }
+    }
+  }
+
+  return preferences
+    .filter((item) => !ignoredUuids.has(item.uuid))
+    .map((item) => item.recipient)
 }

--- a/app/routes/user.email/email_notices.server.ts
+++ b/app/routes/user.email/email_notices.server.ts
@@ -9,17 +9,13 @@ import { tables } from '@architect/functions'
 import crypto from 'crypto'
 import { validate } from 'email-validator'
 
+import type { EmailSubscription } from '~/lib/email.server'
 import { sendEmail } from '~/lib/email.server'
 import { topicToFormatAndNoticeType } from '~/lib/utils'
 
 // db model
-export type EmailNotification = {
-  name: string
-  recipient: string
-  created: number
-  uuid?: string
+export type EmailNotification = EmailSubscription & {
   topics: string[]
-  sub: string
 }
 
 // view model

--- a/app/table-streams/circulars-email/index.ts
+++ b/app/table-streams/circulars-email/index.ts
@@ -10,13 +10,17 @@ import type { DynamoDBRecord } from 'aws-lambda'
 import { unmarshallTrigger } from '../utils'
 import { createTriggerHandler } from '~/lib/lambdaTrigger.server'
 import type { Circular } from '~/routes/circulars/circulars.lib'
-import { send } from '~/routes/circulars/circulars.server'
+import {
+  send,
+  sendEventTypedEmails,
+} from '~/routes/user.email/email_circulars.server'
 
 export const handler = createTriggerHandler(
   async ({ eventName, dynamodb }: DynamoDBRecord) => {
     if (eventName === 'INSERT') {
       const circular = unmarshallTrigger(dynamodb!.NewImage) as Circular
       await send(circular)
+      await sendEventTypedEmails(circular)
     }
   }
 )

--- a/app/table-streams/circulars-email/index.ts
+++ b/app/table-streams/circulars-email/index.ts
@@ -8,15 +8,17 @@
 import type { DynamoDBRecord } from 'aws-lambda'
 
 import { unmarshallTrigger } from '../utils'
+import { feature } from '~/lib/env.server'
 import { createTriggerHandler } from '~/lib/lambdaTrigger.server'
 import type { Circular } from '~/routes/circulars/circulars.lib'
-import { send } from '~/routes/circulars/circulars.server'
+import { send, sendEventTypedEmails } from '~/routes/circulars/circulars.server'
 
 export const handler = createTriggerHandler(
   async ({ eventName, dynamodb }: DynamoDBRecord) => {
     if (eventName === 'INSERT') {
       const circular = unmarshallTrigger(dynamodb!.NewImage) as Circular
       await send(circular)
+      if (feature('EVENTTYPE')) await sendEventTypedEmails(circular)
     }
   }
 )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
   "compilerOptions": {
     "incremental": true,
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": ["DOM", "DOM.Iterable", "ES2022", "ES2024"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
- Adds new tables for circular email subscriptions associated to specific event types
- Refactors a reusable `EmailSubscription` type based on the notices emails
- Adds functions to `app/routes/circulars/circulars.server.ts` to send event type email and get addresses from the new list
- Updates table stream lambda to send event type emails after main send behind feature flag