### PR TITLE
Add clarification of Docker container runtime to contributing guide

### DIFF
--- a/app/routes/docs.contributing._index.mdx
+++ b/app/routes/docs.contributing._index.mdx
@@ -79,6 +79,8 @@ Here are instructions for getting the GCN site set up and running on your own co
     -   [Docker Desktop](https://www.docker.com/products/docker-desktop/) is just as easy to install, but it is not free.
     -   [Docker Engine](https://docs.docker.com/engine/) is free, and on most Linux distributions you can install it easily and directly from your favorite package manager. On macOS or Windows it requires signficant setup.
 
+    Make sure that your Docker container runtime is running.
+
   </ProcessListItem>
   <ProcessListItem>
     <ProcessListHeading type="h3">


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
Current contributing guide (https://gcn.nasa.gov/docs/contributing) is a bit vague on whether or not the Docker container runtime should be running before executing:
```sh
npm run dev
```
Adding an explicit mention that the Docker container runtime should be running before avoids potential future confusion.

# Related Issue(s)
<!-- Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
Example:
`Resolves #100` -->
Resolves #3781 

# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->

Before:
<img width="657" height="566" alt="Screenshot 2026-08-18 at 10 45 50 AM" src="https://github.com/user-attachments/assets/7b3fbc50-72ef-47a9-9b6d-22c30eb9792c" />

After:
<img width="661" height="599" alt="Screenshot 2026-08-18 at 10 31 00 AM" src="https://github.com/user-attachments/assets/6075c257-7ade-40ff-9ba2-4e95e86fcd25" />