### PR TITLE
Fix circular event navigation to archive

### DIFF
--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -5,7 +5,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { joinListWithOxfordComma, truncateJsonMaxBytes } from '~/lib/utils'
+import {
+  cleanSearchString,
+  joinListWithOxfordComma,
+  truncateJsonMaxBytes,
+} from '~/lib/utils'
 import { stripTags } from '~/lib/utils.server'
 
 describe('stripTags', () => {
@@ -21,6 +25,25 @@ describe('stripTags', () => {
   })
   test('handles partial html tags', () => {
     expect(stripTags(partialTag)).toBe('')
+  })
+})
+
+describe('cleanSearchsString', () => {
+  test('handles searchString with sample parameters and a standard question mark.', () => {
+    expect(cleanSearchString('view=index&query=ligo', '?')).toBe(
+      '?view=index&query=ligo'
+    )
+  })
+  test('handles searchString with sample parameters and a standard ampersand.', () => {
+    expect(cleanSearchString('view=index&query=ligo', '&')).toBe(
+      '&view=index&query=ligo'
+    )
+  })
+  test('handles empty searchString and a standard question mark.', () => {
+    expect(cleanSearchString('', '?')).toBe('')
+  })
+  test('handles empty searchString and a standard ampersand.', () => {
+    expect(cleanSearchString('', '&')).toBe('')
   })
 })
 

--- a/app/components/circularDisplay/FrontMatter.tsx
+++ b/app/components/circularDisplay/FrontMatter.tsx
@@ -5,13 +5,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Link } from '@remix-run/react'
+import { Link, useSearchParams } from '@remix-run/react'
 import { Grid } from '@trussworks/react-uswds'
 import { slug } from 'github-slugger'
 import type { ReactNode } from 'react'
 
 import TimeAgo from '~/components/TimeAgo'
-import { useSearchString } from '~/lib/utils'
+import { cleanSearchString } from '~/lib/utils'
 import { type Circular, formatDateISO } from '~/routes/circulars/circulars.lib'
 
 const submittedHowMap = {
@@ -39,6 +39,7 @@ function FrontMatterItem({
 }
 
 export function FrontMatter({
+  circularId,
   subject,
   createdOn,
   eventId,
@@ -48,6 +49,7 @@ export function FrontMatter({
   editedOn,
 }: Pick<
   Circular,
+  | 'circularId'
   | 'subject'
   | 'createdOn'
   | 'eventId'
@@ -56,13 +58,16 @@ export function FrontMatter({
   | 'editedBy'
   | 'editedOn'
 >) {
-  const searchString = useSearchString()
+  const [searchParams] = useSearchParams()
+  const searchString = cleanSearchString(searchParams.toString(), '&')
   return (
     <>
       <FrontMatterItem label="Subject">{subject}</FrontMatterItem>
       {eventId && (
         <FrontMatterItem label="Event">
-          <Link to={`/circulars/events/${slug(eventId)}${searchString}`}>
+          <Link
+            to={`/circulars/events/${slug(eventId)}?fromCircular=${circularId}${searchString}`}
+          >
             {eventId}
           </Link>
         </FrontMatterItem>

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -61,6 +61,17 @@ export function getEnvBannerHeaderAndDescription(hostname?: string) {
   return { heading, description }
 }
 
+export function cleanSearchString(
+  searchString?: string,
+  queryCharacter?: string
+) {
+  if (searchString) {
+    return `${queryCharacter}${searchString}`
+  } else {
+    return searchString
+  }
+}
+
 /** Return the search string for the current page. */
 export function useSearchString() {
   const [searchParams] = useSearchParams()

--- a/app/routes/circulars.$circularId.($version)/route.tsx
+++ b/app/routes/circulars.$circularId.($version)/route.tsx
@@ -140,7 +140,7 @@ export default function () {
         )}
       </ToolbarButtonGroup>
       <h1 className="margin-bottom-0">GCN Circular {circularId}</h1>
-      <FrontMatter {...frontMatter} />
+      <FrontMatter circularId={circularId} {...frontMatter} />
       <Body className="margin-y-2">{body}</Body>
       <ButtonGroup type="segmented">
         {Number.isFinite(previousCircular) ? (

--- a/app/routes/circulars.events.$slug.tsx
+++ b/app/routes/circulars.events.$slug.tsx
@@ -8,6 +8,7 @@
 import type { LoaderFunctionArgs } from '@remix-run/node'
 import { Link, useLoaderData, useSearchParams } from '@remix-run/react'
 import { Icon } from '@trussworks/react-uswds'
+import { slug } from 'github-slugger'
 import invariant from 'tiny-invariant'
 
 import type { Synonym } from './synonyms/synonyms.lib'
@@ -19,6 +20,7 @@ import { Anchor } from '~/components/Anchor'
 import { ToolbarButtonGroup } from '~/components/ToolbarButtonGroup'
 import { MarkdownBody, PlainTextBody } from '~/components/circularDisplay/Body'
 import { FrontMatter } from '~/components/circularDisplay/FrontMatter'
+import { cleanSearchString } from '~/lib/utils'
 import type { BreadcrumbHandle } from '~/root/Title'
 
 export const handle: BreadcrumbHandle<Awaited<ReturnType<typeof loader>>> = {
@@ -40,13 +42,20 @@ export async function loader({ params: { slug } }: LoaderFunctionArgs) {
 export default function Group() {
   const { members, eventIds } = useLoaderData<typeof loader>()
   const [searchParams] = useSearchParams()
-  const searchString = searchParams.toString()
+  const fromCircularId = searchParams.get('fromCircular')
 
+  let searchString = cleanSearchString(searchParams.toString(), '?')
+
+  if (fromCircularId) {
+    searchParams.delete('fromCircular')
+    const newSearchString = cleanSearchString(searchParams.toString(), '?')
+    searchString = `/${slug(fromCircularId)}${newSearchString}`
+  }
   return (
     <>
       <ToolbarButtonGroup className="flex-wrap">
         <Link
-          to={`/circulars?${searchString}`}
+          to={`/circulars${searchString}`}
           className="usa-button flex-align-stretch"
         >
           <Icon.ArrowBack role="presentation" className="margin-y-neg-2px" />
@@ -75,6 +84,7 @@ export default function Group() {
               </h2>
               <div className="margin-2">
                 <FrontMatter
+                  circularId={circularId}
                   createdOn={createdOn}
                   submitter={submitter}
                   subject={subject}


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Use of AI Disclosure
GitHub CoPilot was used to help me navigate through the codebase and identify key areas to help resolve the issue. All physical code was handwritten by me.

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
When navigating to an event page through a circular page, pressing the back button will return users to the main archive page instead of the circular page they navigated through.
This PR adds an additional 'fromCircular' query parameter when an event page has been navigated to from a circular, providing an accessible manner of backtracking. The 'fromCircular' query parameter will only appear  when navigating from a circular page to an event page.

# Related Issue(s)
<!-- Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
Example:
`Resolves #100` -->
Resolves #3749 

# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->
This PR was tested through local dev. 
1. Go to a circular page that contains a link to an event and click it.
2. Within the URL should be the 'fromCircular' query parameter.
3. Press the in-page back button. 
4. You should arrive at the circular in step 1.