### PR TITLE
Add Errata to retraction keywords

### DIFF
--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -346,6 +346,7 @@ const eventTypeMatchers: Record<EventType, RegExp[]> = {
     /\bInvalid\b/i,
     /\bBogus\b/i,
     /\bFake\b/i,
+    /\bErrata\b/i,
   ],
   GRB: [
     /\bGRB\d{4,8}[A-Z]?\b/i,

--- a/app/routes/circulars/circulars.lib.ts
+++ b/app/routes/circulars/circulars.lib.ts
@@ -347,6 +347,7 @@ const eventTypeMatchers: Record<EventType, RegExp[]> = {
     /\bBogus\b/i,
     /\bFake\b/i,
     /\bErrata\b/i,
+    /\bErratum\b/i,
   ],
   GRB: [
     /\bGRB\d{4,8}[A-Z]?\b/i,


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
This adds 'Errata' and its plural form as a keyword matched to the Retraction event type. I noticed there were just over [30 circulars](https://gcn.nasa.gov/circulars?view=index&query=subject%3A%22Errata%22+OR+subject%3A%22erratum%22&startDate=&endDate=&sort=circularID) that could accurately be described as retractions but would not be tagged as such

# Related Issue(s)
<!-- Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
Example:
`Resolves #100` -->
Updates #3518 

# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->
n/a