### PR TITLE
Catch Unknown s3 error

### DIFF
--- a/app/routes/circulars._archive.tsx
+++ b/app/routes/circulars._archive.tsx
@@ -34,7 +34,9 @@ async function getFileSize(format: string) {
       process.env.NODE_ENV !== 'production' &&
       e instanceof Object &&
       'name' in e &&
-      e.name === 'InvalidBucketName'
+      // TODO: This may have to do with a change to the error response from s3
+      // Look inot this and get a better fix, I noticed it on main as well
+      (e.name === 'InvalidBucketName' || e.name === '400')
     ) {
       console.warn('making up fake object size')
       return 1024 * 1024 * 50


### PR DESCRIPTION
There seems to be some Unknown Error being thrown in the function that checks for an object size. @Courey tried to replicate this locally, but did not see the error.
Other than the stack trace, the only content of the error is:

```
400: UnknownError
    at throwDefaultError (C:\Users\ddutko\repos\gcn.nasa.gov\node_modules\@smithy\smithy-client\dist-cjs\index.js:327:22)
    at C:\Users\ddutko\repos\gcn.nasa.gov\node_modules\@smithy\smithy-client\dist-cjs\index.js:336:9
    at de_CommandError (C:\Users\ddutko\repos\gcn.nasa.gov\node_modules\@aws-sdk\client-s3\dist-cjs\index.js:5202:14)
    at processTicksAndRejections (node:internal/process/task_queues:104:5)
    at C:\Users\ddutko\repos\gcn.nasa.gov\node_modules\@smithy\middleware-serde\dist-cjs\index.js:9:24
    at C:\Users\ddutko\repos\gcn.nasa.gov\node_modules\@aws-sdk\middleware-sdk-s3\dist-cjs\index.js:488:18
    at C:\Users\ddutko\repos\gcn.nasa.gov\node_modules\@smithy\middleware-retry\dist-cjs\index.js:300:46
    at C:\Users\ddutko\repos\gcn.nasa.gov\node_modules\@aws-sdk\middleware-sdk-s3\dist-cjs\index.js:110:22
    at C:\Users\ddutko\repos\gcn.nasa.gov\node_modules\@aws-sdk\middleware-sdk-s3\dist-cjs\index.js:137:14
    at C:\Users\ddutko\repos\gcn.nasa.gov\node_modules\@aws-sdk\middleware-logger\dist-cjs\index.js:33:22 
```
The error seems to come from:
```js
    const { ContentLength } = await s3.send(
      new HeadObjectCommand({
        Bucket,
        Key,
      })
    )
```