### PR TITLE
Add link to zendesk ticket and list modified fields in moderator queue

### DIFF
--- a/app/routes/circulars.moderation.$circularId.$requestor.tsx
+++ b/app/routes/circulars.moderation.$circularId.$requestor.tsx
@@ -86,6 +86,18 @@ export default function () {
           {circular.circularId}
         </Link>
       </h2>
+      {correction.zendeskTicketId && (
+        <h3>
+          Zendesk Ticket:{' '}
+          <a
+            href={`https://nasa-gcn.zendesk.com/agent/tickets/${correction.zendeskTicketId}`}
+            target="_blank"
+            rel="external noopener"
+          >
+            {correction.zendeskTicketId}
+          </a>
+        </h3>
+      )}
       <h3>Original Author</h3>
       <DiffedContent
         oldString={circular.submitter}

--- a/app/routes/circulars.moderation.$circularId.$requestor.tsx
+++ b/app/routes/circulars.moderation.$circularId.$requestor.tsx
@@ -87,8 +87,8 @@ export default function () {
         </Link>
       </h2>
       {correction.zendeskTicketId && (
-        <h3>
-          Zendesk Ticket:{' '}
+        <>
+          <h3>Zendesk Ticket</h3>
           <a
             href={`https://nasa-gcn.zendesk.com/agent/tickets/${correction.zendeskTicketId}`}
             target="_blank"
@@ -96,7 +96,7 @@ export default function () {
           >
             {correction.zendeskTicketId}
           </a>
-        </h3>
+        </>
       )}
       <h3>Original Author</h3>
       <DiffedContent

--- a/app/routes/circulars.moderation._index.tsx
+++ b/app/routes/circulars.moderation._index.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react'
 
 import { getUser } from './_auth/user.server'
 import type {
+  Circular,
   CircularChangeRequest,
   CircularChangeRequestKeys,
 } from './circulars/circulars.lib'
@@ -167,29 +168,26 @@ function CircularChangeRequestRow({
   )
 }
 
-type RequestedFieldKey = keyof Pick<
-  CircularChangeRequest,
-  'submitter' | 'subject' | 'eventId' | 'format' | 'body'
->
-
-const requestedFieldLabels = {
-  submitter: 'Submitter',
-  subject: 'Subject',
-  eventId: 'Event ID',
-  format: 'Format',
-  body: 'Body',
-} satisfies Record<RequestedFieldKey, string>
-
 function getModifiedFields(
-  circular: Awaited<ReturnType<typeof get>>,
+  circular: Circular,
   changeRequest: CircularChangeRequest
 ) {
-  return (Object.keys(requestedFieldLabels) as RequestedFieldKey[])
+  const excludedFields = [
+    'submittedHow',
+    'format',
+    'bibcode',
+    'editedOn',
+    'createdOn',
+    'version',
+  ]
+  return (Object.keys(circular) as (keyof Circular)[])
     .filter((key) => {
-      const changedValue = changeRequest[key]
-      const originalValue = circular[key]
+      const changedValue = changeRequest[key as keyof CircularChangeRequest]
+      const originalValue = circular[key as keyof Circular]
 
-      return changedValue !== originalValue
+      return (
+        changedValue !== originalValue && !excludedFields.includes(String(key))
+      )
     })
-    .map((key) => requestedFieldLabels[key])
+    .map((key) => String(key))
 }

--- a/app/routes/circulars.moderation._index.tsx
+++ b/app/routes/circulars.moderation._index.tsx
@@ -17,6 +17,7 @@ import type {
 } from './circulars/circulars.lib'
 import {
   bulkDeleteChangeRequests,
+  get,
   getChangeRequests,
   moderatorGroup,
 } from './circulars/circulars.server'
@@ -34,8 +35,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
   if (!user || !user.groups.includes(moderatorGroup))
     throw new Response(null, { status: 403 })
   const changeRequests = await getChangeRequests()
+  const circulars = await Promise.all(
+    changeRequests.map((request) => get(request.circularId))
+  )
   return {
     changeRequests,
+    circulars,
   }
 }
 
@@ -59,7 +64,7 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function () {
-  const { changeRequests } = useLoaderData<typeof loader>()
+  const { changeRequests, circulars } = useLoaderData<typeof loader>()
   const [selectedCount, setSelectedCount] = useState(0)
 
   function checkboxOnChange(checked: boolean) {
@@ -83,10 +88,11 @@ export default function () {
           </Button>
         </ToolbarButtonGroup>
         <SegmentedCards>
-          {changeRequests.map((correction) => (
+          {changeRequests.map((correction, index) => (
             <CircularChangeRequestRow
               key={`${correction.circularId}-${correction.requestor}`}
               changeRequest={correction}
+              circular={circulars[index]}
               checkboxOnChange={checkboxOnChange}
             />
           ))}
@@ -98,11 +104,15 @@ export default function () {
 
 function CircularChangeRequestRow({
   changeRequest,
+  circular,
   checkboxOnChange,
 }: {
   changeRequest: CircularChangeRequest
+  circular: Awaited<ReturnType<typeof get>>
   checkboxOnChange: (checked: boolean) => void
 }) {
+  const modifiedFields = getModifiedFields(circular, changeRequest)
+
   return (
     <Grid row>
       <div className="tablet:grid-col flex-fill">
@@ -123,6 +133,24 @@ function CircularChangeRequestRow({
                 <strong>Requestor: </strong>
                 {changeRequest.requestor}
               </div>
+              {changeRequest.zendeskTicketId && (
+                <div>
+                  <strong>Zendesk Ticket: </strong>
+                  <a
+                    href={`https://nasa-gcn.zendesk.com/agent/tickets/${changeRequest.zendeskTicketId}`}
+                    target="_blank"
+                    rel="external noopener"
+                  >
+                    {changeRequest.zendeskTicketId}
+                  </a>
+                </div>
+              )}
+              {modifiedFields.length > 0 && (
+                <div>
+                  <strong>Modified Fields: </strong>
+                  {modifiedFields.join(', ')}
+                </div>
+              )}
             </>
           }
         />
@@ -137,4 +165,31 @@ function CircularChangeRequestRow({
       </div>
     </Grid>
   )
+}
+
+type RequestedFieldKey = keyof Pick<
+  CircularChangeRequest,
+  'submitter' | 'subject' | 'eventId' | 'format' | 'body'
+>
+
+const requestedFieldLabels = {
+  submitter: 'Submitter',
+  subject: 'Subject',
+  eventId: 'Event ID',
+  format: 'Format',
+  body: 'Body',
+} satisfies Record<RequestedFieldKey, string>
+
+function getModifiedFields(
+  circular: Awaited<ReturnType<typeof get>>,
+  changeRequest: CircularChangeRequest
+) {
+  return (Object.keys(requestedFieldLabels) as RequestedFieldKey[])
+    .filter((key) => {
+      const changedValue = changeRequest[key]
+      const originalValue = circular[key]
+
+      return changedValue !== originalValue
+    })
+    .map((key) => requestedFieldLabels[key])
 }


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
This adds a link to the relevant Zendesk ticket for a requested change as well as a list of the fields changed in the request to the moderation queue

<img width="981" height="850" alt="image" src="https://github.com/user-attachments/assets/7ec995a5-e5ca-45b7-a076-4679bdd3fa7c" />
<img width="963" height="482" alt="image" src="https://github.com/user-attachments/assets/a4884b39-ce7d-4e29-b9c6-3cad8ea4b3c7" />



# Related Issue(s)
<!-- Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
Example:
`Resolves #100` -->
n/a

# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->
1. Log into a dummy account 
2. Go to moderation queue
3. The modified fields should be shown, but the zendesk ticket links will not show because the dummy request changes do not seem to have zendesk tickets associated with them