### PR TITLE
Update topicToFormatAndNoticeType to catch circulars  and heartbeats

### DIFF
--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -21,7 +21,12 @@ export function topicToFormatAndNoticeType(topic: string): {
   noticeFormat: string
   noticeType: string
 } {
-  if (topic.startsWith('gcn.notices.') || topic === 'igwn.gwalert')
+  if (
+    topic.startsWith('gcn.notices.') ||
+    topic.startsWith('gcn.circulars') ||
+    topic.startsWith('gcn.heartbeat') ||
+    topic === 'igwn.gwalert'
+  )
     return {
       noticeFormat: 'json',
       noticeType: topic,

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -21,7 +21,12 @@ export function topicToFormatAndNoticeType(topic: string): {
   noticeFormat: string
   noticeType: string
 } {
-  if (
+  if (topic.startsWith('gcn.notices.svom')) {
+    return {
+      noticeFormat: 'voevent',
+      noticeType: topic,
+    }
+  } else if (
     topic.startsWith('gcn.notices.') ||
     topic.startsWith('gcn.circulars') ||
     topic.startsWith('gcn.heartbeat') ||


### PR DESCRIPTION
Fixes an issue where topicToFormatAndNoticeType wouldn't return the correct values when selecting circulars and/or heartbeats, causing the UI to be blank