### PR TITLE
Create dummy zendesk response for local development

### DIFF
--- a/app/lib/zendesk.server.ts
+++ b/app/lib/zendesk.server.ts
@@ -8,7 +8,7 @@
 import memoizee from 'memoizee'
 import { Issuer } from 'openid-client'
 
-import { getEnvOrDie } from './env.server'
+import { feature, getEnvOrDie } from './env.server'
 import { getBearerAuthHeaders } from './headers.server'
 import { throwForStatus } from './utils'
 
@@ -28,6 +28,7 @@ interface RequestComment {
 }
 
 const zendeskDomain = 'https://nasa-gcn.zendesk.com'
+const disableZendesk = feature('DISABLE_ZENDESK')
 
 const getAccessToken = memoizee(
   async () => {
@@ -53,6 +54,12 @@ const getAccessToken = memoizee(
 )
 
 async function fetchZendesk(url: string | URL, method: string, body: any) {
+  if (disableZendesk) {
+    return new Response(JSON.stringify({ request: { id: 1 } }), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
   const accessToken = await getAccessToken()
   const response = await fetch(url, {
     method,


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
To facilitate local development of circular moderation features, it would be useful to have a way to test locally without creating real zendesk tickets. This adds a feature flag that, when enabled, returns a dummy response when attempting to fetch zendesk credentials. As a result, any testing of edit requests and moderation will not actually submit to zendesk, but it is still possible to test the zendesk connection locally by removing the feature flag. 

# Related Issue(s)
<!-- Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
Example:
`Resolves #100` -->
n/a

# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->
Note: you will need real values for `ZENDESK_CLIENT_ID` and `ZENDESK_CLIENT_SECRET` as well as access to the zendesk dashboard to properly test this.
1. Access https://nasa-gcn.zendesk.com
2. Add necessary zendesk info to `.env` along with `DISABLE_ZENDESK` feature flag
3. Start the local environment
4. Navigate to a circular and request an edit
5. The edit should be in the local moderation queue without creating a zendesk ticket
6. Accept the request. This should update the local instance of the circular
7. Kill local dev and remove the zendesk token and client from `.env` before restarting
8. Repeat steps 1 through 4. These should all still function and demonstrate the same behavior