### PR TITLE
Clear search when switching archive views

### DIFF
--- a/app/routes/circulars._archive._index/ArchiveHeader.tsx
+++ b/app/routes/circulars._archive._index/ArchiveHeader.tsx
@@ -136,7 +136,7 @@ export default function ArchiveHeader({
             id="query"
             name="query"
             type="search"
-            defaultValue={inputQuery}
+            value={inputQuery}
             placeholder={searchText}
             aria-describedby="searchHint"
             onChange={({ target: { form, value } }) => {
@@ -158,6 +158,9 @@ export default function ArchiveHeader({
             to={`/circulars?view=index&limit=${limit}`}
             preventScrollReset
             className={getSelection('index')}
+            onClick={() => {
+              setInputQuery('')
+            }}
           >
             <Icon.List role="presentation" />
             Circulars
@@ -166,6 +169,9 @@ export default function ArchiveHeader({
             to={`/circulars?view=group&limit=${limit}`}
             preventScrollReset
             className={getSelection('group')}
+            onClick={() => {
+              setInputQuery('')
+            }}
           >
             <Icon.ContentCopy role="presentation" />
             Events


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Use of AI Disclosure
GitHub CoPilot was used to help me navigate through the codebase and identify key areas to help resolve the issue. All physical code was handwritten by me.

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
When clicking on the buttons to navigate between Circular and Event view, I added an onClick to clear the inputQuery between the two views. In doing so, defaultValue had to be changed to value because defaultValue does not change during re-mounts of the component.

# Related Issue(s)
<!-- Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
Example:
`Resolves #100` -->
Resolves #3769 


# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->
This was tested in local development.
1) Type a search query into the Circulars/Events search bar and press enter.
2) Navigate to the other view using its respective button.
3) The search bar should be cleared and the results should be displayed.