### PR TITLE
Add hidden input field to prevent stripped eventType

### DIFF
--- a/app/routes/circulars.new.$circularId/CircularEditForm.tsx
+++ b/app/routes/circulars.new.$circularId/CircularEditForm.tsx
@@ -285,6 +285,15 @@ export function CircularEditForm({
                 setEventId(derivedEventId)
               }}
             />
+            {!showEventTypes &&
+              defaultEventTypes.map((eventType) => (
+                <input
+                  key={`preserved-event-type-${eventType}`}
+                  type="hidden"
+                  name="eventTypes"
+                  value={eventType}
+                />
+              ))}
             {showEventTypes && (
               <>
                 <fieldset className="margin-top-2">


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
This adds a hidden input field to the edit request page that is only set when the event type feature flag is not present (as is the case in production at the moment). This ensures existing event types are not stripped from circulars when unrelated edits are requested.

# Related Issue(s)
<!-- Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
Example:
`Resolves #100` -->
Fixes #3792

# Testing
<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
Be detailed and include images where appropriate. -->
1. Start up local _without_ `EVENTTYPE` as a feature flag in `.env`
2. Go to a circular; check the existing event types in the json
3.  Request any edit of the circular 
4. Go to the moderation queue
5. The event types should be preserved