### PR TITLE
Add template indexes via postdeploy-search

### DIFF
--- a/postdeploy-search.js
+++ b/postdeploy-search.js
@@ -1,0 +1,50 @@
+const data = {
+  index_templates: [
+    {
+      name: 'circulars_template',
+      index_template: {
+        index_patterns: ['circular*'],
+        template: {
+          settings: {
+            index: {
+              number_of_shards: '1',
+              number_of_replicas: '1',
+            },
+          },
+          mappings: {},
+        },
+        priority: 1,
+        version: 1,
+        _meta: { description: 'Circulars template' },
+      },
+    },
+    {
+      name: 'synonyms_template',
+      index_template: {
+        index_patterns: ['synonym*'],
+        template: {
+          settings: {
+            index: {
+              number_of_shards: '1',
+              number_of_replicas: '1',
+            },
+          },
+          mappings: {},
+        },
+        priority: 1,
+        version: 1,
+        _meta: { description: 'Synonyms template' },
+      },
+    },
+  ],
+}
+
+export default async function (client) {
+  const promises = data.index_templates.map(({ name, index_template }) => {
+    return client.indices.putIndexTemplate({
+      name,
+      body: index_template,
+    })
+  })
+  await Promise.all(promises)
+}


### PR DESCRIPTION
Uses the `postdeploy-search.js` check from [@nasa-gcn/architect-plugin-search](https://github.com/nasa-gcn/architect-plugin-search) to put an index template in place for circulars and synonyms, specifying 1 shard and 1 replica limits. 

